### PR TITLE
feat(web): supervise private Pi session daemon

### DIFF
--- a/docs/pichamber-pi-workstream-0.md
+++ b/docs/pichamber-pi-workstream-0.md
@@ -2,7 +2,7 @@
 
 ## Status and scope
 
-This is the Workstream 0 implementation record for the approved [Pi migration plan](./pichamber-pimigration.md). It records the migration boundary, names the new Pi-owned surfaces, and captures the current OpenCode dependency inventory. The Week 0 disposable-environment spike is now in progress under the Pi-owned web-server boundary; it does not create a releasable dual-runtime path.
+This is the Workstream 0 implementation record for the approved [Pi migration plan](./pichamber-pimigration.md). It records the migration boundary, names the new Pi-owned surfaces, and captures the current OpenCode dependency inventory. The Week 0 disposable-environment spike is complete; its successor daemon-lifecycle work is recorded separately. Neither creates a releasable dual-runtime path.
 
 The spike adds the reviewed, exactly pinned Pi SDK only to `@pichamber/web`, its direct consumer. It does not add Pi code to an OpenCode module or expose a browser-facing daemon listener.
 
@@ -258,7 +258,7 @@ find packages/web/server/lib/opencode -type f | sort
 
 ## Week 0 spike implementation
 
-The focused implementation now lives in `packages/web/server/lib/pi/session-daemon/` with colocated tests. It:
+The completed focused spike lives in `packages/web/server/lib/pi/session-daemon/` with colocated tests. It:
 
 1. imports the approved, exactly pinned Pi SDK and creates a persistent session using a disposable agent directory and selected cwd;
 2. binds only a local Unix socket (or Windows named pipe), authenticates the private client, and creates the socket with owner-only permissions on POSIX;
@@ -266,4 +266,4 @@ The focused implementation now lives in `packages/web/server/lib/pi/session-daem
 4. keeps the runtime alive while a client disconnects and sends a sequenced snapshot to the reconnecting client; and
 5. rejects TCP endpoints and unauthenticated clients instead of presenting a false empty/idle state.
 
-It intentionally does not register public `/api/pi/*` routes, integrate lifecycle supervision, or retain an OpenCode fallback. Those remain later Workstream 1–4 work.
+The spike itself did not register public routes or lifecycle supervision. The initial detached-process supervision and `GET /api/pi/runtime` adapter are now recorded in [the Workstream 1 daemon record](./pichamber-pi-workstream-1.md); session registry, operation families, queue policy, and recovery remain later work.

--- a/docs/pichamber-pi-workstream-1.md
+++ b/docs/pichamber-pi-workstream-1.md
@@ -1,0 +1,45 @@
+# PiChamber Pi Migration: Workstream 1 Daemon Lifecycle Record
+
+## Status and scope
+
+This record covers the initial daemon-lifecycle implementation following the completed boundary and SDK spike in [the Workstream 0 record](./pichamber-pi-workstream-0.md). It makes the private Pi runtime independently supervised by the web server and exposes only authenticated public health. It is not a session/UI cutover and does not create a supported OpenCode/Pi runtime choice.
+
+## Implemented ownership
+
+| Surface | Implementation | Rationale |
+| --- | --- | --- |
+| Private process | `packages/web/server/lib/pi/session-daemon/daemon-process.js` | A detached local process owns the SDK runtime, so a browser disconnect and a web-server restart do not automatically dispose active Pi work. |
+| Server supervision | `supervisor.js` | The web server resolves local endpoint/data paths, serializes start/reuse/stop, health-checks an existing daemon before reuse, starts the private process when absent, and signals only a health-identity-matched daemon on shutdown. |
+| Private client | `ipc-client.js` | The server reaches the daemon with its local credential over JSONL IPC. The module owns framing/timeouts and gives callers stable errors rather than an empty runtime result. |
+| Public health adapter | `packages/web/server/lib/pi/routes.js` | `GET /api/pi/runtime` is registered before the generic OpenCode proxy and returns only `protocolVersion`, `state`, `capabilities`, or a stable unavailable error code. It never returns endpoint, key, PID, cwd, agent directory, or session data. |
+| Web lifecycle | `packages/web/server/index.js` | The server starts the daemon after its listener is ready and attempts a graceful daemon stop before HTTP shutdown. A startup failure leaves the route available with `503`/`DAEMON_*`, not a fabricated idle or empty response. |
+
+## Local files and permissions
+
+All paths are server-only. Browser clients neither receive nor construct them.
+
+| Item | Path | Rule |
+| --- | --- | --- |
+| POSIX endpoint | `$XDG_RUNTIME_DIR/pichamber/pi-session-daemon.sock`, or `$OPENCHAMBER_DATA_DIR/runtime/pi-session-daemon.sock` | Parent is `0700`; socket is `0600`. TCP is rejected. |
+| Windows endpoint | `\\.\pipe\pichamber-pi-session-daemon-<owner-key>` | Named-pipe endpoint only; credential authentication remains mandatory. Windows ACL enforcement needs a dedicated platform implementation before claiming equivalent owner-only OS permissions. |
+| Credential | `$OPENCHAMBER_DATA_DIR/pi/session-daemon.key` | 32 random bytes encoded as hex, created/read `0600`; passed by file access, never command line, public response, or logs. |
+| State | `$OPENCHAMBER_DATA_DIR/pi/session-daemon-state.json` | `0600`; non-secret protocol, PID, endpoint, and start-time metadata written only after daemon readiness. |
+| Operation lock | `$OPENCHAMBER_DATA_DIR/pi/session-daemon.lock` | `0600`; `wx` claim serializes start/reuse/stop. A stale claim is removed only after its PID is no longer alive. |
+
+An existing socket that cannot be authenticated and matched to the state PID is never removed automatically. The supervisor reports `DAEMON_ENDPOINT_UNVERIFIED`, preserving safety over speculative cleanup.
+
+## Runtime behavior
+
+- The supervisor honors `OPENCHAMBER_DATA_DIR`, `OPENCHAMBER_PI_AGENT_DIR`, and `OPENCHAMBER_PI_SESSION_DAEMON_ENDPOINT` only on the server.
+- The Pi runtime now uses `SessionManager.create(cwd)` without overriding Pi's default session directory, preserving Pi's normal cwd-scoped session discovery.
+- The private health response includes a daemon PID only for supervisor identity verification. The public adapter strips it.
+- The server's existing authenticated `/api` middleware protects `/api/pi/runtime`; the adapter is registered before the generic OpenCode `/api/*` proxy.
+- Shutdown is best-effort only after the same private health/identity verification. It cannot signal an arbitrary PID from a stale sidecar.
+
+## Deliberate limits
+
+This foundation still has one active runtime/session in the daemon. It does not yet implement the Workstream 1 registry and directory-scoping responsibilities, Pi session list/create/open/delete/tree/fork/clone operations, session replacement rebinding, idle runtime disposal, malformed-JSONL reporting, queue policy, replay persistence, or forced-crash interruption/recovery. The only public Pi route is runtime health; session routes and public event streaming are later contract work.
+
+## Validation evidence
+
+Focused tests use temporary PiChamber data roots, XDG runtime directories, project directories, and Pi agent directories with `PI_OFFLINE=1`. They verify real detached daemon start/reuse/health/stop, sidecar key mode, no secret in health output, socket authentication/reconnect behavior, and public health response redaction/unavailable status. They do not exercise Windows pipe ACLs, a live model provider, full server startup, or the deferred registry/recovery operations.

--- a/docs/pichamber-pimigration.md
+++ b/docs/pichamber-pimigration.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Approved design plan. This document records the agreed migration from the current OpenCode-backed product to a Pi-native PiChamber. Workstream 0 and its Week 0 architecture spike are in progress; the spike is not a releasable dual-runtime path. The plan does not authorize a partial dual-runtime release.
+Approved design plan. This document records the agreed migration from the current OpenCode-backed product to a Pi-native PiChamber. Workstream 0 and its Week 0 architecture spike are complete; the Workstream 1 daemon-lifecycle foundation is in progress. None of these implementation stages is a releasable dual-runtime path. The plan does not authorize a partial dual-runtime release.
 
 This document is the approved plan for the Pi-native migration and is intentionally scoped separately from the completed identity-stabilization work recorded in the changelog.
 

--- a/packages/web/server/index.js
+++ b/packages/web/server/index.js
@@ -102,6 +102,8 @@ import { createSystemPromptRuntime } from './lib/system-prompt/runtime.js';
 import { createPiChamberSessionService } from './lib/openchamber-sessions/routes.js';
 import { createScheduledTaskService } from './lib/scheduled-tasks/service.js';
 import { createPiChamberControlService } from './lib/openchamber-control/service.js';
+import { createPiSessionDaemonSupervisor } from './lib/pi/session-daemon/supervisor.js';
+import { registerPiRuntimeRoutes } from './lib/pi/routes.js';
 import { createProxyMiddleware, responseInterceptor } from 'http-proxy-middleware';
 import webPush from 'web-push';
 
@@ -509,6 +511,7 @@ let runtimeManagedRemoteTunnelHostname = '';
 let terminalRuntime = null;
 let dictationRuntime = null;
 let messageStreamRuntime = null;
+let piSessionDaemonRuntime = null;
 const userProvidedOpenCodePassword = hmrStateRuntime.getUserProvidedOpenCodePassword(hmrState);
 const initialOpenCodeAuthState = hmrStateRuntime.resolveOpenCodeAuthFromState({
   hmrState,
@@ -1253,6 +1256,12 @@ const gracefulShutdownRuntime = createGracefulShutdownRuntime({
   setMessageStreamRuntime: (value) => {
     messageStreamRuntime = value;
   },
+  getRuntimeShutdownHooks: () => piSessionDaemonRuntime ? [{
+    stop: () => piSessionDaemonRuntime.stop(),
+    clear: () => {
+      piSessionDaemonRuntime = null;
+    },
+  }] : [],
   shouldSkipOpenCodeStop: () => ENV_SKIP_OPENCODE_START || isExternalOpenCode,
   getOpenCodePort: () => openCodePort,
   getOpenCodeProcess: () => openCodeProcess,
@@ -1298,6 +1307,10 @@ async function main(options = {}) {
   systemPromptRuntime = createSystemPromptRuntime({
     fsPromises,
     path,
+    dataDir: OPENCHAMBER_DATA_DIR,
+  });
+  piSessionDaemonRuntime = createPiSessionDaemonSupervisor({
+    cwd: process.cwd(),
     dataDir: OPENCHAMBER_DATA_DIR,
   });
 
@@ -1600,6 +1613,9 @@ async function main(options = {}) {
     agentToolRuntime,
   });
   uiAuthController = bootstrapResult.uiAuthController;
+  registerPiRuntimeRoutes(app, {
+    getPiSessionDaemonRuntime: () => piSessionDaemonRuntime,
+  });
   realtimeProxyRuntime = attachRealtimeProxy({
     app,
     server,
@@ -1761,6 +1777,13 @@ async function main(options = {}) {
   terminalRuntime = startupPipelineResult.terminalRuntime;
   dictationRuntime = startupPipelineResult.dictationRuntime;
   messageStreamRuntime = startupPipelineResult.messageStreamRuntime;
+
+  // The API is already registered, so a startup failure remains an explicit
+  // unavailable state instead of delaying the web server or falling through to
+  // the generic OpenCode proxy.
+  void piSessionDaemonRuntime.start().catch((error) => {
+    console.warn(`[PiSessionDaemon] unavailable: ${error?.code ?? 'DAEMON_UNAVAILABLE'}`);
+  });
 
   try {
     await scheduledTasksRuntime.start();

--- a/packages/web/server/lib/opencode/shutdown-runtime.js
+++ b/packages/web/server/lib/opencode/shutdown-runtime.js
@@ -18,6 +18,7 @@ export const createGracefulShutdownRuntime = (dependencies) => {
     setTerminalRuntime,
     getMessageStreamRuntime,
     setMessageStreamRuntime,
+    getRuntimeShutdownHooks = () => [],
     shouldSkipOpenCodeStop,
     getOpenCodePort,
     getOpenCodeProcess,
@@ -71,6 +72,16 @@ export const createGracefulShutdownRuntime = (dependencies) => {
       } catch {
       } finally {
         setMessageStreamRuntime(null);
+      }
+    }
+
+    for (const hook of getRuntimeShutdownHooks()) {
+      try {
+        await hook.stop();
+      } catch (error) {
+        console.warn(`[Runtime] shutdown hook failed: ${error?.code ?? 'RUNTIME_STOP_FAILED'}`);
+      } finally {
+        hook.clear?.();
       }
     }
 

--- a/packages/web/server/lib/pi/routes.js
+++ b/packages/web/server/lib/pi/routes.js
@@ -1,0 +1,33 @@
+/**
+ * Browser-visible Pi runtime health is intentionally narrower than the private
+ * daemon protocol. It never exposes the local endpoint, credential, pid, or
+ * server filesystem paths.
+ */
+export const registerPiRuntimeRoutes = (app, { getPiSessionDaemonRuntime }) => {
+  app.get('/api/pi/runtime', async (_req, res) => {
+    const runtime = getPiSessionDaemonRuntime();
+    if (!runtime) {
+      res.status(503).json({
+        protocolVersion: 1,
+        state: 'unavailable',
+        error: { code: 'DAEMON_UNAVAILABLE' },
+      });
+      return;
+    }
+
+    const health = await runtime.health();
+    if (health.state !== 'ready') {
+      res.status(503).json({
+        protocolVersion: health.protocolVersion,
+        state: 'unavailable',
+        error: { code: health.error?.code ?? 'DAEMON_UNAVAILABLE' },
+      });
+      return;
+    }
+    res.json({
+      protocolVersion: health.protocolVersion,
+      state: 'ready',
+      capabilities: Array.isArray(health.capabilities) ? health.capabilities : [],
+    });
+  });
+};

--- a/packages/web/server/lib/pi/routes.test.js
+++ b/packages/web/server/lib/pi/routes.test.js
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import express from 'express';
+
+import { registerPiRuntimeRoutes } from './routes.js';
+
+const listen = (app) => new Promise((resolve, reject) => {
+  const server = app.listen(0, '127.0.0.1', () => resolve(server));
+  server.once('error', reject);
+});
+
+const close = (server) => new Promise((resolve, reject) => {
+  if (!server) return resolve();
+  server.close((error) => error ? reject(error) : resolve());
+});
+
+describe('Pi runtime route', () => {
+  let server;
+
+  afterEach(async () => {
+    await close(server);
+    server = undefined;
+  });
+
+  it('returns only public daemon health fields and marks an unavailable daemon as a service failure', async () => {
+    const runtime = {
+      health: async () => ({
+        state: 'ready',
+        protocolVersion: 1,
+        capabilities: ['sessions.prompt'],
+        endpoint: '/private/socket',
+        credential: 'never-expose-this',
+        pid: 123,
+      }),
+    };
+    const app = express();
+    registerPiRuntimeRoutes(app, { getPiSessionDaemonRuntime: () => runtime });
+    server = await listen(app);
+
+    const ready = await fetch(`http://127.0.0.1:${server.address().port}/api/pi/runtime`);
+    expect(ready.status).toBe(200);
+    await expect(ready.json()).resolves.toEqual({
+      state: 'ready',
+      protocolVersion: 1,
+      capabilities: ['sessions.prompt'],
+    });
+
+    runtime.health = async () => ({
+      state: 'unavailable',
+      protocolVersion: 1,
+      error: { code: 'DAEMON_UNAVAILABLE' },
+    });
+    const unavailable = await fetch(`http://127.0.0.1:${server.address().port}/api/pi/runtime`);
+    expect(unavailable.status).toBe(503);
+    await expect(unavailable.json()).resolves.toEqual({
+      state: 'unavailable',
+      protocolVersion: 1,
+      error: { code: 'DAEMON_UNAVAILABLE' },
+    });
+  });
+});

--- a/packages/web/server/lib/pi/session-daemon/DOCUMENTATION.md
+++ b/packages/web/server/lib/pi/session-daemon/DOCUMENTATION.md
@@ -2,19 +2,25 @@
 
 ## Purpose
 
-This module is the Pi-owned Week 0 runtime spike. It creates one `AgentSessionRuntime` with the Pi SDK, keeps it behind a private local socket, and maps a small event subset to the PiChamber IPC contract. It is not a public HTTP route and browsers never connect to it.
+This module is the Pi-owned session-daemon foundation. A detached local daemon process creates one `AgentSessionRuntime` with the Pi SDK, keeps it behind a private local socket, and maps a small event subset to the PiChamber IPC contract. Browsers never connect to it.
 
 ## Entrypoints
 
 - `session-daemon.js`
   - `createPiSessionRuntime({ cwd, agentDir })` creates a persistent Pi runtime using the selected server-side cwd and Pi agent directory. It uses Pi's normal settings, credentials, models, sessions, skills, prompts, and context discovery, with native extensions explicitly disabled for the core milestone.
   - `createSessionDaemon(options)` starts/stops the authenticated local socket daemon and validates its endpoint and setup inputs.
-- `session-daemon.test.js` tests the disposable socket spike with an injected session runtime; it never loads a developer's Pi home, credentials, or sessions.
+- `daemon-process.js` is the detached private-process entrypoint. It reads the daemon credential from its owner-only sidecar, starts the socket, writes non-secret identity state only after readiness, and removes only its own state on signal shutdown.
+- `ipc-client.js` is the server-only authenticated request client. It owns JSONL framing and never exposes endpoint or credential values to callers.
+- `supervisor.js` resolves server-only overrides, creates the credential, serializes start/reuse/stop through an owner-only lock, validates daemon identity through `runtime.health`, and starts or stops the detached process.
+- `../routes.js` registers the authenticated public `GET /api/pi/runtime` adapter. It returns only protocol/state/capabilities or a stable unavailable code.
+- `*.test.js` uses temporary cwd, agent, data, and runtime directories; it never loads a developer's Pi home, credentials, or sessions.
 
 ## Protocol and security invariants
 
 - The endpoint is a Unix domain socket on POSIX or a Windows named pipe. TCP endpoints are rejected.
 - POSIX socket parent directories are mode `0700`; the socket is created mode `0600`. An existing endpoint fails startup rather than being unlinked without daemon-identity verification.
+- The daemon credential and non-secret state sidecars are mode `0600`; their PiChamber parent directory and the operation lock serialize start/reuse/stop. Health identity includes the daemon PID and must match the state sidecar before the supervisor reuses or signals a process.
+- The public health route deliberately whitelists its response fields. It never returns a daemon endpoint, credential, PID, cwd, agent directory, or transcript data.
 - A client must send an `authenticate` frame carrying the host-private daemon credential before it can issue a request. Credentials are never logged or returned.
 - Frames are LF-delimited JSON. They have a 1 MiB maximum buffered size. A malformed, oversized, unauthenticated, or invalid request closes the connection.
 - The current spike supports `runtime.health` and `sessions.prompt`. It maps text/thinking deltas, tool lifecycle, queue changes, and agent lifecycle to the canonical event names in `docs/pichamber-pi-workstream-0.md`.
@@ -23,6 +29,6 @@ This module is the Pi-owned Week 0 runtime spike. It creates one `AgentSessionRu
 
 ## Deliberate limits
 
-This is a focused architecture spike, not a public API or UI migration. It does not register `/api/pi/*` routes, start a child process, expose provider operations, or implement session registry/queue/recovery persistence. Those remain Workstreams 1–4 work.
+This is not a session/UI migration. `GET /api/pi/runtime` is the only public adapter and the daemon still has one runtime/session rather than a directory-scoped registry. It does not expose project/session collection operations, provider operations, queue policy, replay persistence, or recovery after a forced daemon crash. Those remain later daemon and API work.
 
 The Pi SDK is pinned exactly at `0.84.1`. Any Pi 0.x minor upgrade requires a deliberate SDK/release-note review and repeat of this module's disposable-runtime smoke validation.

--- a/packages/web/server/lib/pi/session-daemon/daemon-process.js
+++ b/packages/web/server/lib/pi/session-daemon/daemon-process.js
@@ -1,0 +1,87 @@
+import { readFile, chmod, rename, rm, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+import { createSessionDaemon } from './session-daemon.js';
+
+const argument = (name) => {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? undefined : process.argv[index + 1];
+};
+
+const endpoint = argument('--endpoint');
+const credentialFile = argument('--credential-file');
+const stateFile = argument('--state-file');
+const cwd = argument('--cwd');
+const agentDir = argument('--agent-dir');
+
+const exitWithFailure = (code) => {
+  // Do not log configuration paths, credentials, or session data from this
+  // private process. The parent maps startup failure to a stable error code.
+  process.exitCode = code;
+};
+
+const writeState = async () => {
+  const temporaryPath = `${stateFile}.${process.pid}.tmp`;
+  const state = JSON.stringify({
+    protocolVersion: 1,
+    pid: process.pid,
+    endpoint,
+    startedAt: new Date().toISOString(),
+  });
+  await writeFile(temporaryPath, state, { mode: 0o600 });
+  await chmod(temporaryPath, 0o600);
+  await rename(temporaryPath, stateFile);
+  await chmod(stateFile, 0o600);
+};
+
+const removeOwnState = async () => {
+  try {
+    const state = JSON.parse(await readFile(stateFile, 'utf8'));
+    if (state?.pid === process.pid) await rm(stateFile, { force: true });
+  } catch {
+    // A missing or malformed state sidecar cannot block daemon shutdown.
+  }
+};
+
+if (!endpoint || !credentialFile || !stateFile || !cwd) {
+  exitWithFailure(64);
+} else {
+  let daemon;
+  let stopping = false;
+  try {
+    const credential = (await readFile(credentialFile, 'utf8')).trim();
+    daemon = createSessionDaemon({
+      endpoint,
+      credential,
+      cwd,
+      ...(agentDir ? { agentDir } : {}),
+      healthMetadata: { daemonPid: process.pid },
+    });
+    await daemon.start();
+    await writeState();
+  } catch {
+    try {
+      await daemon?.stop();
+    } catch {
+      // Process exit closes the local listener if startup cleanup also failed.
+    }
+    await removeOwnState();
+    exitWithFailure(1);
+  }
+
+  const stop = async () => {
+    if (stopping) return;
+    stopping = true;
+    try {
+      await daemon?.stop();
+    } finally {
+      await removeOwnState();
+    }
+  };
+
+  for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
+    process.once(signal, () => {
+      void stop().finally(() => process.exit(0));
+    });
+  }
+}

--- a/packages/web/server/lib/pi/session-daemon/ipc-client.js
+++ b/packages/web/server/lib/pi/session-daemon/ipc-client.js
@@ -1,0 +1,86 @@
+import { randomUUID } from 'node:crypto';
+import { createConnection } from 'node:net';
+import { StringDecoder } from 'node:string_decoder';
+
+const PROTOCOL_VERSION = 1;
+const MAX_FRAME_BYTES = 1024 * 1024;
+
+export class SessionDaemonClientError extends Error {
+  constructor(code, message = 'The Pi session daemon is unavailable.') {
+    super(message);
+    this.code = code;
+  }
+}
+
+/**
+ * Send one authenticated request to the private daemon. This module is server
+ * infrastructure: callers must never return its endpoint or credential.
+ */
+export const requestSessionDaemon = ({ endpoint, credential, command, payload, timeoutMs = 5_000 }) => new Promise((resolve, reject) => {
+  const requestId = randomUUID();
+  const decoder = new StringDecoder('utf8');
+  let buffer = '';
+  let authenticated = false;
+  let settled = false;
+  let timer;
+
+  const socket = createConnection(endpoint);
+  const finish = (callback, value) => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(timer);
+    socket.destroy();
+    callback(value);
+  };
+  const fail = (code) => finish(reject, new SessionDaemonClientError(code));
+
+  timer = setTimeout(() => fail('DAEMON_UNAVAILABLE'), timeoutMs);
+  socket.once('error', () => fail('DAEMON_UNAVAILABLE'));
+  socket.on('connect', () => {
+    socket.write(`${JSON.stringify({ kind: 'authenticate', credential })}\n`);
+  });
+  socket.on('data', (chunk) => {
+    buffer += decoder.write(chunk);
+    if (Buffer.byteLength(buffer) > MAX_FRAME_BYTES) {
+      fail('MALFORMED_DAEMON_RESPONSE');
+      return;
+    }
+
+    while (true) {
+      const newline = buffer.indexOf('\n');
+      if (newline === -1) return;
+      const line = buffer.slice(0, newline).replace(/\r$/, '');
+      buffer = buffer.slice(newline + 1);
+      if (!line) continue;
+
+      let message;
+      try {
+        message = JSON.parse(line);
+      } catch {
+        fail('MALFORMED_DAEMON_RESPONSE');
+        return;
+      }
+      if (message.protocolVersion !== PROTOCOL_VERSION) {
+        fail('UNSUPPORTED_DAEMON_PROTOCOL');
+        return;
+      }
+      if (!authenticated) {
+        if (message.kind !== 'authenticated') {
+          fail('DAEMON_AUTH_FAILED');
+          return;
+        }
+        authenticated = true;
+        socket.write(`${JSON.stringify({ protocolVersion: PROTOCOL_VERSION, kind: 'request', requestId, command, payload })}\n`);
+        continue;
+      }
+      if (message.kind === 'response' && message.requestId === requestId) {
+        finish(resolve, message.result);
+        return;
+      }
+      if (message.kind === 'error') {
+        fail(typeof message.error?.code === 'string' ? message.error.code : 'DAEMON_REQUEST_FAILED');
+        return;
+      }
+    }
+  });
+});

--- a/packages/web/server/lib/pi/session-daemon/session-daemon.js
+++ b/packages/web/server/lib/pi/session-daemon/session-daemon.js
@@ -20,7 +20,7 @@ class SessionDaemonProtocolError extends Error {
   }
 }
 
-function isLocalSessionDaemonEndpoint(endpoint, platform = process.platform) {
+export function isLocalSessionDaemonEndpoint(endpoint, platform = process.platform) {
   if (typeof endpoint !== 'string' || endpoint.length === 0) return false;
 
   if (platform === 'win32') {
@@ -55,7 +55,7 @@ async function createPiSessionRuntime({ cwd, agentDir = getAgentDir() }) {
   return createAgentSessionRuntime(createRuntime, {
     cwd,
     agentDir,
-    sessionManager: SessionManager.create(cwd, `${agentDir}/sessions`),
+    sessionManager: SessionManager.create(cwd),
   });
 }
 
@@ -65,6 +65,7 @@ export function createSessionDaemon({
   cwd,
   agentDir = getAgentDir(),
   createRuntime = createPiSessionRuntime,
+  healthMetadata = {},
   platform = process.platform,
 } = {}) {
   if (!isLocalSessionDaemonEndpoint(endpoint, platform)) {
@@ -171,6 +172,7 @@ export function createSessionDaemon({
             state: 'ready',
             sessionId: runtime.session.sessionId,
             lastSequence: sequence,
+            ...(Number.isInteger(healthMetadata.daemonPid) ? { daemonPid: healthMetadata.daemonPid } : {}),
           },
         });
         return;
@@ -264,6 +266,7 @@ export function createSessionDaemon({
       try {
         if (platform !== 'win32') {
           await mkdir(dirname(endpoint), { recursive: true, mode: 0o700 });
+          await chmod(dirname(endpoint), 0o700);
           try {
             await lstat(endpoint);
             throw new SessionDaemonProtocolError('ENDPOINT_IN_USE', 'The daemon endpoint already exists.');

--- a/packages/web/server/lib/pi/session-daemon/supervisor.js
+++ b/packages/web/server/lib/pi/session-daemon/supervisor.js
@@ -1,0 +1,322 @@
+import { createHash, randomBytes } from 'node:crypto';
+import { spawn as spawnChildProcess } from 'node:child_process';
+import { chmod, lstat, mkdir, open, readFile, rm, writeFile } from 'node:fs/promises';
+import { userInfo } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
+
+import { resolvePiChamberDataDir } from '../../pichamber-data-dir.js';
+import { isLocalSessionDaemonEndpoint } from './session-daemon.js';
+import { requestSessionDaemon, SessionDaemonClientError } from './ipc-client.js';
+
+const PROTOCOL_VERSION = 1;
+const STARTUP_TIMEOUT_MS = 5_000;
+const RETRY_DELAY_MS = 100;
+const DAEMON_ENTRYPOINT = fileURLToPath(new URL('./daemon-process.js', import.meta.url));
+
+class PiSessionDaemonUnavailableError extends Error {
+  constructor(code) {
+    super('The Pi session daemon is unavailable.');
+    this.code = code;
+  }
+}
+
+const delay = (milliseconds) => new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds));
+
+const getWindowsOwnerKey = () => {
+  try {
+    return createHash('sha256').update(userInfo().username).digest('hex').slice(0, 16);
+  } catch {
+    return 'owner';
+  }
+};
+
+const isValidState = (state) => (
+  state
+  && state.protocolVersion === PROTOCOL_VERSION
+  && Number.isInteger(state.pid)
+  && state.pid > 0
+  && typeof state.endpoint === 'string'
+  && typeof state.startedAt === 'string'
+);
+
+const isPidAlive = (processLike, pid) => {
+  try {
+    processLike.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === 'EPERM';
+  }
+};
+
+const resolvePiSessionDaemonPaths = ({
+  env = process.env,
+  dataDir = resolvePiChamberDataDir({ env }),
+  pathModule = { join, resolve, isAbsolute },
+  platform = process.platform,
+} = {}) => {
+  const piDataDir = pathModule.join(dataDir, 'pi');
+  const runtimeDir = typeof env.XDG_RUNTIME_DIR === 'string' && env.XDG_RUNTIME_DIR.trim()
+    ? pathModule.join(pathModule.resolve(env.XDG_RUNTIME_DIR.trim()), 'pichamber')
+    : pathModule.join(dataDir, 'runtime');
+  const configuredEndpoint = typeof env.OPENCHAMBER_PI_SESSION_DAEMON_ENDPOINT === 'string'
+    ? env.OPENCHAMBER_PI_SESSION_DAEMON_ENDPOINT.trim()
+    : '';
+  const endpoint = configuredEndpoint || (platform === 'win32'
+    ? `\\\\.\\pipe\\pichamber-pi-session-daemon-${getWindowsOwnerKey()}`
+    : pathModule.join(runtimeDir, 'pi-session-daemon.sock'));
+
+  if (!isLocalSessionDaemonEndpoint(endpoint, platform)) {
+    throw new PiSessionDaemonUnavailableError('INVALID_DAEMON_ENDPOINT');
+  }
+
+  const configuredAgentDir = typeof env.OPENCHAMBER_PI_AGENT_DIR === 'string' ? env.OPENCHAMBER_PI_AGENT_DIR.trim() : '';
+  return {
+    endpoint,
+    agentDir: configuredAgentDir ? pathModule.resolve(configuredAgentDir) : undefined,
+    piDataDir,
+    runtimeDir,
+    credentialFile: pathModule.join(piDataDir, 'session-daemon.key'),
+    stateFile: pathModule.join(piDataDir, 'session-daemon-state.json'),
+    lockFile: pathModule.join(piDataDir, 'session-daemon.lock'),
+  };
+};
+
+/**
+ * Owns a single daemon for the local PiChamber host. The state sidecar is
+ * deliberately non-secret; the credential is read only by this process and
+ * the child daemon, never passed to a browser or logged.
+ */
+export const createPiSessionDaemonSupervisor = ({
+  env = process.env,
+  cwd = process.cwd(),
+  dataDir,
+  platform = process.platform,
+  processLike = process,
+  request = requestSessionDaemon,
+  spawn = spawnChildProcess,
+  wait = delay,
+  startupTimeoutMs = STARTUP_TIMEOUT_MS,
+} = {}) => {
+  const paths = resolvePiSessionDaemonPaths({ env, dataDir, platform });
+  let startPromise = null;
+
+  const withOperationLock = async (operation) => {
+    const deadline = Date.now() + startupTimeoutMs;
+    await mkdir(paths.piDataDir, { recursive: true, mode: 0o700 });
+    await chmod(paths.piDataDir, 0o700);
+    while (true) {
+      try {
+        const handle = await open(paths.lockFile, 'wx', 0o600);
+        try {
+          await handle.writeFile(JSON.stringify({ pid: processLike.pid, claimedAt: new Date().toISOString() }));
+          await chmod(paths.lockFile, 0o600);
+        } finally {
+          await handle.close();
+        }
+        try {
+          return await operation();
+        } finally {
+          try {
+            const claim = JSON.parse(await readFile(paths.lockFile, 'utf8'));
+            if (claim?.pid === processLike.pid) await rm(paths.lockFile, { force: true });
+          } catch {
+            // A missing or already-replaced lock must not remove another owner.
+          }
+        }
+      } catch (error) {
+        if (error?.code !== 'EEXIST') throw new PiSessionDaemonUnavailableError('DAEMON_LOCK_UNAVAILABLE');
+        try {
+          const claim = JSON.parse(await readFile(paths.lockFile, 'utf8'));
+          if (!isPidAlive(processLike, claim?.pid)) await rm(paths.lockFile, { force: true });
+        } catch (readError) {
+          if (readError?.code !== 'ENOENT') throw new PiSessionDaemonUnavailableError('DAEMON_LOCK_UNAVAILABLE');
+        }
+        if (Date.now() >= deadline) throw new PiSessionDaemonUnavailableError('DAEMON_LOCK_TIMEOUT');
+        await wait(RETRY_DELAY_MS);
+      }
+    }
+  };
+
+  const readState = async () => {
+    try {
+      const state = JSON.parse(await readFile(paths.stateFile, 'utf8'));
+      return isValidState(state) ? state : null;
+    } catch {
+      return null;
+    }
+  };
+
+  const readCredential = async () => {
+    try {
+      const credential = (await readFile(paths.credentialFile, 'utf8')).trim();
+      if (credential.length < 32) throw new Error('invalid credential');
+      return credential;
+    } catch {
+      throw new PiSessionDaemonUnavailableError('DAEMON_CREDENTIAL_UNAVAILABLE');
+    }
+  };
+
+  const ensureCredential = async () => {
+    await mkdir(paths.piDataDir, { recursive: true, mode: 0o700 });
+    await chmod(paths.piDataDir, 0o700);
+    try {
+      const credential = await readCredential();
+      await chmod(paths.credentialFile, 0o600);
+      return credential;
+    } catch (error) {
+      if (error.code !== 'DAEMON_CREDENTIAL_UNAVAILABLE') throw error;
+    }
+
+    const credential = randomBytes(32).toString('hex');
+    try {
+      await writeFile(paths.credentialFile, `${credential}\n`, { flag: 'wx', mode: 0o600 });
+      await chmod(paths.credentialFile, 0o600);
+      return credential;
+    } catch (error) {
+      if (error?.code !== 'EEXIST') throw new PiSessionDaemonUnavailableError('DAEMON_CREDENTIAL_UNAVAILABLE');
+      return readCredential();
+    }
+  };
+
+  const probe = async (credential) => {
+    const state = await readState();
+    if (!state || state.endpoint !== paths.endpoint) {
+      throw new PiSessionDaemonUnavailableError('DAEMON_UNAVAILABLE');
+    }
+    try {
+      const health = await request({ endpoint: paths.endpoint, credential, command: 'runtime.health' });
+      if (health?.state !== 'ready' || health.daemonPid !== state.pid) {
+        throw new PiSessionDaemonUnavailableError('DAEMON_IDENTITY_MISMATCH');
+      }
+      return { state, health };
+    } catch (error) {
+      if (error instanceof PiSessionDaemonUnavailableError) throw error;
+      throw new PiSessionDaemonUnavailableError(error instanceof SessionDaemonClientError ? error.code : 'DAEMON_UNAVAILABLE');
+    }
+  };
+
+  const endpointExists = async () => {
+    if (platform === 'win32') return false;
+    try {
+      await lstat(paths.endpoint);
+      return true;
+    } catch (error) {
+      if (error?.code === 'ENOENT') return false;
+      throw new PiSessionDaemonUnavailableError('DAEMON_ENDPOINT_UNREADABLE');
+    }
+  };
+
+  const removeStaleState = async (state) => {
+    const current = await readState();
+    if (current?.pid === state?.pid && current.endpoint === paths.endpoint) {
+      await rm(paths.stateFile, { force: true });
+    }
+  };
+
+  const start = async () => {
+    if (startPromise) return startPromise;
+    startPromise = withOperationLock(async () => {
+      const credential = await ensureCredential();
+      try {
+        const existing = await probe(credential);
+        return { state: 'ready', reused: true, protocolVersion: PROTOCOL_VERSION, capabilities: existing.health.capabilities ?? [] };
+      } catch (error) {
+        if (!(error instanceof PiSessionDaemonUnavailableError)) throw error;
+      }
+
+      const staleState = await readState();
+      if (staleState && isPidAlive(processLike, staleState.pid)) {
+        throw new PiSessionDaemonUnavailableError('DAEMON_UNAVAILABLE');
+      }
+      if (await endpointExists()) {
+        // Do not unlink a socket we could not authenticate and identify.
+        throw new PiSessionDaemonUnavailableError('DAEMON_ENDPOINT_UNVERIFIED');
+      }
+      if (staleState) await removeStaleState(staleState);
+      await mkdir(dirname(paths.stateFile), { recursive: true, mode: 0o700 });
+      if (platform !== 'win32') {
+        await mkdir(paths.runtimeDir, { recursive: true, mode: 0o700 });
+        await chmod(paths.runtimeDir, 0o700);
+      }
+
+      const child = spawn(processLike.execPath, [
+        DAEMON_ENTRYPOINT,
+        '--endpoint', paths.endpoint,
+        '--credential-file', paths.credentialFile,
+        '--state-file', paths.stateFile,
+        '--cwd', cwd,
+        ...(paths.agentDir ? ['--agent-dir', paths.agentDir] : []),
+      ], {
+        cwd,
+        detached: platform !== 'win32',
+        stdio: 'ignore',
+        windowsHide: true,
+        env,
+      });
+      child.unref?.();
+
+      const deadline = Date.now() + startupTimeoutMs;
+      while (Date.now() < deadline) {
+        try {
+          const started = await probe(credential);
+          return { state: 'ready', reused: false, protocolVersion: PROTOCOL_VERSION, capabilities: started.health.capabilities ?? [] };
+        } catch {
+          await wait(RETRY_DELAY_MS);
+        }
+      }
+      try {
+        processLike.kill(child.pid, 'SIGTERM');
+      } catch {
+        // The child may have exited before the timeout; either way it is not ready.
+      }
+      throw new PiSessionDaemonUnavailableError('DAEMON_START_TIMEOUT');
+    });
+
+    try {
+      return await startPromise;
+    } finally {
+      startPromise = null;
+    }
+  };
+
+  const health = async () => {
+    try {
+      const credential = await readCredential();
+      const ready = await probe(credential);
+      return { state: 'ready', protocolVersion: PROTOCOL_VERSION, capabilities: ready.health.capabilities ?? [] };
+    } catch (error) {
+      return {
+        state: 'unavailable',
+        protocolVersion: PROTOCOL_VERSION,
+        error: { code: error instanceof PiSessionDaemonUnavailableError ? error.code : 'DAEMON_UNAVAILABLE' },
+      };
+    }
+  };
+
+  const stop = async () => {
+    const pendingStart = startPromise;
+    if (pendingStart) await pendingStart.catch(() => {});
+    return withOperationLock(async () => {
+      const credential = await readCredential();
+      const { state } = await probe(credential);
+      try {
+        processLike.kill(state.pid, 'SIGTERM');
+      } catch {
+        throw new PiSessionDaemonUnavailableError('DAEMON_STOP_FAILED');
+      }
+
+      const deadline = Date.now() + startupTimeoutMs;
+      while (Date.now() < deadline) {
+        if (!isPidAlive(processLike, state.pid)) {
+          await removeStaleState(state);
+          return { state: 'stopped' };
+        }
+        await wait(RETRY_DELAY_MS);
+      }
+      throw new PiSessionDaemonUnavailableError('DAEMON_STOP_TIMEOUT');
+    });
+  };
+
+  return { paths, start, health, stop };
+};

--- a/packages/web/server/lib/pi/session-daemon/supervisor.test.js
+++ b/packages/web/server/lib/pi/session-daemon/supervisor.test.js
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, readFile, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { createPiSessionDaemonSupervisor } from './supervisor.js';
+
+describe('Pi session daemon supervisor', () => {
+  let supervisor;
+
+  afterEach(async () => {
+    await supervisor?.stop().catch(() => {});
+    supervisor = undefined;
+  });
+
+  it('starts, reuses, health-checks, and stops a private daemon without exposing its credential', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'pichamber-pi-supervisor-'));
+    const cwd = join(root, 'project');
+    const agentDir = join(root, 'agent');
+    await Promise.all([mkdir(cwd), mkdir(agentDir)]);
+    const env = {
+      ...process.env,
+      PI_OFFLINE: '1',
+      OPENCHAMBER_DATA_DIR: join(root, 'data'),
+      OPENCHAMBER_PI_AGENT_DIR: agentDir,
+      XDG_RUNTIME_DIR: join(root, 'runtime'),
+    };
+
+    supervisor = createPiSessionDaemonSupervisor({ env, cwd });
+    await expect(supervisor.start()).resolves.toMatchObject({ state: 'ready', reused: false, protocolVersion: 1 });
+    await expect(supervisor.start()).resolves.toMatchObject({ state: 'ready', reused: true, protocolVersion: 1 });
+    await expect(supervisor.health()).resolves.toEqual({ state: 'ready', protocolVersion: 1, capabilities: [] });
+
+    const credential = await readFile(supervisor.paths.credentialFile, 'utf8');
+    expect(credential.trim()).toHaveLength(64);
+    expect((await stat(supervisor.paths.credentialFile)).mode & 0o777).toBe(0o600);
+    expect(JSON.stringify(await supervisor.health())).not.toContain(credential.trim());
+
+    await expect(supervisor.stop()).resolves.toEqual({ state: 'stopped' });
+    await expect(supervisor.health()).resolves.toMatchObject({
+      state: 'unavailable',
+      error: { code: 'DAEMON_UNAVAILABLE' },
+    });
+  }, 20_000);
+});


### PR DESCRIPTION
## Intent

Make the private Pi SDK daemon independently owned by the web server rather than leaving the disposable socket spike unreachable. The web server now starts or reuses a detached local daemon, exposes authenticated runtime health without exposing private connection data, and stops an identity-verified daemon during graceful shutdown.

## Non-goals

- No browser/session UI migration, shared UI client, session store, realtime event endpoint, or public session-operation routes.
- No OpenCode/Pi engine selector, fallback, compatibility endpoint, or removal of existing OpenCode behavior.
- No directory-scoped session registry, session list/create/open/tree/fork/clone operations, queue policy, provider APIs, attachment APIs, replay persistence, malformed-JSONL handling, or forced-crash recovery.
- No Windows named-pipe ACL implementation or Windows runtime smoke test; private credential authentication remains mandatory there.

## Affected surfaces

| Surface | Change and rationale |
| --- | --- |
| Web server lifecycle | Constructs a Pi daemon supervisor during server startup, starts it after the HTTP listener is ready, and invokes it through a generic graceful-shutdown hook. This gives daemon work a process boundary and avoids delaying web-server availability on daemon startup failure. |
| Private daemon runtime | Adds a detached process entrypoint, authenticated JSONL IPC client, and supervisor. They preserve the local-only socket/pipe boundary while allowing a later web-server process to authenticate and reuse a live daemon. |
| Server-side sidecars | Adds owner-only credential, state, and operation-lock files under the PiChamber data root. The state contains only PID/endpoint/protocol/start time; the credential is generated locally, read from a file by the child, and never passed on the command line. |
| Session persistence behavior | Removes the custom `${agentDir}/sessions` override so Pi uses its normal cwd-scoped session location through `SessionManager.create(cwd)`. This aligns future discovery with Pi's standard session rules. |
| Public API | Adds authenticated `GET /api/pi/runtime` before the generic OpenCode proxy. It deliberately whitelists only protocol/state/capabilities and returns `503` plus a stable `DAEMON_*` code when unavailable. |
| Tests | Adds a real disposable Pi SDK child-process start/reuse/health/stop test with temporary project, agent, data, and XDG runtime directories under `PI_OFFLINE=1`; adds a route-redaction/unavailable-response test; retains and extends socket-spike coverage. |
| Documentation | Updates the completed spike record and migration status, adds the lifecycle record, and documents the owning module's new process, sidecar, identity, permission, and public-response invariants. |

Electron continues to call the same web-server composition root and therefore receives the lifecycle hook, but no Electron-specific main/preload/IPC code changed. Shared UI, VS Code, hosted mobile, and Capacitor have no Pi client or route consumer yet and are intentionally unaffected.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` runtime boundaries and correctness invariants | This adds server-owned agent lifecycle, local IPC, sidecars, and a public route. | Keeps Pi code in `packages/web/server/lib/pi/`; uses no browser-facing daemon listener; treats unavailable/identity failures as explicit errors rather than empty state; documents ownership and cleanup. |
| `openchamber-change-discipline` | Source files, lifecycle contracts, public route, and persisted sidecars changed. | Uses focused modules with injected seams, adjacent observable tests, explicit state/credential cleanup rules, and updated owning documentation. |
| `ui-api-decoupling` plus the implementation map | The new health endpoint is a PiChamber-owned server capability. | Registers the explicit `/api/pi/runtime` route before the generic proxy, retains existing `/api` authentication, and does not expose private runtime URLs or credentials to clients. |
| `sync-state-invariants` | Health/bootstrap failure and reconnect ownership must not imply empty or idle agent state. | Returns a stable unavailable result and `503`; a client can never receive a fabricated empty session list from this adapter. |
| `performance-engineering` | Daemon health and IPC are lifecycle/event paths. | Uses one bounded request per health check, no polling loop or UI subscription, and does not introduce a high-frequency render/store path. No performance claim is made. |
| `packages/web/README.md`, daemon `DOCUMENTATION.md`, and existing server lifecycle conventions | The web package and daemon own the change. | Follows existing injected runtime factories, post-listener async startup, route ordering, and graceful-shutdown patterns; records changed module invariants adjacent to the code. |

## Validation

| Check | Result |
| --- | --- |
| `bun run --cwd packages/web test -- server/lib/pi/session-daemon/session-daemon.test.js server/lib/pi/session-daemon/supervisor.test.js server/lib/pi/routes.test.js` | Passed: 3 files, 6 tests. Includes real detached Pi SDK startup/reuse/health/stop against disposable directories with `PI_OFFLINE=1`. |
| `node --check packages/web/server/index.js packages/web/server/lib/opencode/shutdown-runtime.js packages/web/server/lib/pi/routes.js packages/web/server/lib/pi/session-daemon/{session-daemon,ipc-client,daemon-process,supervisor}.js` | Passed. |
| `bun run type-check:web` | Passed. |
| `bun run lint:web` | Passed. |
| `bun run dead-code` | Completed; the existing non-blocking report has no finding for the Pi route or daemon modules. |
| Focused Python Markdown fence/local-link validation for the updated migration and daemon records | Passed. |
| `git diff --check` | Passed. |

Not run: full workspace test/build, full web-server startup with its existing OpenCode dependencies, Electron packaging/runtime smoke test, Windows named-pipe smoke/ACL test, daemon crash/recovery test, or live provider prompt/tool run. The focused supervisor test is a real Pi SDK process test but deliberately has no developer credentials, session files, or network provider access.

## Visual evidence

There is no rendered UI change. The only public behavior is a machine-facing authenticated JSON health response, and no shared UI consumes it yet; screenshots would not represent the private daemon lifecycle. The route's ready, unavailable, and private-field-redaction behavior is covered by the focused route test at this PR HEAD.

## Risks and failure behavior

- Startup failures leave the web server running but return `503`/stable `DAEMON_*` health errors; they do not fall through to the generic proxy or produce empty/idle session state.
- The supervisor refuses to unlink an existing unauthenticated socket and requires the private health PID to match its non-secret state sidecar before reuse or shutdown. This favors a visible `DAEMON_ENDPOINT_UNVERIFIED` failure over deleting another process's endpoint.
- Credential, state, and lock files are owner-only on POSIX. Public health output is allowlisted, so endpoint, credential, PID, cwd, agent directory, and transcript data cannot be serialized by this route.
- A normal graceful web-server stop signals the verified daemon. An ungraceful server exit intentionally leaves the detached daemon available for a later server to reuse; forced daemon crash/restart interruption recovery is explicitly not implemented yet.
- The default Windows pipe name has a stable hashed OS-user component and private authentication, but equivalent Windows ACL enforcement remains deferred and is documented as such.
