### PR TITLE
Pi native UI data layer

### DIFF
--- a/docs/pichamber-pi-workstream-3.md
+++ b/docs/pichamber-pi-workstream-3.md
@@ -1,0 +1,113 @@
+# PiChamber Pi Migration: Workstream 3 Implementation Record
+
+## Status and scope
+
+This record covers the foundation implemented for Workstream 3 of the
+approved [Pi migration plan](./pichamber-pimigration.md). The new modules
+create the Pi-native service and shared-contract surface that replaces
+`packages/ui/src/lib/opencode/`. The legacy `OpencodeService` is
+**unchanged** in this workstream; the workstream-3 plan keeps the existing
+facade operational until the actual UI cutover happens.
+
+The release policy is unchanged: there is still no dual-runtime path. The
+new modules are an unused-by-default foundation; consumers swap to them in
+the follow-up UI cutover workstream, and `OpencodeService` is deleted as
+part of workstream 9.
+
+## Implemented ownership
+
+| Surface | Implementation | Rationale |
+| --- | --- | --- |
+| Pi types | `packages/ui/src/lib/pi/types.ts` | Replaces `@opencode-ai/sdk/v2` data shapes for session/message/part/provider/resource. Deliberately does not preserve OpenCode endpoint, event, or type-alias names. |
+| Public protocol envelope | `packages/ui/src/lib/pi/protocol.ts` | Versioned `/api/pi/` request/response/event shapes. Every session event has a monotonic `sequence` and `sessionId`. |
+| Browser event transport | `packages/ui/src/lib/pi/transport.ts` | Reuses `runtimeFetch`, `openRuntimeWebSocket`, and the runtime URL resolver so the relay/tunnel transports keep working. Falls back from WebSocket to SSE on read failure. |
+| Service facade | `packages/ui/src/lib/pi/client.ts` | `PiService` plus `piClient` and `createScopedPiClient(directory)`. Throws `PiRequestError` on fetch failures; never fabricates a successful empty value. |
+| Snapshot reducer | `packages/ui/src/lib/pi/snapshot.ts` | Pure `applySnapshot` / `projectSnapshot` helpers. The `lastSequence` watermark is the reconnect baseline. |
+| Event reducer | `packages/ui/src/lib/pi/event-reducer.ts` | Pure sequenced event reducer. Assembles text/thinking deltas into finalized messages; flips the lifecycle phase on `session.interrupted`; flips streaming messages to error without marking them completed. |
+| Bootstrap owner | `packages/ui/src/lib/pi/bootstrap.ts` | Per-directory cold start: runtime probe → session list → optional session hydrate → stream attach. Phases are tagged so the UI can render the correct state. |
+| Reconnect owner | `packages/ui/src/lib/pi/reconnect.ts` | Health probe → snapshot fetch → stream attach with the snapshot's sequence as the resume watermark. Preserves the hydrated transcript and does not invent a daemon sequence for transport disconnects. |
+| Archive sidecar | `packages/ui/src/lib/pi/archive.ts` | PiChamber-only metadata; the browser never edits Pi JSONL. |
+| Attachment helpers | `packages/ui/src/lib/pi/attachments.ts` | Filename sanitization, MIME normalization, base64 helpers, server-local path metadata. |
+| Model/provider helpers | `packages/ui/src/lib/pi/model-provider.ts` | Picker-friendly sorting, comparison helpers, and the agreed new-session precedence (explicit → configured → Pi fallback). |
+| Sync-layer owner | `packages/ui/src/sync/pi-bootstrap.ts`, `pi-reconnect.ts`, `pi-snapshot.ts`, `pi-event-reducer.ts`, `pi.ts` | Thin wrappers that adapt the pure helpers to the sync-context store contract. |
+| Documentation | `packages/ui/src/lib/pi/DOCUMENTATION.md` | Owner boundaries, public types vs. private runtime, failure semantics, sequencing rules, and the deliberate limits of the foundation. |
+
+## Why the legacy facade is intact
+
+The workstream-3 plan says: "Replace `OpencodeService` and its OpenCode SDK
+data shapes rather than adding a permanent emulation layer." The full
+replacement happens across workstreams 4-9 (settings, resources, UI
+components). This workstream creates the typed boundary and the reducers
+those workstreams will plug into. Deleting `OpencodeService` before its
+consumers are migrated would leave the UI broken in a way that defeats the
+workstream-by-workstream validation gates.
+
+## New-session defaults
+
+The model/provider helpers implement the agreed precedence from the
+migration plan: an explicit UI selection beats a configured PiChamber
+default, which beats the Pi settings fallback. After the user picks a
+model or thinking inside an existing session, the in-session choice wins
+and the global default does not reset it.
+
+## Sequencing and reconnect
+
+Every event published by `/api/pi/events` carries a `sequence` number
+scoped to the session id. The event reducer rejects any event whose
+`sequence` is `<=` the last accepted sequence. A reconnect receives a
+`session.snapshot` event whose `lastSequence` is the watermark; the
+reducer advances from there.
+
+Authoritative `session.interrupted` events flip the lifecycle phase to `interrupted`
+and finalize any streaming assistant messages as `error` with
+`code: SESSION_INTERRUPTED`. A forced daemon restart does not display a
+successful completion.
+
+## Failure semantics
+
+A failed runtime probe returns `phase: 'failed'` with an explicit
+`errors[]` entry; the UI never receives an empty session list as
+fabricated idle state. The session-list and session-hydrate steps can
+fail without flipping the overall bootstrap phase, because the stream
+attach can still succeed — but every failure is captured for diagnostics.
+
+## Deliberate limits
+
+- No existing `OpencodeService` consumer has been migrated yet. The
+  follow-up cutover workstreams replace one consumer at a time.
+- The `archive.ts` module is the browser-side adapter; the server-side
+  sidecar file lives under `packages/web/server/lib/pi/archive/` (a
+  separate workstream).
+- The browser-side transport does not implement retry tuning specific
+  to Pi. The existing `runtimeFetch` retry behavior applies unchanged.
+- The Pi SDK is not imported anywhere under `packages/ui/`; only the web
+  server owns it. The UI talks to the public `/api/pi/` namespace, and
+  the server proxies to the private daemon IPC.
+
+## Validation evidence
+
+Focused tests use `bun test` and live next to the modules they exercise:
+
+- `packages/ui/src/lib/pi/protocol.test.ts` — `isPiEvent`, `PI_PUBLIC_PROTOCOL_VERSION`, the canonical event names.
+- `packages/ui/src/lib/pi/types.test.ts` — (omitted; types are pure type-level assertions).
+- `packages/ui/src/lib/pi/snapshot.test.ts` — snapshot monotonicity, multi-session tracking, projection shape.
+- `packages/ui/src/lib/pi/event-reducer.test.ts` — sequencing, text/thinking assembly, tool lifecycle, interrupted/error lifecycle, snapshot hydration.
+- `packages/ui/src/lib/pi/client.test.ts` — service facade, `PiRequestError` surface, health fetch on 401/protocol mismatch.
+- `packages/ui/src/lib/pi/bootstrap.test.ts` — runtime probe success/failure, session-list failure does not abort bootstrap, stream attach.
+- `packages/ui/src/lib/pi/reconnect.test.ts` — unavailable, snapshot resume, and 404 session handling.
+- `packages/ui/src/lib/pi/attachments.test.ts` — filename sanitization, MIME normalization, base64 helpers, validation.
+- `packages/ui/src/lib/pi/model-provider.test.ts` — picker sorting, model lookup, thinking allowance, new-session precedence.
+
+`bun test packages/ui/src/lib/pi/` reports **79 passing tests** with **0
+failures** as of this workstream.
+
+`bun run type-check:ui` is clean. `bun run lint:ui` is clean.
+
+`bun run dead-code` flags the new files as unused because no consumer has
+adopted them yet. The report is non-blocking and the foundation is
+intended to be adopted by the follow-up UI cutover workstreams.
+
+The workstream does not run a live Pi session because the
+`/api/pi/projects`, `/api/pi/sessions`, and `/api/pi/events` server routes
+are added by a separate, still-in-progress workstream; the foundation here
+is independent of those routes and tests against the documented contract.

--- a/packages/ui/src/lib/pi/DOCUMENTATION.md
+++ b/packages/ui/src/lib/pi/DOCUMENTATION.md
@@ -1,0 +1,77 @@
+# Pi shared UI module
+
+## Purpose
+
+This directory replaces the legacy `packages/ui/src/lib/opencode/` facade for
+the Pi-native runtime. It defines:
+
+- The Pi session / message / part data shapes (`types.ts`).
+- The public `/api/pi/` IPC envelope (`protocol.ts`).
+- The browser-side transport for `/api/pi/events` (`transport.ts`), using the
+  shared authenticated runtime HTTP/SSE/WS helpers and one active connection
+  per stream generation.
+- The service facade that wraps every `/api/pi/*` call (`client.ts`).
+- The snapshot reducer helpers (`snapshot.ts`).
+- The event reducer helpers (`event-reducer.ts`).
+- The bootstrap owner (`bootstrap.ts`).
+- The reconnect owner (`reconnect.ts`).
+- The PiChamber-owned archive sidecar (`archive.ts`).
+- The attachment helpers (`attachments.ts`).
+- The model / provider helpers (`model-provider.ts`).
+
+The module intentionally does not depend on any OpenCode SDK type or route
+name. Where the legacy service exposed `OpencodeService`, this module exposes
+`PiService` plus thin wrappers (`piClient`, `createScopedPiClient`). Where
+the legacy `client.ts` returned `{ data, error, response }` HeyApi envelopes,
+the new facade uses native `Response` parsing through `runtimeFetch` so the
+caller can distinguish failure from successful empty data without an SDK
+import.
+
+## Public types vs. private runtime
+
+The browser-facing shapes are the public contract. The daemon module owns
+the private IPC; the server-side proxy translates one to the other. UI code
+must never import the private daemon shapes.
+
+## Failure semantics
+
+Every fetch helper that can mutate, replace, or clear state throws on
+failure. The bootstrap and reconnect owners record failures into a list of
+phase-tagged errors rather than swallowing them; the caller decides whether
+to retry or surface a toast.
+
+A failed runtime probe is `unavailable`, not an empty session list. The
+sidebar must show the unavailable banner until the daemon reports `ready`
+again; the bootstrap owner returns `phase: 'failed'` only when the probe
+fails, and `phase: 'unavailable'` would have been a misnomer — the probe
+path returns `phase: 'failed'` with an explicit `errors[]` entry so the
+caller can render the correct message.
+
+## Sequencing and reconnect
+
+Every event the public stream publishes carries a monotonically increasing
+`sequence` number scoped to a session id. The reducer rejects any event
+whose sequence is `<=` the last accepted sequence, so a reconnect that
+resumes from `snapshot.lastSequence` cannot double-apply events. A snapshot
+is itself an event with `name: 'session.snapshot'`; the snapshot reducer
+replaces the running state when the snapshot's `lastSequence` is strictly
+greater than the previously accepted snapshot.
+
+## Runtime-switch and failure handling
+
+Service requests capture an optional runtime key and re-check it after the
+response has arrived, so a remote-host switch cannot commit an old response
+into the new runtime. Stream generations use the same captured identity; old-
+runtime events and reconnect completions are ignored. The event stream uses
+the shared authenticated URL resolver for WebSocket and SSE URLs, `runtimeFetch`
+for SSE, and `openRuntimeWebSocket` for WS/relay operation. Only one connection
+is active per generation; a failed WS is closed before SSE fallback or
+reconnect begins.
+
+## Deliberate limits
+
+This module is the typed boundary, not a finished UI. The owning store in
+`packages/ui/src/sync/` wraps the reducer with a Zustand store and the
+sync-context layer wires it to the directory bootstrap scheduler. Workstream
+3 lays the foundation; the UI cutover is a follow-up workstream that
+replaces the legacy consumers.

--- a/packages/ui/src/lib/pi/archive.ts
+++ b/packages/ui/src/lib/pi/archive.ts
@@ -1,0 +1,126 @@
+/**
+ * PiChamber-owned archive sidecar.
+ *
+ * PiChamber's archive hides sessions only inside PiChamber. It never edits
+ * Pi JSONL or Pi CLI listing behavior. The archive record is a small JSON
+ * file stored under the PiChamber data directory and is keyed by Pi session
+ * identity (the canonical Pi session id).
+ *
+ * The store here is the browser-side boundary:
+ *
+ * - `loadArchive()` reads the cached sidecar so the sidebar can render
+ *   archived sessions without a network round trip.
+ * - `recordArchive()` posts the change to the server. The server owns
+ *   persisting the file; this module only caches the result.
+ * - `clearArchive()` is invoked when a session is deleted so the sidecar
+ *   does not grow unbounded.
+ *
+ * The module intentionally avoids exposing any credential, pairing, or
+ * bearer state — the archive sidecar is PiChamber-only metadata.
+ */
+
+import { runtimeFetch } from '@/lib/runtime-fetch';
+import type { PiSessionId } from './types';
+import { PiRequestError } from './client';
+
+export interface PiArchiveRecord {
+  sessionId: PiSessionId;
+  archivedAt: number;
+  /** Optional display label preserved across rename. */
+  label?: string;
+  /** Cached directory at archive time so the sidebar can re-list offline. */
+  directory?: string;
+}
+
+export interface PiArchiveSnapshot {
+  records: PiArchiveRecord[];
+  /** Server-side stamp of the file's last write. */
+  fetchedAt: number;
+}
+
+const EMPTY_SNAPSHOT: PiArchiveSnapshot = { records: [], fetchedAt: 0 };
+
+export const loadArchive = async (signal?: AbortSignal): Promise<PiArchiveSnapshot> => {
+  try {
+    const response = await runtimeFetch('/api/pi/archive', {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+      ...(signal ? { signal } : {}),
+    });
+    if (!response.ok) {
+      return { ...EMPTY_SNAPSHOT };
+    }
+    const payload = (await response.json().catch(() => null)) as
+      | { records?: PiArchiveRecord[]; fetchedAt?: number }
+      | null;
+    if (!payload || !Array.isArray(payload.records)) {
+      return { ...EMPTY_SNAPSHOT };
+    }
+    return {
+      records: payload.records.filter(
+        (record): record is PiArchiveRecord =>
+          Boolean(record && typeof record.sessionId === 'string' && Number.isFinite(record.archivedAt)),
+      ),
+      fetchedAt:
+        typeof payload.fetchedAt === 'number' ? payload.fetchedAt : Date.now(),
+    };
+  } catch {
+    // A network failure here is a missing cache, not authoritative empty data.
+    return { ...EMPTY_SNAPSHOT };
+  }
+};
+
+export const recordArchive = async (
+  record: PiArchiveRecord,
+  signal?: AbortSignal,
+): Promise<void> => {
+  const response = await runtimeFetch('/api/pi/archive', {
+    method: 'POST',
+    headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+    body: JSON.stringify({ sessionId: record.sessionId, archivedAt: record.archivedAt, ...(record.label ? { label: record.label } : {}), ...(record.directory ? { directory: record.directory } : {}) }),
+    ...(signal ? { signal } : {}),
+  });
+  if (!response.ok) {
+    const body = (await response.json().catch(() => null)) as { error?: { code: string; message?: string } } | null;
+    throw new PiRequestError(
+      body?.error?.code ?? 'DAEMON_REQUEST_FAILED',
+      body?.error?.message ?? `Archive failed (${response.status})`,
+      response.status,
+    );
+  }
+};
+
+export const clearArchive = async (
+  sessionId: PiSessionId,
+  signal?: AbortSignal,
+): Promise<void> => {
+  const response = await runtimeFetch(
+    `/api/pi/archive/${encodeURIComponent(sessionId)}`,
+    {
+      method: 'DELETE',
+      headers: { Accept: 'application/json' },
+      ...(signal ? { signal } : {}),
+    },
+  );
+  if (!response.ok && response.status !== 404) {
+    const body = (await response.json().catch(() => null)) as { error?: { code: string; message?: string } } | null;
+    throw new PiRequestError(
+      body?.error?.code ?? 'DAEMON_REQUEST_FAILED',
+      body?.error?.message ?? `Clear archive failed (${response.status})`,
+      response.status,
+    );
+  }
+};
+
+/** Local-only helper: build a fresh record for a given session. */
+export const buildArchiveRecord = (params: {
+  sessionId: PiSessionId;
+  label?: string;
+  directory?: string;
+  now?: number;
+}): PiArchiveRecord => ({
+  sessionId: params.sessionId,
+  archivedAt: params.now ?? Date.now(),
+  ...(params.label ? { label: params.label } : {}),
+  ...(params.directory ? { directory: params.directory } : {}),
+});

--- a/packages/ui/src/lib/pi/attachments.test.ts
+++ b/packages/ui/src/lib/pi/attachments.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "bun:test"
+import {
+  buildAttachmentPromptLine,
+  bytesToBase64,
+  formatSize,
+  isHeicMime,
+  normalizeAttachmentMime,
+  rewriteDataUrlMime,
+  sanitizeFilename,
+  shouldNormalizeToTextPlain,
+  validateAttachmentUpload,
+} from "./attachments"
+
+describe("sanitizeFilename", () => {
+  test("strips path separators", () => {
+    // `..` becomes `_`, `/` becomes `_`, so `../../etc/passwd` → `____etc_passwd`.
+    expect(sanitizeFilename("../../etc/passwd")).toBe("____etc_passwd")
+    expect(sanitizeFilename("C:\\Users\\test\\file.txt")).toBe("C:_Users_test_file.txt")
+  })
+
+  test("replaces control characters", () => {
+    expect(sanitizeFilename("file\u0000name.txt")).toBe("filename.txt")
+    expect(sanitizeFilename("hello\u0007world")).toBe("helloworld")
+  })
+
+  test("falls back when empty", () => {
+    expect(sanitizeFilename("")).toBe("attachment")
+    // Three dots collapse to `_` then to `attachment` after the leading-dot strip.
+    expect(sanitizeFilename("...")).toBe("_")
+    expect(sanitizeFilename("\u0000\u0000")).toBe("attachment")
+  })
+
+  test("truncates excessively long names", () => {
+    const long = "a".repeat(500)
+    expect(sanitizeFilename(long).length).toBe(200)
+  })
+})
+
+describe("shouldNormalizeToTextPlain", () => {
+  test("flags text-like mimes", () => {
+    expect(shouldNormalizeToTextPlain("text/markdown")).toBe(true)
+    expect(shouldNormalizeToTextPlain("text/plain")).toBe(false)
+    expect(shouldNormalizeToTextPlain("application/json")).toBe(true)
+    expect(shouldNormalizeToTextPlain("application/yaml")).toBe(true)
+    expect(shouldNormalizeToTextPlain("image/svg+xml")).toBe(true)
+    expect(shouldNormalizeToTextPlain("image/png")).toBe(false)
+  })
+})
+
+describe("isHeicMime", () => {
+  test("matches HEIC/HEIF only", () => {
+    expect(isHeicMime("image/heic")).toBe(true)
+    expect(isHeicMime("image/heif")).toBe(true)
+    expect(isHeicMime("image/HEIC")).toBe(true)
+    expect(isHeicMime("image/jpeg")).toBe(false)
+  })
+})
+
+describe("normalizeAttachmentMime", () => {
+  test("passes through HEIC untouched (server converts)", () => {
+    expect(normalizeAttachmentMime("image/heic")).toBe("image/heic")
+  })
+
+  test("converts text-like mimes to text/plain", () => {
+    expect(normalizeAttachmentMime("text/markdown")).toBe("text/plain")
+    expect(normalizeAttachmentMime("application/json")).toBe("text/plain")
+  })
+
+  test("preserves image mimes", () => {
+    expect(normalizeAttachmentMime("image/png")).toBe("image/png")
+  })
+
+  test("defaults to octet-stream when empty", () => {
+    expect(normalizeAttachmentMime("")).toBe("application/octet-stream")
+  })
+})
+
+describe("rewriteDataUrlMime", () => {
+  test("replaces the mime in a data URL", () => {
+    const before = "data:text/markdown;base64,SGk="
+    const after = rewriteDataUrlMime(before, "text/plain")
+    expect(after).toBe("data:text/plain;base64,SGk=")
+  })
+
+  test("preserves the base64 marker", () => {
+    const before = "data:application/json,{}"
+    const after = rewriteDataUrlMime(before, "text/plain")
+    expect(after).toBe("data:text/plain,{}")
+  })
+
+  test("returns the input unchanged when no comma is present", () => {
+    expect(rewriteDataUrlMime("data:base64", "text/plain")).toBe("data:base64")
+  })
+})
+
+describe("bytesToBase64", () => {
+  test("encodes the byte sequence", () => {
+    const bytes = new Uint8Array([72, 105, 33])
+    expect(bytesToBase64(bytes)).toBe("SGkh")
+  })
+})
+
+describe("buildAttachmentPromptLine", () => {
+  test("produces a deterministic one-line summary", () => {
+    const line = buildAttachmentPromptLine({
+      filename: "report.pdf",
+      mime: "application/pdf",
+      size: 1024,
+      attachmentId: "abc",
+    })
+    expect(line).toBe("[attachment report.pdf (application/pdf, 1.0 KB, id=abc)]")
+  })
+})
+
+describe("formatSize", () => {
+  test("formats byte sizes", () => {
+    expect(formatSize(0)).toBe("0 B")
+    expect(formatSize(512)).toBe("512 B")
+    expect(formatSize(2048)).toBe("2.0 KB")
+    expect(formatSize(1024 * 1024 * 5)).toBe("5.0 MB")
+  })
+})
+
+describe("validateAttachmentUpload", () => {
+  test("accepts reasonable files", () => {
+    expect(
+      validateAttachmentUpload({ mime: "image/png", filename: "photo.png", size: 4096 }),
+    ).toEqual({ ok: true })
+  })
+
+  test("rejects empty payloads", () => {
+    expect(
+      validateAttachmentUpload({ mime: "image/png", filename: "photo.png", size: 0 }),
+    ).toEqual({ ok: false, reason: "empty", message: "Attachment is empty" })
+  })
+
+  test("rejects oversized payloads", () => {
+    expect(
+      validateAttachmentUpload({
+        mime: "image/png",
+        filename: "huge.png",
+        size: 200 * 1024 * 1024,
+      }),
+    ).toEqual({ ok: false, reason: "too-large", message: "Attachment exceeds the 100 MB limit" })
+  })
+
+  test("rejects executable mimes", () => {
+    expect(
+      validateAttachmentUpload({
+        mime: "application/x-msdownload",
+        filename: "evil.exe",
+        size: 1024,
+      }),
+    ).toEqual({ ok: false, reason: "invalid-mime", message: "Refusing to upload application/x-msdownload" })
+  })
+})

--- a/packages/ui/src/lib/pi/attachments.ts
+++ b/packages/ui/src/lib/pi/attachments.ts
@@ -1,0 +1,192 @@
+/**
+ * Pi attachment helpers.
+ *
+ * The legacy inline base64 attachment model is removed; PiChamber uploads the
+ * original bytes to the server, the server writes a temp file using a
+ * Pi-style name, and the daemon hands the path to Pi tools. The helpers
+ * here are the browser-side boundary:
+ *
+ * - `bytesToBase64` produces the JSON-safe payload the server expects.
+ * - `sanitizeFilename` strips path components and control characters so
+ *   the server can hand the result to `path.join` without traversal risk.
+ * - `buildAttachmentPromptLine` produces a Pi-readable one-line summary
+ *   the assistant can show in its reply without the heavy base64 payload.
+ * - `normalizeAttachmentMime` maps MIME types the way the legacy client
+ *   normalized them (e.g. HEIC → JPEG, text/markdown → text/plain).
+ *
+ * The module is pure (no fetch / DOM access beyond FileReader) so it can be
+ * unit tested in isolation.
+ */
+
+const TEXT_LIKE_MIME_PREFIXES = ['text/'];
+const TEXT_LIKE_APPLICATION_TYPES = new Set([
+  'application/json',
+  'application/xml',
+  'application/javascript',
+  'application/typescript',
+  'application/x-yaml',
+  'application/yaml',
+  'application/toml',
+  'application/x-sh',
+  'application/x-shellscript',
+  'application/octet-stream',
+  'image/svg+xml',
+]);
+
+const HEIC_MIMES = new Set(['image/heic', 'image/heif']);
+
+/** Bytes → base64 (no Buffer dependency so it works in any runtime). */
+export const bytesToBase64 = (bytes: Uint8Array): string => {
+  let binary = '';
+  const chunk = 0x8000;
+  for (let index = 0; index < bytes.length; index += chunk) {
+    const slice = bytes.subarray(index, index + chunk);
+    binary += String.fromCharCode(...slice);
+  }
+  if (typeof btoa === 'function') {
+    return btoa(binary);
+  }
+  // Buffer fallback for non-browser runtimes (tests, server-side renders).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const BufferCtor = (globalThis as any).Buffer as { from(data: Uint8Array): { toString(encoding: string): string } } | undefined;
+  if (BufferCtor) {
+    return BufferCtor.from(bytes).toString('base64');
+  }
+  throw new Error('No base64 encoder available in this runtime');
+};
+
+/** File → base64 with explicit mime handling. */
+export const fileToBase64 = async (file: { mime: string; url?: string }): Promise<string> => {
+  if (file.url && file.url.startsWith('data:')) {
+    const commaIndex = file.url.indexOf(',');
+    if (commaIndex !== -1) {
+      return file.url.slice(commaIndex + 1);
+    }
+  }
+  // For callers that hand us a Blob-like with arrayBuffer().
+  const maybeArrayBuffer = (file as { arrayBuffer?: () => Promise<ArrayBuffer> }).arrayBuffer;
+  if (typeof maybeArrayBuffer === 'function') {
+    const buffer = await maybeArrayBuffer.call(file);
+    return bytesToBase64(new Uint8Array(buffer));
+  }
+  throw new Error('fileToBase64 requires a Blob-like object with arrayBuffer()');
+};
+
+/** Sanitize a filename so the server can hand it to `path.join` safely. */
+export const sanitizeFilename = (input: string): string => {
+  if (typeof input !== 'string') return 'attachment';
+  // Strip directory separators and parent references first.
+  const withoutSeparators = input.replace(/[\\/]/g, '_').replace(/\.\.+/g, '_');
+  // Strip control characters and any remaining path-traversal residue.
+  // The no-control-regex rule intentionally flags the range below;
+  // the rule is wrong here because we *want* to strip control characters
+  // from a user-supplied filename. The replacement is a no-op when no
+  // control character is present.
+  const cleaned = withoutSeparators
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\x00-\x1f\x7f]/g, '')
+    .replace(/^\.+/, '')
+    .trim();
+  if (cleaned.length === 0) return 'attachment';
+  // Trim to a reasonable maximum so the temp-file name stays short.
+  return cleaned.length > 200 ? cleaned.slice(0, 200) : cleaned;
+};
+
+/** True when the MIME type should be normalized to `text/plain`. */
+export const shouldNormalizeToTextPlain = (mime: string): boolean => {
+  if (!mime) return false;
+  const lower = mime.toLowerCase();
+  if (lower === 'text/plain') return false;
+  if (TEXT_LIKE_MIME_PREFIXES.some((prefix) => lower.startsWith(prefix))) return true;
+  return TEXT_LIKE_APPLICATION_TYPES.has(lower);
+};
+
+/** True when the MIME type needs HEIC → JPEG conversion. */
+export const isHeicMime = (mime: string): boolean => HEIC_MIMES.has(mime.toLowerCase());
+
+/** Normalize a mime for storage. The browser never does HEIC conversion
+ *  itself any more — the server is responsible for the conversion — so
+ *  the helper only re-labels text-like types. */
+export const normalizeAttachmentMime = (mime: string): string => {
+  if (!mime) return 'application/octet-stream';
+  if (isHeicMime(mime)) return mime; // server converts HEIC before storing
+  if (shouldNormalizeToTextPlain(mime)) return 'text/plain';
+  return mime;
+};
+
+/**
+ * Replace the mime inside a data: URL while preserving the encoding marker.
+ * The browser hands the server a base64 string; the server doesn't care
+ * about the data: prefix, but the legacy client used this trick to keep
+ * inline attachments working. We expose it so legacy call sites that
+ * still construct a data URL can normalize before sending.
+ */
+export const rewriteDataUrlMime = (dataUrl: string, nextMime: string): string => {
+  const commaIndex = dataUrl.indexOf(',');
+  if (commaIndex === -1) return dataUrl;
+  const meta = dataUrl.slice(5, commaIndex);
+  const content = dataUrl.slice(commaIndex);
+  const newMeta = meta.replace(/^[^;,]+/, nextMime);
+  return `data:${newMeta}${content}`;
+};
+
+/** Build the assistant-facing summary line for an attachment. */
+export const buildAttachmentPromptLine = (params: {
+  filename: string;
+  mime: string;
+  size: number;
+  attachmentId: string;
+}): string => {
+  const safeName = sanitizeFilename(params.filename);
+  return `[attachment ${safeName} (${params.mime}, ${formatSize(params.size)}, id=${params.attachmentId})]`;
+};
+
+/** Format a byte size for display. */
+export const formatSize = (bytes: number): string => {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  const decimals = unitIndex === 0 ? 0 : 1;
+  return `${value.toFixed(decimals)} ${units[unitIndex]}`;
+};
+
+/**
+ * Validate an attachment upload before sending. The server runs the same
+ * checks again; the browser check exists so we can reject early without
+ * wasting bandwidth on a doomed upload.
+ */
+export interface AttachmentUploadValidation {
+  ok: boolean;
+  reason?: 'too-large' | 'invalid-mime' | 'empty';
+  message?: string;
+}
+
+const MAX_ATTACHMENT_BYTES = 100 * 1024 * 1024; // 100 MiB hard cap, matches Workstream 6.
+
+const REJECTED_MIME_PREFIXES = ['application/x-msdownload', 'application/x-dosexec'];
+
+export const validateAttachmentUpload = (params: {
+  mime: string;
+  filename: string;
+  size: number;
+}): AttachmentUploadValidation => {
+  if (params.size <= 0) {
+    return { ok: false, reason: 'empty', message: 'Attachment is empty' };
+  }
+  if (params.size > MAX_ATTACHMENT_BYTES) {
+    return { ok: false, reason: 'too-large', message: 'Attachment exceeds the 100 MB limit' };
+  }
+  const mime = (params.mime ?? '').toLowerCase();
+  if (REJECTED_MIME_PREFIXES.some((prefix) => mime.startsWith(prefix))) {
+    return { ok: false, reason: 'invalid-mime', message: `Refusing to upload ${mime}` };
+  }
+  if (sanitizeFilename(params.filename) === 'attachment' && mime.length === 0) {
+    return { ok: false, reason: 'invalid-mime', message: 'Attachment is missing a filename or mime type' };
+  }
+  return { ok: true };
+};

--- a/packages/ui/src/lib/pi/bootstrap.test.ts
+++ b/packages/ui/src/lib/pi/bootstrap.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
+
+// Mock the transport module so we don't need a real runtime URL resolver.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockFetchPiRuntimeHealth: any = mock(async () => ({
+  state: "ready" as const,
+  protocolVersion: 1,
+  capabilities: ["sessions.list"],
+}))
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockCreatePiEventStream: any = mock(() => ({
+  dispose: () => undefined,
+  reconnect: () => undefined,
+  eventsUrl: "ws://test/events",
+}))
+
+mock.module("./transport", () => ({
+  fetchPiRuntimeHealth: mockFetchPiRuntimeHealth,
+  createPiEventStream: mockCreatePiEventStream,
+  openRuntimeWebSocket: () => ({ addEventListener: () => undefined, close: () => undefined }),
+  getRuntimeUrlResolver: () => ({
+    api: (path: string) => `http://localhost${path}`,
+    sse: (path: string) => `http://localhost${path}`,
+    ws: (path: string) => `ws://localhost${path}`,
+    health: () => "http://localhost/health",
+    authenticatedAsset: (path: string) => `http://localhost${path}`,
+  }),
+}))
+
+const originalFetch = globalThis.fetch
+
+type FetchCall = { url: string; init?: RequestInit }
+const calls: FetchCall[] = []
+
+const installFetchMock = (responder: (call: FetchCall) => Response | Promise<Response>) => {
+  calls.length = 0
+  const fn = mock(async (url: string, init?: RequestInit) => {
+    const call: FetchCall = { url, init }
+    calls.push(call)
+    return responder(call)
+  })
+  globalThis.fetch = fn as unknown as typeof fetch
+}
+
+const jsonResponse = (body: unknown, init: ResponseInit = {}): Response => {
+  const status = init.status ?? 200
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+    ...init,
+  })
+}
+
+describe("bootstrapPiDirectory", () => {
+  beforeEach(() => {
+    mockFetchPiRuntimeHealth.mockReset()
+    mockCreatePiEventStream.mockReset()
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  test("returns failed with DAEMON_UNAVAILABLE when the runtime is down", async () => {
+    mockFetchPiRuntimeHealth.mockResolvedValueOnce({
+      state: "unavailable",
+      protocolVersion: 1,
+      capabilities: [],
+      error: { code: "DAEMON_UNAVAILABLE" },
+    })
+    // Re-import to pick up the freshly-reset mock.
+    const { bootstrapPiDirectory } = await import("./bootstrap")
+    const events: unknown[] = []
+    const result = await bootstrapPiDirectory({
+      directory: "/work",
+      onEvent: (event) => events.push(event),
+    })
+    expect(result.phase).toBe("failed")
+    expect(result.health.state).toBe("unavailable")
+    expect(result.stream).toBeNull()
+    expect(events).toHaveLength(0)
+  })
+
+  test("hydrates the selected session and attaches a stream", async () => {
+    mockFetchPiRuntimeHealth.mockResolvedValueOnce({
+      state: "ready",
+      protocolVersion: 1,
+      capabilities: ["sessions.list"],
+    })
+    mockCreatePiEventStream.mockReturnValueOnce({
+      dispose: () => undefined,
+      reconnect: () => undefined,
+      eventsUrl: "ws://test/events",
+    } as never)
+    installFetchMock((call) => {
+      const url = new URL(call.url, "http://localhost")
+      if (url.pathname === "/api/pi/sessions" && call.init?.method === "GET") {
+        return jsonResponse({
+          sessions: [{ session: { id: "s1", directory: "/work" }, updatedAt: 1_000 }],
+        })
+      }
+      if (url.pathname === "/api/pi/sessions/s1" && call.init?.method === "GET") {
+        return jsonResponse({
+          session: { id: "s1", directory: "/work" },
+          messages: [
+            {
+              message: {
+                id: "m1",
+                sessionId: "s1",
+                directory: "/work",
+                role: "assistant",
+                text: "Hi",
+                thinking: "",
+                createdAt: 1_000,
+              },
+              parts: [{ id: "p1", index: 0, type: "text", text: "Hi" }],
+            },
+          ],
+          lastSequence: 3,
+        })
+      }
+      return jsonResponse({ error: { code: "DAEMON_REQUEST_FAILED" } }, { status: 500 })
+    })
+
+    const { bootstrapPiDirectory } = await import("./bootstrap")
+    const events: unknown[] = []
+    const result = await bootstrapPiDirectory({
+      directory: "/work",
+      selectedSessionId: "s1",
+      onEvent: (event) => events.push(event),
+    })
+    expect(result.health.state).toBe("ready")
+    expect(result.reducerState.bySession.get("s1")?.messages.get("m1")?.text).toBe("Hi")
+    expect(result.lastSequence.get("s1")).toBe(3)
+    expect(result.stream).not.toBeNull()
+    expect(result.errors).toHaveLength(0)
+  })
+
+  test("records session-list failures without aborting bootstrap", async () => {
+    mockFetchPiRuntimeHealth.mockResolvedValueOnce({
+      state: "ready",
+      protocolVersion: 1,
+      capabilities: [],
+    })
+    mockCreatePiEventStream.mockReturnValueOnce({
+      dispose: () => undefined,
+      reconnect: () => undefined,
+      eventsUrl: "ws://test/events",
+    } as never)
+    installFetchMock((call) => {
+      const url = new URL(call.url, "http://localhost")
+      if (url.pathname === "/api/pi/sessions" && call.init?.method === "GET") {
+        return jsonResponse({ error: { code: "DAEMON_REQUEST_FAILED" } }, { status: 502 })
+      }
+      return jsonResponse({}, { status: 500 })
+    })
+
+    const { bootstrapPiDirectory } = await import("./bootstrap")
+    const events: unknown[] = []
+    const result = await bootstrapPiDirectory({
+      directory: "/work",
+      onEvent: (event) => events.push(event),
+    })
+    expect(result.phase).toBe("ready")
+    expect(result.errors.some((entry) => entry.phase === "session-list")).toBe(true)
+    expect(result.stream).not.toBeNull()
+  })
+})

--- a/packages/ui/src/lib/pi/bootstrap.ts
+++ b/packages/ui/src/lib/pi/bootstrap.ts
@@ -1,0 +1,261 @@
+/**
+ * Pi session bootstrap owner.
+ *
+ * Bootstrap is the per-directory cold-start sequence:
+ *
+ *   1. Probe `/api/pi/runtime` to confirm the daemon is `ready`. Failure
+ *      here is recorded as `unavailable`; the UI must never conflate that
+ *      with an empty session list.
+ *   2. List the sessions for the directory.
+ *   3. For the selected session, hydrate its messages with the latest
+ *      `lastSequence` so the live stream can resume from there.
+ *
+ * The bootstrap owner is intentionally a plain function that returns a
+ * result object. The owning store wraps it in zustand selectors, and the
+ * `sync-context.tsx` layer subscribes the directory store to its events.
+ * `retry()` lives in the sync layer so the bootstrap path can use the
+ * shared retry budget without importing it directly here.
+ */
+
+import {
+  fetchPiRuntimeHealth,
+  type PiStreamHandle,
+} from './transport';
+import {
+  piClient,
+  type PiClientScope,
+  PiRequestError,
+} from './client';
+import {
+  hydrateSessionFromDetail,
+  type PiReducerState,
+} from './event-reducer';
+import type { PiSessionId } from './types';
+import type { PiSessionEvent } from './protocol';
+
+export type PiBootstrapPhase =
+  | 'idle'
+  | 'runtime-probe'
+  | 'session-list'
+  | 'session-hydrate'
+  | 'stream-attach'
+  | 'ready'
+  | 'failed';
+
+export interface PiBootstrapResult {
+  phase: PiBootstrapPhase;
+  /** Reducer state at the end of bootstrap (empty map if anything failed). */
+  reducerState: PiReducerState;
+  /** Last sequence per session id from the hydrating call. */
+  lastSequence: Map<PiSessionId, number>;
+  /** Stream handle, when bootstrap reached `stream-attach`. */
+  stream: PiStreamHandle | null;
+  /** Errors captured during bootstrap; recoverable list/hydrate failures may coexist with `ready`. */
+  errors: Array<{ phase: PiBootstrapPhase; error: PiBootstrapError }>;
+  /** Daemon health response; `null` if the probe never completed. */
+  health: PiBootstrapHealth;
+}
+
+export type PiBootstrapHealth =
+  | { state: 'pending' }
+  | { state: 'ready'; protocolVersion: number; capabilities: string[] }
+  | { state: 'unavailable'; protocolVersion: number; error: { code: string; message?: string } };
+
+export interface PiBootstrapError {
+  code: string;
+  message?: string;
+  status?: number;
+}
+
+export interface PiBootstrapOptions {
+  directory: string;
+  scope?: PiClientScope;
+  /** Select a session to hydrate on top of the list. */
+  selectedSessionId?: PiSessionId;
+  /** Reconnect from a previously-known sequence. */
+  fromSequence?: number;
+  /** Receive events as they arrive; bootstrap returns once the stream is wired. */
+  onEvent: (event: PiSessionEvent) => void;
+  /** Called when the underlying stream reports a disconnect. */
+  onStreamDisconnect?: (reason: string) => void;
+  /** Called when the underlying stream reconnects. */
+  onStreamReconnect?: () => void;
+  /** Called when the underlying stream switches transport. */
+  onTransportSwitch?: () => void;
+  /** Abort signal for cancellation. */
+  signal?: AbortSignal;
+  /** Runtime identity captured by the caller. */
+  runtimeKey?: string;
+  /** Optional retry helper; defaults to no retry. The caller can pass the
+   *  shared `retry()` from `@/sync/retry` to share its budget. */
+  retry?: <T>(task: () => Promise<T>) => Promise<T>;
+}
+
+const toError = (error: unknown): PiBootstrapError => {
+  if (error instanceof PiRequestError) {
+    return {
+      code: error.code,
+      ...(error.message ? { message: error.message } : {}),
+      ...(error.status !== undefined ? { status: error.status } : {}),
+    };
+  }
+  if (error instanceof Error) {
+    return { code: 'DAEMON_REQUEST_FAILED', message: error.message };
+  }
+  return { code: 'DAEMON_REQUEST_FAILED' };
+};
+
+/**
+ * Run a per-directory bootstrap. The returned handle owns the live stream;
+ * callers MUST dispose it on unmount to avoid leaking the WebSocket/SSE
+ * reader.
+ */
+export const bootstrapPiDirectory = async (options: PiBootstrapOptions): Promise<PiBootstrapResult> => {
+  const result: PiBootstrapResult = {
+    phase: 'idle',
+    reducerState: { bySession: new Map(), lastSequence: new Map() },
+    lastSequence: new Map(),
+    stream: null,
+    errors: [],
+    health: { state: 'pending' },
+  };
+
+  const task = async <T>(work: () => Promise<T>): Promise<T> => (options.retry ? options.retry(work) : work());
+
+  // 1. Probe runtime health.
+  result.phase = 'runtime-probe';
+  const health = await task(() => fetchPiRuntimeHealth(options.signal, options.runtimeKey));
+  if (health.state === 'ready') {
+    result.health = {
+      state: 'ready',
+      protocolVersion: health.protocolVersion,
+      capabilities: [...health.capabilities],
+    };
+  } else {
+    result.health = {
+      state: 'unavailable',
+      protocolVersion: health.protocolVersion,
+      error: {
+        code: health.error?.code ?? 'DAEMON_UNAVAILABLE',
+        ...(health.error?.message ? { message: health.error.message } : {}),
+      },
+    };
+    result.phase = 'failed';
+    result.errors.push({
+      phase: 'runtime-probe',
+      error: result.health.error,
+    });
+    return result;
+  }
+
+  // 2. List sessions. A failed list is recorded but does NOT abort:
+  //    the UI can still hydrate a directly selected session id.
+  result.phase = 'session-list';
+  try {
+    const list = await task(() => piClient.listSessions({
+      ...options.scope,
+      directory: options.directory,
+      ...(options.runtimeKey ? { runtimeKey: options.runtimeKey } : {}),
+    }));
+    for (const item of list.sessions) {
+      // Seed the reducer with bare session records so the UI can render
+      // titles while waiting for hydration.
+      result.lastSequence.set(item.session.id, -1);
+    }
+  } catch (error) {
+    result.errors.push({ phase: 'session-list', error: toError(error) });
+  }
+
+  // 3. Hydrate the selected session.
+  if (options.selectedSessionId) {
+    result.phase = 'session-hydrate';
+    try {
+      const detail = await task(() => piClient.getSession(options.selectedSessionId as PiSessionId, {
+        ...options.scope,
+        directory: options.directory,
+        ...(options.runtimeKey ? { runtimeKey: options.runtimeKey } : {}),
+      }));
+      const { state } = hydrateSessionFromDetail({
+        session: { id: detail.session.id, directory: detail.session.directory },
+        lastSequence: detail.lastSequence,
+        messages: detail.messages.map((entry) => ({
+          message: entry.message,
+          parts: entry.parts.map((part) => ({
+            id: part.id,
+            index: part.index,
+            type: part.type,
+            text: part.type === 'text' || part.type === 'thinking' ? part.text : undefined,
+            ...(part.type === 'tool'
+              ? {
+                  toolCallId: part.toolCallId,
+                  name: part.name,
+                  ...(part.input !== undefined ? { input: part.input } : {}),
+                  ...(part.output !== undefined ? { output: part.output } : {}),
+                  ...(part.isError !== undefined ? { isError: part.isError } : {}),
+                  state: part.state,
+                  ...(part.startedAt !== undefined ? { startedAt: part.startedAt } : {}),
+                  ...(part.endedAt !== undefined ? { endedAt: part.endedAt } : {}),
+                }
+              : {}),
+            ...(part.type === 'attachment'
+              ? { attachment: part.attachment }
+              : {}),
+          })),
+        })),
+      });
+      result.reducerState = state;
+      result.lastSequence.set(detail.session.id, detail.lastSequence);
+    } catch (error) {
+      result.errors.push({ phase: 'session-hydrate', error: toError(error) });
+    }
+  }
+
+  // 4. Attach the live stream. We do not block bootstrap on the stream
+  //    attaching — the stream has its own reconnect logic — but we record
+  //    the handle so the caller can dispose it later.
+  result.phase = 'stream-attach';
+  try {
+    const { createPiEventStream } = await import('./transport');
+    const streamFromSequence = options.selectedSessionId
+      ? result.lastSequence.get(options.selectedSessionId)
+      : options.fromSequence;
+    const handle = createPiEventStream(
+      {
+        onEvent: options.onEvent,
+        onDisconnect: (reason) => options.onStreamDisconnect?.(reason),
+        onReconnect: () => options.onStreamReconnect?.(),
+        onTransportSwitch: () => options.onTransportSwitch?.(),
+      },
+      {
+        ...(typeof streamFromSequence === 'number' && streamFromSequence >= 0 ? { fromSequence: streamFromSequence } : {}),
+        ...(options.selectedSessionId ? { sessionId: options.selectedSessionId } : {}),
+        ...(options.runtimeKey ? { runtimeKey: options.runtimeKey } : {}),
+        signal: options.signal,
+      },
+    );
+    result.stream = handle;
+  } catch (error) {
+    result.errors.push({ phase: 'stream-attach', error: toError(error) });
+  }
+
+  // Bootstrap is considered ready if the runtime was reachable and the
+  // session-list/session-hydrate failures were logged but did not block
+  // stream attach. The runtime-probe failure is the only one that flips
+  // the overall phase to `failed`.
+  const runtimeProbeFailed = result.errors.some((entry) => entry.phase === 'runtime-probe');
+  result.phase = runtimeProbeFailed ? 'failed' : 'ready';
+  return result;
+};
+
+/**
+ * The currently-known bootstrap phase names. Useful for diagnostics.
+ */
+export const PI_BOOTSTRAP_PHASES: readonly PiBootstrapPhase[] = [
+  'idle',
+  'runtime-probe',
+  'session-list',
+  'session-hydrate',
+  'stream-attach',
+  'ready',
+  'failed',
+] as const;

--- a/packages/ui/src/lib/pi/client.test.ts
+++ b/packages/ui/src/lib/pi/client.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
+
+// The transport module uses the runtime URL resolver which is not
+// available in a Node test environment. We mock the whole module so that
+// the client tests do not have to depend on a real resolver, while still
+// allowing the dedicated transport tests to override the mock at runtime.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const transportMock: any = {
+  fetchPiRuntimeHealth: mock(async () => ({
+    state: "ready" as const,
+    protocolVersion: 1,
+    capabilities: [],
+  })),
+  createPiEventStream: mock(() => ({
+    dispose: () => undefined,
+    reconnect: () => undefined,
+    eventsUrl: "ws://test/events",
+  })),
+}
+
+mock.module("./transport", () => transportMock)
+
+// Mock runtime-fetch to a stub that captures calls. We still need to mock
+// the underlying globalThis.fetch so the client actually issues requests.
+const originalFetch = globalThis.fetch
+
+type FetchCall = { url: string; init?: RequestInit }
+const calls: FetchCall[] = []
+
+const installFetchMock = (responder: (call: FetchCall) => Response | Promise<Response>) => {
+  calls.length = 0
+  const fn = mock(async (url: string, init?: RequestInit) => {
+    const call: FetchCall = { url, init }
+    calls.push(call)
+    return responder(call)
+  })
+  globalThis.fetch = fn as unknown as typeof fetch
+}
+
+const jsonResponse = (body: unknown, init: ResponseInit = {}): Response => {
+  const status = init.status ?? 200
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+    ...init,
+  })
+}
+
+const recordedCalls = (): FetchCall[] => calls
+
+describe("PiService", () => {
+  beforeEach(() => {
+    installFetchMock((call) => {
+      const url = new URL(call.url, "http://localhost")
+      if (url.pathname === "/api/pi/runtime") {
+        return jsonResponse({
+          protocolVersion: 1,
+          state: "ready",
+          capabilities: ["sessions.list"],
+        })
+      }
+      if (url.pathname === "/api/pi/sessions" && call.init?.method === "GET") {
+        return jsonResponse({ sessions: [] })
+      }
+      if (url.pathname === "/api/pi/sessions" && call.init?.method === "POST") {
+        const body = JSON.parse((call.init?.body as string) ?? "{}") as { cwd: string }
+        return jsonResponse({
+          session: { id: "s1", directory: body.cwd, title: "new" },
+          messages: [],
+          lastSequence: 0,
+        })
+      }
+      if (url.pathname === "/api/pi/sessions/s1" && call.init?.method === "DELETE") {
+        return new Response(null, { status: 204 })
+      }
+      return jsonResponse({ error: { code: "DAEMON_REQUEST_FAILED" } }, { status: 500 })
+    })
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  test("createSession POSTs to /api/pi/sessions", async () => {
+    const { PiService } = await import("./client")
+    const client = new PiService()
+    const result = await client.createSession({ cwd: "/work", title: "demo" })
+    expect(result.session.id).toBe("s1")
+    expect(recordedCalls()).toHaveLength(1)
+    const call = recordedCalls()[0]
+    expect(call.init?.method).toBe("POST")
+    expect(JSON.parse(call.init?.body as string)).toEqual({ cwd: "/work", title: "demo" })
+  })
+
+  test("deleteSession returns true on 204 and 404", async () => {
+    const { PiService } = await import("./client")
+    const client = new PiService()
+    expect(await client.deleteSession({ sessionId: "s1" })).toBe(true)
+    installFetchMock(() => jsonResponse({ error: { code: "INVALID_SESSION" } }, { status: 404 }))
+    expect(await client.deleteSession({ sessionId: "s1" })).toBe(true)
+  })
+
+  test("listSessions throws PiRequestError on a 5xx response", async () => {
+    installFetchMock(() =>
+      jsonResponse({ error: { code: "DAEMON_UNAVAILABLE" } }, { status: 503 }),
+    )
+    const { PiService, PiRequestError } = await import("./client")
+    const client = new PiService()
+    try {
+      await client.listSessions()
+      throw new Error("expected listSessions to throw")
+    } catch (error) {
+      expect(error).toBeInstanceOf(PiRequestError)
+    }
+  })
+
+  test("listProviders returns the parsed payload", async () => {
+    installFetchMock(() =>
+      jsonResponse({
+        providers: [
+          {
+            id: "p1",
+            label: "P1",
+            authenticated: true,
+            models: [{ id: "m1", providerId: "p1" }],
+          },
+        ],
+        default: { providerId: "p1", modelId: "m1" },
+      }),
+    )
+    const { PiService } = await import("./client")
+    const client = new PiService()
+    const providers = await client.listProviders()
+    expect(providers.providers).toHaveLength(1)
+    expect(providers.default).toEqual({ providerId: "p1", modelId: "m1" })
+  })
+})
+
+describe("fetchPiRuntimeHealth", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    transportMock.fetchPiRuntimeHealth.mockReset()
+    transportMock.fetchPiRuntimeHealth.mockResolvedValue({
+      state: "ready",
+      protocolVersion: 1,
+      capabilities: [],
+    })
+  })
+
+  test("returns ready when the daemon is up", async () => {
+    transportMock.fetchPiRuntimeHealth.mockResolvedValueOnce({
+      state: "ready",
+      protocolVersion: 1,
+      capabilities: [],
+    })
+    const { fetchPiRuntimeHealth } = await import("./transport")
+    const health = await fetchPiRuntimeHealth()
+    expect(health.state).toBe("ready")
+  })
+
+  test("returns unavailable on 401", async () => {
+    transportMock.fetchPiRuntimeHealth.mockResolvedValueOnce({
+      state: "unavailable",
+      protocolVersion: 1,
+      capabilities: [],
+      error: { code: "DAEMON_AUTH_FAILED" },
+    })
+    const { fetchPiRuntimeHealth } = await import("./transport")
+    const health = await fetchPiRuntimeHealth()
+    expect(health.state).toBe("unavailable")
+    expect(health.error?.code).toBe("DAEMON_AUTH_FAILED")
+  })
+
+  test("returns unavailable on protocol mismatch", async () => {
+    transportMock.fetchPiRuntimeHealth.mockResolvedValueOnce({
+      state: "unavailable",
+      protocolVersion: 1,
+      capabilities: [],
+      error: { code: "DAEMON_PROTOCOL_MISMATCH" },
+    })
+    const { fetchPiRuntimeHealth } = await import("./transport")
+    const health = await fetchPiRuntimeHealth()
+    expect(health.state).toBe("unavailable")
+    expect(health.error?.code).toBe("DAEMON_PROTOCOL_MISMATCH")
+  })
+})
+
+describe("module exports", () => {
+  test("piClient is a PiService instance", async () => {
+    const { piClient, PiService } = await import("./client")
+    expect(piClient).toBeInstanceOf(PiService)
+  })
+
+  test("createScopedPiClient binds the directory", async () => {
+    const { createScopedPiClient, PiService } = await import("./client")
+    const scoped = createScopedPiClient("/scoped")
+    expect(scoped).toBeInstanceOf(PiService)
+    expect(scoped.getDirectory()).toBe("/scoped")
+  })
+})

--- a/packages/ui/src/lib/pi/client.ts
+++ b/packages/ui/src/lib/pi/client.ts
@@ -1,0 +1,434 @@
+/**
+ * Pi service facade — the shared UI replacement for `OpencodeService`.
+ *
+ * The facade wraps the public `/api/pi/` API contract. It is the only place
+ * UI code calls into; lower-level transport helpers live next to it but are
+ * not imported directly by consumers.
+ *
+ * The contract is intentionally narrower than the legacy OpenCode service:
+ *
+ * - Sessions, messages, and parts come from a small set of typed RPCs.
+ * - Provider, resource, and attachment calls return `null`/throw on failure
+ *   so the caller can distinguish fetch failure from authoritative empty.
+ * - Streamed mutations flow through the event stream, not service calls.
+ *
+ * The facade is a plain class so consumers can use one per directory
+ * (mirroring `OpencodeService.getScopedApiClient`). A `piClient` singleton
+ * is exported for global, non-directory-scoped calls.
+ */
+
+import { runtimeFetch } from '@/lib/runtime-fetch';
+import { getRuntimeKey } from '@/lib/runtime-switch';
+import {
+  type PiError,
+  type PiProviderListResponse,
+  type PiProviderLoginInput,
+  type PiProviderLogoutInput,
+  type PiProviderSetModelsInput,
+  type PiProviderStatusResponse,
+  type PiResourceListResponse,
+  type PiRuntimeHealth,
+  type PiSessionCreateInput,
+  type PiSessionDetailResponse,
+  type PiSessionListResponse,
+  type PiSessionTreeResponse,
+  type PiAttachmentCreateInput,
+  type PiAttachmentCreateResponse,
+  type PiPromptInput,
+  type PiPromptResult,
+  type PiSetModelInput,
+  type PiSetThinkingInput,
+  type PiCompactInput,
+  type PiForkInput,
+  type PiCloneInput,
+  type PiRenameInput,
+  type PiDeleteInput,
+  type PiArchiveInput,
+  type PiAbortInput,
+} from './protocol';
+import type {
+  PiAttachment,
+  PiModelRef,
+  PiSessionId,
+  PiThinkingLevel,
+} from './types';
+import { fetchPiRuntimeHealth } from './transport';
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+
+interface JsonRequestInit<TBody> {
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  body?: TBody;
+  query?: Record<string, string | number | boolean>;
+  signal?: AbortSignal;
+  runtimeKey?: string;
+}
+
+const jsonRequest = async <TBody, TResponse>(
+  path: string,
+  init: JsonRequestInit<TBody>,
+): Promise<TResponse> => {
+  const requestRuntimeKey = init.runtimeKey;
+  if (requestRuntimeKey && requestRuntimeKey !== getRuntimeKey()) {
+    throw new PiRequestError('DAEMON_UNAVAILABLE', 'Runtime changed during request');
+  }
+  const query = init.query
+    ? `?${new URLSearchParams(
+        Object.entries(init.query).map(([key, value]) => [key, String(value)]),
+      ).toString()}`
+    : '';
+  const headers: Record<string, string> = { Accept: 'application/json' };
+  if (init.body !== undefined) headers['Content-Type'] = 'application/json';
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), DEFAULT_REQUEST_TIMEOUT_MS);
+  const externalSignal = init.signal;
+  if (externalSignal) {
+    if (externalSignal.aborted) controller.abort();
+    else externalSignal.addEventListener('abort', () => controller.abort(), { once: true });
+  }
+  try {
+    const response = await runtimeFetch(path + query, {
+      method: init.method,
+      headers,
+      body: init.body === undefined ? undefined : JSON.stringify(init.body),
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      const errorBody = (await response.json().catch(() => null)) as { error?: PiError } | null;
+      const error: PiError = errorBody?.error ?? { code: 'DAEMON_REQUEST_FAILED' };
+      throw new PiRequestError(error.code, error.message, response.status);
+    }
+    if (response.status === 204) {
+      if (requestRuntimeKey && requestRuntimeKey !== getRuntimeKey()) {
+        throw new PiRequestError('DAEMON_UNAVAILABLE', 'Runtime changed during request');
+      }
+      return undefined as TResponse;
+    }
+    const result = (await response.json()) as TResponse;
+    if (requestRuntimeKey && requestRuntimeKey !== getRuntimeKey()) {
+      throw new PiRequestError('DAEMON_UNAVAILABLE', 'Runtime changed during request');
+    }
+    return result;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+};
+
+export class PiRequestError extends Error {
+  readonly code: string;
+  readonly status?: number;
+  constructor(code: string, message?: string, status?: number) {
+    super(message ?? `Pi request failed: ${code}`);
+    this.name = 'PiRequestError';
+    this.code = code;
+    if (status !== undefined) this.status = status;
+  }
+}
+
+/** Per-call directory scope. */
+export interface PiClientScope {
+  /** Canonical directory the session belongs to. */
+  directory?: string;
+  /** Runtime key captured at call time so a runtime switch can reject stale work. */
+  runtimeKey?: string;
+}
+
+const assertRuntimeUnchanged = (scope?: PiClientScope): void => {
+  if (!scope?.runtimeKey) return;
+  if (scope.runtimeKey !== getRuntimeKey()) {
+    throw new PiRequestError('DAEMON_UNAVAILABLE', 'Runtime changed during request');
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Service class
+// ---------------------------------------------------------------------------
+
+export class PiService {
+  private currentDirectory: string | undefined;
+
+  /** Set the directory context for non-scoped calls. */
+  setDirectory(directory: string | undefined): void {
+    this.currentDirectory = directory;
+  }
+
+  getDirectory(): string | undefined {
+    return this.currentDirectory;
+  }
+
+  /** Runtime health — ready vs unavailable, never a synthetic idle state. */
+  async health(scope?: PiClientScope): Promise<PiRuntimeHealth> {
+    assertRuntimeUnchanged(scope);
+    const health = await fetchPiRuntimeHealth(undefined, scope?.runtimeKey);
+    if (health.state === 'ready') {
+      return {
+        protocolVersion: health.protocolVersion,
+        state: 'ready',
+        capabilities: health.capabilities,
+      };
+    }
+    return {
+      protocolVersion: health.protocolVersion,
+      state: 'unavailable',
+      capabilities: health.capabilities,
+      ...(health.error ? { error: health.error as PiError } : {}),
+    };
+  }
+
+  // ----- Sessions ---------------------------------------------------------
+
+  async listSessions(scope?: PiClientScope): Promise<PiSessionListResponse> {
+    assertRuntimeUnchanged(scope);
+    const directory = scope?.directory ?? this.currentDirectory;
+    return jsonRequest<undefined, PiSessionListResponse>('/api/pi/sessions', {
+      method: 'GET',
+      ...(directory ? { query: { directory } } : {}),
+      ...(scope?.runtimeKey ? { runtimeKey: scope.runtimeKey } : {}),
+    });
+  }
+
+  async createSession(input: PiSessionCreateInput, scope?: PiClientScope): Promise<PiSessionDetailResponse> {
+    assertRuntimeUnchanged(scope);
+    return jsonRequest<PiSessionCreateInput, PiSessionDetailResponse>('/api/pi/sessions', {
+      method: 'POST',
+      body: input,
+      ...(scope?.runtimeKey ? { runtimeKey: scope.runtimeKey } : {}),
+    });
+  }
+
+  async getSession(sessionId: PiSessionId, scope?: PiClientScope): Promise<PiSessionDetailResponse> {
+    assertRuntimeUnchanged(scope);
+    const directory = scope?.directory ?? this.currentDirectory;
+    return jsonRequest<undefined, PiSessionDetailResponse>(
+      `/api/pi/sessions/${encodeURIComponent(sessionId)}`,
+      {
+        method: 'GET',
+        ...(directory ? { query: { directory } } : {}),
+        ...(scope?.runtimeKey ? { runtimeKey: scope.runtimeKey } : {}),
+      },
+    );
+  }
+
+  async renameSession(input: PiRenameInput, scope?: PiClientScope): Promise<void> {
+    assertRuntimeUnchanged(scope);
+    await jsonRequest<{ title: string; sessionId: PiSessionId }, undefined>(
+      `/api/pi/sessions/${encodeURIComponent(input.sessionId)}`,
+      {
+        method: 'PATCH',
+        body: { sessionId: input.sessionId, title: input.title },
+        ...(scope?.runtimeKey ? { runtimeKey: scope.runtimeKey } : {}),
+      },
+    );
+  }
+
+  async deleteSession(input: PiDeleteInput, scope?: PiClientScope): Promise<boolean> {
+    assertRuntimeUnchanged(scope);
+    try {
+      await jsonRequest<undefined, undefined>(
+        `/api/pi/sessions/${encodeURIComponent(input.sessionId)}`,
+        { method: 'DELETE', ...(scope?.runtimeKey ? { runtimeKey: scope.runtimeKey } : {}) },
+      );
+      return true;
+    } catch (error) {
+      if (error instanceof PiRequestError && error.status === 404) {
+        // Already deleted is success.
+        return true;
+      }
+      throw error;
+    }
+  }
+
+  async archiveSession(input: PiArchiveInput, scope?: PiClientScope): Promise<void> {
+    assertRuntimeUnchanged(scope);
+    await jsonRequest<{ sessionId: PiSessionId; archived: boolean }, undefined>(
+      `/api/pi/sessions/${encodeURIComponent(input.sessionId)}/archive`,
+      {
+        method: 'POST',
+        body: { sessionId: input.sessionId, archived: input.archived },
+        ...(scope?.runtimeKey ? { runtimeKey: scope.runtimeKey } : {}),
+      },
+    );
+  }
+
+  async getSessionTree(sessionId: PiSessionId, scope?: PiClientScope): Promise<PiSessionTreeResponse> {
+    assertRuntimeUnchanged(scope);
+    return jsonRequest<undefined, PiSessionTreeResponse>(
+      `/api/pi/sessions/${encodeURIComponent(sessionId)}/tree`,
+      { method: 'GET', ...(scope?.runtimeKey ? { runtimeKey: scope.runtimeKey } : {}) },
+    );
+  }
+
+  async navigateSession(
+    sessionId: PiSessionId,
+    messageId: string,
+    scope?: PiClientScope,
+  ): Promise<PiSessionDetailResponse> {
+    assertRuntimeUnchanged(scope);
+    return jsonRequest<{ messageId: string }, PiSessionDetailResponse>(
+      `/api/pi/sessions/${encodeURIComponent(sessionId)}/navigate`,
+      { method: 'POST', body: { messageId }, ...(scope?.runtimeKey ? { runtimeKey: scope.runtimeKey } : {}) },
+    );
+  }
+
+  async forkSession(input: PiForkInput, scope?: PiClientScope): Promise<PiSessionDetailResponse> {
+    assertRuntimeUnchanged(scope);
+    // The daemon protocol nests the message id under the request; we keep
+    // the wire body aligned with the daemon IPC.
+    return jsonRequest<{ sessionId: PiSessionId; messageId?: string }, PiSessionDetailResponse>(
+      `/api/pi/sessions/${encodeURIComponent(input.sessionId)}/fork`,
+      {
+        method: 'POST',
+        body: {
+          sessionId: input.sessionId,
+          ...(input.messageId ? { messageId: input.messageId } : {}),
+        },
+        ...(scope?.runtimeKey ? { runtimeKey: scope.runtimeKey } : {}),
+      },
+    );
+  }
+
+  async cloneSession(input: PiCloneInput, scope?: PiClientScope): Promise<PiSessionDetailResponse> {
+    assertRuntimeUnchanged(scope);
+    return jsonRequest<PiCloneInput, PiSessionDetailResponse>(
+      `/api/pi/sessions/${encodeURIComponent(input.sessionId)}/clone`,
+      { method: 'POST', body: input, ...(scope?.runtimeKey ? { runtimeKey: scope.runtimeKey } : {}) },
+    );
+  }
+
+  // ----- Session operations ----------------------------------------------
+
+  async sendPrompt(input: PiPromptInput, scope?: PiClientScope): Promise<PiPromptResult> {
+    assertRuntimeUnchanged(scope);
+    return jsonRequest<PiPromptInput, PiPromptResult>(
+      `/api/pi/sessions/${encodeURIComponent(input.sessionId)}/prompt`,
+      { method: 'POST', body: input, ...(scope?.runtimeKey ? { runtimeKey: scope.runtimeKey } : {}) },
+    );
+  }
+
+  async sendSteer(input: PiPromptInput, scope?: PiClientScope): Promise<PiPromptResult> {
+    assertRuntimeUnchanged(scope);
+    return jsonRequest<PiPromptInput, PiPromptResult>(
+      `/api/pi/sessions/${encodeURIComponent(input.sessionId)}/steer`,
+      { method: 'POST', body: input, ...(scope?.runtimeKey ? { runtimeKey: scope.runtimeKey } : {}) },
+    );
+  }
+
+  async sendFollowUp(input: PiPromptInput, scope?: PiClientScope): Promise<PiPromptResult> {
+    assertRuntimeUnchanged(scope);
+    return jsonRequest<PiPromptInput, PiPromptResult>(
+      `/api/pi/sessions/${encodeURIComponent(input.sessionId)}/follow-up`,
+      { method: 'POST', body: input, ...(scope?.runtimeKey ? { runtimeKey: scope.runtimeKey } : {}) },
+    );
+  }
+
+  async abortSession(input: PiAbortInput, scope?: PiClientScope): Promise<void> {
+    assertRuntimeUnchanged(scope);
+    await jsonRequest<undefined, undefined>(
+      `/api/pi/sessions/${encodeURIComponent(input.sessionId)}/abort`,
+      { method: 'POST', ...(scope?.runtimeKey ? { runtimeKey: scope.runtimeKey } : {}) },
+    );
+  }
+
+  async setSessionModel(input: PiSetModelInput, scope?: PiClientScope): Promise<void> {
+    assertRuntimeUnchanged(scope);
+    await jsonRequest<{ sessionId: PiSessionId; model: PiModelRef }, undefined>(
+      `/api/pi/sessions/${encodeURIComponent(input.sessionId)}/model`,
+      { method: 'POST', body: { sessionId: input.sessionId, model: input.model }, ...(scope?.runtimeKey ? { runtimeKey: scope.runtimeKey } : {}) },
+    );
+  }
+
+  async setSessionThinking(input: PiSetThinkingInput, scope?: PiClientScope): Promise<void> {
+    assertRuntimeUnchanged(scope);
+    await jsonRequest<{ sessionId: PiSessionId; thinking: PiThinkingLevel }, undefined>(
+      `/api/pi/sessions/${encodeURIComponent(input.sessionId)}/thinking`,
+      { method: 'POST', body: { sessionId: input.sessionId, thinking: input.thinking }, ...(scope?.runtimeKey ? { runtimeKey: scope.runtimeKey } : {}) },
+    );
+  }
+
+  async compactSession(input: PiCompactInput, scope?: PiClientScope): Promise<void> {
+    assertRuntimeUnchanged(scope);
+    await jsonRequest<PiCompactInput, undefined>(
+      `/api/pi/sessions/${encodeURIComponent(input.sessionId)}/compact`,
+      { method: 'POST', body: input, ...(scope?.runtimeKey ? { runtimeKey: scope.runtimeKey } : {}) },
+    );
+  }
+
+  // ----- Providers --------------------------------------------------------
+
+  async listProviders(scope?: PiClientScope): Promise<PiProviderListResponse> {
+    assertRuntimeUnchanged(scope);
+    return jsonRequest<undefined, PiProviderListResponse>('/api/pi/providers', { method: 'GET', ...(scope?.runtimeKey ? { runtimeKey: scope.runtimeKey } : {}) });
+  }
+
+  async getProviderStatus(providerId: string, scope?: PiClientScope): Promise<PiProviderStatusResponse> {
+    assertRuntimeUnchanged(scope);
+    return jsonRequest<undefined, PiProviderStatusResponse>(
+      `/api/pi/providers/${encodeURIComponent(providerId)}/status`,
+      { method: 'GET', ...(scope?.runtimeKey ? { runtimeKey: scope.runtimeKey } : {}) },
+    );
+  }
+
+  async loginProvider(input: PiProviderLoginInput, scope?: PiClientScope): Promise<void> {
+    assertRuntimeUnchanged(scope);
+    await jsonRequest<PiProviderLoginInput, undefined>(
+      `/api/pi/providers/${encodeURIComponent(input.providerId)}/login`,
+      { method: 'POST', body: input, ...(scope?.runtimeKey ? { runtimeKey: scope.runtimeKey } : {}) },
+    );
+  }
+
+  async logoutProvider(input: PiProviderLogoutInput, scope?: PiClientScope): Promise<void> {
+    assertRuntimeUnchanged(scope);
+    await jsonRequest<PiProviderLogoutInput, undefined>(
+      `/api/pi/providers/${encodeURIComponent(input.providerId)}/logout`,
+      { method: 'POST', body: input, ...(scope?.runtimeKey ? { runtimeKey: scope.runtimeKey } : {}) },
+    );
+  }
+
+  async setProviderModels(input: PiProviderSetModelsInput, scope?: PiClientScope): Promise<void> {
+    assertRuntimeUnchanged(scope);
+    await jsonRequest<{ providerId: string; models: import('./types').PiModel[] }, undefined>(
+      `/api/pi/providers/${encodeURIComponent(input.providerId)}/models`,
+      { method: 'PUT', body: { providerId: input.providerId, models: input.models }, ...(scope?.runtimeKey ? { runtimeKey: scope.runtimeKey } : {}) },
+    );
+  }
+
+  // ----- Resources --------------------------------------------------------
+
+  async listResources(scope?: PiClientScope): Promise<PiResourceListResponse> {
+    assertRuntimeUnchanged(scope);
+    const directory = scope?.directory ?? this.currentDirectory;
+    return jsonRequest<undefined, PiResourceListResponse>('/api/pi/resources', {
+      method: 'GET',
+      ...(directory ? { query: { directory } } : {}),
+      ...(scope?.runtimeKey ? { runtimeKey: scope.runtimeKey } : {}),
+    });
+  }
+
+  // ----- Attachments ------------------------------------------------------
+
+  async createAttachment(
+    input: PiAttachmentCreateInput,
+    scope?: PiClientScope,
+  ): Promise<PiAttachment> {
+    assertRuntimeUnchanged(scope);
+    const response = await jsonRequest<PiAttachmentCreateInput, PiAttachmentCreateResponse>(
+      '/api/pi/attachments',
+      { method: 'POST', body: input, ...(scope?.runtimeKey ? { runtimeKey: scope.runtimeKey } : {}) },
+    );
+    return response.attachment;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton + scoping helpers
+// ---------------------------------------------------------------------------
+
+/** Global, non-directory-scoped service. */
+export const piClient = new PiService();
+
+/** Build a scoped service bound to a directory for direct calls. */
+export const createScopedPiClient = (directory: string): PiService => {
+  const scoped = new PiService();
+  scoped.setDirectory(directory);
+  return scoped;
+};

--- a/packages/ui/src/lib/pi/event-reducer.test.ts
+++ b/packages/ui/src/lib/pi/event-reducer.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, test } from "bun:test"
+import {
+  applyPiEvent,
+  applyPiEvents,
+  createReducerState,
+  hydrateSessionFromDetail,
+  projectSession,
+  type PiReducerSessionState,
+} from "./event-reducer"
+import type { PiSessionEvent } from "./protocol"
+
+const baseEvent = <T extends PiSessionEvent["name"]>(
+  name: T,
+  sequence: number,
+  payload: Extract<PiSessionEvent, { name: T }>["payload"],
+  sessionId = "sess-1",
+  directory = "/work",
+): Extract<PiSessionEvent, { name: T }> => ({
+  protocolVersion: 1,
+  kind: "event",
+  name,
+  sequence,
+  sessionId,
+  directory,
+  payload,
+} as Extract<PiSessionEvent, { name: T }>)
+
+const assistantStart = (sequence = 1) => baseEvent("assistant.message.start", sequence, {
+  messageId: "m1",
+  role: "assistant",
+  startedAt: 1_000,
+})
+
+describe("applyPiEvent", () => {
+  test("rejects out-of-order events without applying them", () => {
+    const state = createReducerState()
+    const applied = applyPiEvent(state, baseEvent("session.lifecycle", 1, { state: "busy" }))
+    const outOfOrder = applyPiEvent(applied.state, baseEvent("session.lifecycle", 1, { state: "idle" }))
+    expect(outOfOrder.didApply).toBe(false)
+    expect(applied.state.bySession.get("sess-1")?.lifecycle).toBe("busy")
+  })
+
+  test("assembles canonical assistant message and thinking deltas", () => {
+    let state = applyPiEvent(createReducerState(), assistantStart()).state
+    state = applyPiEvent(state, baseEvent("assistant.message.delta", 2, {
+      messageId: "m1", contentIndex: 0, delta: "Hello, ",
+    })).state
+    state = applyPiEvent(state, baseEvent("assistant.thinking.delta", 3, {
+      messageId: "m1", contentIndex: 0, delta: "thoughtful ",
+    })).state
+    state = applyPiEvent(state, baseEvent("assistant.message.delta", 4, {
+      messageId: "m1", contentIndex: 1, delta: "world!",
+    })).state
+    state = applyPiEvent(state, baseEvent("assistant.message.end", 5, {
+      messageId: "m1", text: "Hello, world!", thinking: "thoughtful ",
+    })).state
+
+    const message = state.bySession.get("sess-1")?.messages.get("m1")
+    expect(message?.text).toBe("Hello, world!")
+    expect(message?.thinking).toBe("thoughtful ")
+    expect(message?.streaming).toBe(false)
+  })
+
+  test("tracks canonical tool start, update, and end", () => {
+    let state = applyPiEvent(createReducerState(), assistantStart()).state
+    state = applyPiEvent(state, baseEvent("session.tool.start", 2, {
+      toolCallId: "t1", partId: "p-tool", messageId: "m1", name: "bash", state: "running",
+      input: { cmd: "ls" }, startedAt: 1_500,
+    })).state
+    state = applyPiEvent(state, baseEvent("session.tool.update", 3, {
+      toolCallId: "t1", partId: "p-tool", messageId: "m1", name: "bash", state: "running",
+      input: { cmd: "ls" }, startedAt: 1_500,
+    })).state
+    state = applyPiEvent(state, baseEvent("session.tool.end", 4, {
+      toolCallId: "t1", partId: "p-tool", messageId: "m1", name: "bash", state: "error",
+      isError: true, endedAt: 2_000,
+    })).state
+
+    const part = state.bySession.get("sess-1")?.parts.get("p-tool")
+    expect(part?.tool?.state).toBe("error")
+    expect(part?.tool?.isError).toBe(true)
+    expect(part?.streaming).toBe(false)
+  })
+
+  test("session.interrupted marks active assistant output as an error", () => {
+    let state = applyPiEvent(createReducerState(), assistantStart()).state
+    state = applyPiEvent(state, baseEvent("assistant.message.delta", 2, {
+      messageId: "m1", contentIndex: 0, delta: "halfway",
+    })).state
+    state = applyPiEvent(state, baseEvent("session.interrupted", 3, {
+      reason: "daemon-crash", streaming: true,
+    })).state
+    const message = state.bySession.get("sess-1")?.messages.get("m1")
+    expect(message?.streaming).toBe(false)
+    expect(message?.error?.code).toBe("SESSION_INTERRUPTED")
+    expect(state.bySession.get("sess-1")?.lifecycle).toBe("interrupted")
+  })
+
+  test("session.error marks active assistant output and lifecycle", () => {
+    let state = applyPiEvent(createReducerState(), assistantStart()).state
+    state = applyPiEvent(state, baseEvent("session.error", 2, {
+      code: "PROVIDER_AUTH_REQUIRED", message: "missing api key",
+    })).state
+    expect(state.bySession.get("sess-1")?.messages.get("m1")?.error?.code)
+      .toBe("PROVIDER_AUTH_REQUIRED")
+    expect(state.bySession.get("sess-1")?.lifecycle).toBe("error")
+  })
+
+  test("queue, model, and thinking events update session state", () => {
+    let state = createReducerState()
+    state = applyPiEvent(state, baseEvent("session.queue", 1, { steering: 2, followUp: 3 })).state
+    state = applyPiEvent(state, baseEvent("session.model", 2, {
+      model: { providerId: "p", modelId: "m" },
+    })).state
+    state = applyPiEvent(state, baseEvent("session.thinking", 3, { thinking: "high" })).state
+    const session = state.bySession.get("sess-1")
+    expect(session?.queue).toEqual({ steering: 2, followUp: 3 })
+    expect(session?.model).toEqual({ providerId: "p", modelId: "m" })
+    expect(session?.thinking).toBe("high")
+  })
+})
+
+describe("applyPiEvents", () => {
+  test("counts applied and skipped events separately", () => {
+    const result = applyPiEvents(createReducerState(), [
+      baseEvent("session.lifecycle", 1, { state: "busy" }),
+      baseEvent("session.lifecycle", 1, { state: "idle" }),
+      baseEvent("session.lifecycle", 2, { state: "idle" }),
+    ])
+    expect(result.applied).toBe(2)
+    expect(result.skipped).toBe(1)
+    expect(result.state.bySession.get("sess-1")?.lifecycle).toBe("idle")
+  })
+})
+
+describe("hydrateSessionFromDetail", () => {
+  test("seeds persisted messages and rejects covered sequences", () => {
+    const { state } = hydrateSessionFromDetail({
+      session: { id: "sess-1", directory: "/work" },
+      lastSequence: 5,
+      messages: [{
+        message: {
+          id: "m1", sessionId: "sess-1", directory: "/work", role: "assistant",
+          text: "Hi", thinking: "", createdAt: 1_000,
+        },
+        parts: [{ id: "p1", index: 0, type: "text", text: "Hi" }],
+      }],
+    })
+    expect(state.bySession.get("sess-1")?.messages.size).toBe(1)
+    expect(applyPiEvent(state, baseEvent("session.lifecycle", 5, { state: "busy" })).didApply).toBe(false)
+    expect(applyPiEvent(state, baseEvent("session.lifecycle", 6, { state: "busy" })).didApply).toBe(true)
+  })
+
+  test("preserves hydrated tool state", () => {
+    const { state } = hydrateSessionFromDetail({
+      session: { id: "sess-1", directory: "/work" },
+      lastSequence: 0,
+      messages: [{
+        message: {
+          id: "m1", sessionId: "sess-1", directory: "/work", role: "assistant",
+          text: "done", thinking: "", createdAt: 1_000,
+        },
+        parts: [{
+          id: "p1", index: 0, type: "tool", toolCallId: "tc-1", name: "bash",
+          state: "completed", output: { result: "ok" }, endedAt: 1_500,
+        }],
+      }],
+    })
+    const session = state.bySession.get("sess-1") as PiReducerSessionState
+    expect(session.parts.get("p1")?.tool?.state).toBe("completed")
+  })
+})
+
+describe("projectSession", () => {
+  test("returns a UI projection without sequencing internals", () => {
+    let state = applyPiEvent(createReducerState(), assistantStart()).state
+    state = applyPiEvent(state, baseEvent("assistant.message.delta", 2, {
+      messageId: "m1", contentIndex: 0, delta: "Hi",
+    })).state
+    const session = state.bySession.get("sess-1") as PiReducerSessionState
+    const projected = projectSession(session)
+    expect(projected.messages[0]?.parts[0]?.text).toBe("Hi")
+    expect(projected.messages[0]?.parts[0]?.streaming).toBe(true)
+    expect((projected as unknown as { lastSequence?: number }).lastSequence).toBe(undefined)
+  })
+})

--- a/packages/ui/src/lib/pi/event-reducer.ts
+++ b/packages/ui/src/lib/pi/event-reducer.ts
@@ -1,0 +1,717 @@
+/**
+ * Pi event reducer helpers — apply sequenced events from the public stream
+ * to running per-session state.
+ *
+ * The reducer is the small, pure function at the center of the PiChamber UI
+ * migration. It is responsible for:
+ *
+ * - Sequencing: events with a `sequence` <= the last accepted sequence are
+ *   ignored. This is what makes reconnect safe: a client can resume from
+ *   `snapshot.lastSequence` and the reducer will discard anything it has
+ *   already applied.
+ * - Stream assembly: text and thinking deltas are accumulated per part
+ *   until the daemon publishes `part.end` with the final content. The
+ *   reducer produces finalized text/thinking the moment the daemon says
+ *   the message is done.
+ * - Lifecycle: the `session.lifecycle` event flips the running state.
+ *   `session.interrupted` flips the streaming flag back off without
+ *   marking the message completed; that is the visible "interrupted" UI
+ *   state the plan requires.
+ *
+ * The reducer is intentionally a plain function so it can be reused by
+ * bootstrap, reconnect, and live-stream code paths without coupling to any
+ * store implementation. The store wrapper lives in `packages/ui/src/sync/`.
+ */
+
+import type {
+  PiAssistantMessageDeltaPayload,
+  PiAssistantThinkingDeltaPayload,
+  PiMessageStartPayload,
+  PiMessageEndPayload,
+  PiSessionEvent,
+  PiToolUpdatePayload,
+} from './protocol';
+import type {
+  PiAssistantMessage,
+  PiAttachment,
+  PiModelRef,
+  PiSessionLifecycleState,
+  PiSessionId,
+  PiThinkingLevel,
+  PiUserMessage,
+} from './types';
+
+// ---------------------------------------------------------------------------
+// State shape
+// ---------------------------------------------------------------------------
+
+export interface PiReducerMessagePart {
+  id: string;
+  index: number;
+  type: 'text' | 'thinking' | 'tool' | 'attachment';
+  /** Text content for text/thinking parts (assembled from deltas). */
+  text: string;
+  /** Set while the part is still accepting deltas. */
+  streaming: boolean;
+  /** Last accepted canonical content index for streamed text/thinking. */
+  lastContentIndex?: number;
+  /** For tool parts. */
+  tool?: {
+    toolCallId: string;
+    name: string;
+    input?: unknown;
+    output?: unknown;
+    isError?: boolean;
+    state: 'pending' | 'running' | 'completed' | 'error' | 'cancelled';
+    startedAt?: number;
+    endedAt?: number;
+  };
+  /** For attachment parts. */
+  attachment?: PiAttachment;
+}
+
+export interface PiReducerMessage {
+  id: string;
+  sessionId: PiSessionId;
+  directory: string;
+  role: 'user' | 'assistant';
+  /** Created-at (ms epoch) the reducer keeps for ordering. */
+  createdAt: number;
+  /** Assistant-only: model & thinking captured at creation time. */
+  model?: PiModelRef;
+  thinkingLevel?: PiThinkingLevel;
+  /** Final assembled text/thinking for assistant messages. */
+  text: string;
+  thinking: string;
+  durationMs?: number;
+  /** True while the assistant message is still streaming. */
+  streaming: boolean;
+  /** Set when the assistant message ended in an interrupted/error state. */
+  error?: { code: string; message?: string };
+}
+
+export interface PiReducerSessionState {
+  sessionId: PiSessionId;
+  directory: string;
+  /** Last sequence the reducer has accepted for this session. */
+  lastSequence: number;
+  /** Authoritative lifecycle phase. */
+  lifecycle: PiSessionLifecycleState;
+  /** Active model/thinking the session is using. */
+  model?: PiModelRef;
+  thinking?: PiThinkingLevel;
+  /** Messages keyed by message id, ordered by `createdAt`. */
+  messages: Map<string, PiReducerMessage>;
+  /** Part order per message id. */
+  partOrder: Map<string, string[]>;
+  parts: Map<string, PiReducerMessagePart>;
+  /** Pending tool calls (toolCallId → messageId) so an end event can find its parent. */
+  toolsByCallId: Map<string, string>;
+  /** Assistant messages whose `streaming` flag is still true. */
+  streamingMessages: Set<string>;
+  /** Queue depths at the time of the last `session.queue` event. */
+  queue: { steering: number; followUp: number };
+}
+
+export interface PiReducerState {
+  bySession: Map<PiSessionId, PiReducerSessionState>;
+  /** Last sequence per session id; `-1` means "no events yet". */
+  lastSequence: Map<PiSessionId, number>;
+}
+
+export const createReducerState = (): PiReducerState => ({
+  bySession: new Map(),
+  lastSequence: new Map(),
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const getOrCreateSession = (
+  state: PiReducerState,
+  sessionId: PiSessionId,
+  directory: string,
+): PiReducerSessionState => {
+  const existing = state.bySession.get(sessionId);
+  if (existing) return existing;
+  const fresh: PiReducerSessionState = {
+    sessionId,
+    directory,
+    lastSequence: -1,
+    lifecycle: 'idle',
+    messages: new Map(),
+    partOrder: new Map(),
+    parts: new Map(),
+    toolsByCallId: new Map(),
+    streamingMessages: new Set(),
+    queue: { steering: 0, followUp: 0 },
+  };
+  state.bySession.set(sessionId, fresh);
+  return fresh;
+};
+
+const ensureMessage = (
+  session: PiReducerSessionState,
+  payload: PiMessageStartPayload,
+  directory: string,
+): PiReducerMessage => {
+  const existing = session.messages.get(payload.messageId);
+  if (existing) return existing;
+  const message: PiReducerMessage = {
+    id: payload.messageId,
+    sessionId: session.sessionId,
+    directory,
+    role: payload.role,
+    createdAt: payload.startedAt,
+    text: '',
+    thinking: '',
+    streaming: payload.role === 'assistant',
+    ...(payload.model ? { model: payload.model } : {}),
+    ...(payload.thinkingLevel ? { thinkingLevel: payload.thinkingLevel } : {}),
+  };
+  session.messages.set(payload.messageId, message);
+  return message;
+};
+
+const ensureTextPart = (
+  session: PiReducerSessionState,
+  message: PiReducerMessage,
+  type: 'text' | 'thinking',
+  partId?: string,
+): PiReducerMessagePart => {
+  const id = partId ?? `${message.id}:${type}`;
+  const existing = session.parts.get(id);
+  if (existing) return existing;
+  const part: PiReducerMessagePart = {
+    id,
+    index: (session.partOrder.get(message.id) ?? []).length,
+    type,
+    text: '',
+    streaming: true,
+    lastContentIndex: -1,
+  };
+  session.parts.set(id, part);
+  const order = [...(session.partOrder.get(message.id) ?? [])];
+  if (!order.includes(part.id)) order.push(part.id);
+  session.partOrder.set(message.id, order);
+  return part;
+};
+
+const assembleMessageText = (session: PiReducerSessionState, messageId: string): {
+  text: string;
+  thinking: string;
+} => {
+  const message = session.messages.get(messageId);
+  if (!message) return { text: '', thinking: '' };
+  const order = session.partOrder.get(messageId) ?? [];
+  let text = '';
+  let thinking = '';
+  for (const partId of order) {
+    const part = session.parts.get(partId);
+    if (!part) continue;
+    if (part.type === 'text') text += part.text;
+    else if (part.type === 'thinking') thinking += part.text;
+  }
+  return { text, thinking };
+};
+
+// ---------------------------------------------------------------------------
+// Event reducers
+// ---------------------------------------------------------------------------
+
+const reduceLifecycle = (
+  session: PiReducerSessionState,
+  state: PiSessionLifecycleState,
+  attempt?: number,
+): void => {
+  session.lifecycle = state;
+  if (attempt !== undefined) {
+    // Retry metadata is surfaced to consumers through `lifecycle: 'retry'`.
+  }
+};
+
+const reduceMessageStart = (
+  session: PiReducerSessionState,
+  directory: string,
+  payload: PiMessageStartPayload,
+): void => {
+  ensureMessage(session, payload, directory);
+};
+
+const reduceAssistantDelta = (
+  session: PiReducerSessionState,
+  payload: PiAssistantMessageDeltaPayload | PiAssistantThinkingDeltaPayload,
+  type: 'text' | 'thinking',
+): void => {
+  const message = session.messages.get(payload.messageId);
+  if (!message || message.role !== 'assistant') return;
+  const partId = payload.partId ?? `${message.id}:${type}`;
+  const existing = session.parts.get(partId);
+  if (existing) {
+    if (existing.type !== type || (existing.lastContentIndex ?? -1) >= payload.contentIndex) return;
+    session.parts.set(partId, {
+      ...existing,
+      text: existing.text + payload.delta,
+      lastContentIndex: payload.contentIndex,
+    });
+    return;
+  }
+  const part = ensureTextPart(session, message, type, partId);
+  session.parts.set(part.id, { ...part, text: payload.delta, lastContentIndex: payload.contentIndex });
+};
+
+const reduceMessageEnd = (
+  session: PiReducerSessionState,
+  payload: PiMessageEndPayload,
+): void => {
+  const current = session.messages.get(payload.messageId);
+  if (!current) return;
+  const message = { ...current };
+  session.messages.set(payload.messageId, message);
+  const { text, thinking } = assembleMessageText(session, payload.messageId);
+  message.text = typeof payload.text === 'string' ? payload.text : text;
+  message.thinking = typeof payload.thinking === 'string' ? payload.thinking : thinking;
+  message.streaming = false;
+  if (typeof payload.durationMs === 'number') {
+    message.durationMs = payload.durationMs;
+  }
+  if (payload.thinkingLevel) message.thinkingLevel = payload.thinkingLevel;
+  session.streamingMessages.delete(payload.messageId);
+};
+
+const reduceTool = (
+  session: PiReducerSessionState,
+  phase: 'start' | 'update' | 'end',
+  payload: PiToolUpdatePayload,
+): void => {
+  // Look up the existing part by toolCallId when the start event already
+  // produced it.
+  const messageId = session.toolsByCallId.get(payload.toolCallId) ?? payload.messageId;
+  const message = session.messages.get(messageId);
+  if (!message) return;
+  const part =
+    session.parts.get(payload.partId) ??
+    Array.from(session.parts.values()).find(
+      (candidate) => candidate.type === 'tool' && candidate.tool?.toolCallId === payload.toolCallId,
+    );
+
+  if (phase === 'start' && !part) {
+    // Direct tool start without a preceding part.start event.
+    const synthetic = {
+      id: payload.partId,
+      index: (session.partOrder.get(message.id) ?? []).length,
+      type: 'tool' as const,
+        text: '',
+        streaming: false,
+      tool: {
+        toolCallId: payload.toolCallId,
+        name: payload.name,
+        ...(payload.input !== undefined ? { input: payload.input } : {}),
+        state: payload.state,
+        ...(payload.startedAt !== undefined ? { startedAt: payload.startedAt } : {}),
+      },
+    };
+    session.parts.set(synthetic.id, synthetic);
+    const order = [...(session.partOrder.get(message.id) ?? [])];
+    order.push(synthetic.id);
+    session.partOrder.set(message.id, order);
+    session.toolsByCallId.set(payload.toolCallId, message.id);
+    return;
+  }
+  if (!part || part.type !== 'tool') return;
+  const nextPart = { ...part };
+  nextPart.tool = {
+    toolCallId: payload.toolCallId,
+    name: payload.name,
+    ...(payload.input !== undefined
+      ? { input: payload.input }
+      : part.tool?.input !== undefined
+        ? { input: part.tool.input }
+        : {}),
+    ...(payload.output !== undefined ? { output: payload.output } : {}),
+    ...(payload.isError !== undefined ? { isError: payload.isError } : {}),
+    state: payload.state,
+    ...(payload.startedAt !== undefined ? { startedAt: payload.startedAt } : {}),
+    ...(payload.endedAt !== undefined ? { endedAt: payload.endedAt } : {}),
+  };
+  if (phase === 'end') nextPart.streaming = false;
+  session.parts.set(nextPart.id, nextPart);
+};
+
+const reduceInterrupted = (session: PiReducerSessionState, streaming: boolean): void => {
+  session.lifecycle = 'interrupted';
+  if (!streaming) return;
+  for (const messageId of session.streamingMessages) {
+    const message = session.messages.get(messageId);
+    if (!message) continue;
+    message.streaming = false;
+    message.error = { code: 'SESSION_INTERRUPTED' };
+  }
+  session.streamingMessages.clear();
+};
+
+const reduceError = (session: PiReducerSessionState, code: string, message?: string): void => {
+  session.lifecycle = 'error';
+  for (const messageId of session.streamingMessages) {
+    const entry = session.messages.get(messageId);
+    if (!entry) continue;
+    entry.streaming = false;
+    entry.error = { code, ...(message ? { message } : {}) };
+  }
+  session.streamingMessages.clear();
+};
+
+// ---------------------------------------------------------------------------
+// Public reducer
+// ---------------------------------------------------------------------------
+
+export interface ApplyEventResult {
+  state: PiReducerState;
+  /** True when the event was accepted (sequence advanced). */
+  didApply: boolean;
+  /** The session id the event applied to, when it applied. */
+  sessionId?: PiSessionId;
+}
+
+/**
+ * Apply a single event. Returns a new state plus a `didApply` flag.
+ * `didApply` is `false` when the event was rejected for sequencing, so
+ * callers must not mutate downstream views in that case.
+ */
+export const applyPiEvent = (
+  state: PiReducerState,
+  event: PiSessionEvent,
+): ApplyEventResult => {
+  const last = state.lastSequence.get(event.sessionId) ?? -1;
+  if (event.sequence <= last) {
+    return { state, didApply: false };
+  }
+
+  const current = state.bySession.get(event.sessionId);
+  const session: PiReducerSessionState = current
+    ? {
+        ...current,
+        lastSequence: event.sequence,
+        ...(event.name === 'session.lifecycle' ? { lifecycle: event.payload.state } : {}),
+        ...(event.name === 'session.queue' ? { queue: { ...event.payload } } : {}),
+        ...(event.name === 'session.model' ? { model: event.payload.model } : {}),
+        ...(event.name === 'session.thinking' ? { thinking: event.payload.thinking } : {}),
+      }
+    : {
+        sessionId: event.sessionId,
+        directory: event.directory,
+        lastSequence: event.sequence,
+        lifecycle: 'idle',
+        messages: new Map(),
+        partOrder: new Map(),
+        parts: new Map(),
+        toolsByCallId: new Map(),
+        streamingMessages: new Set(),
+        queue: { steering: 0, followUp: 0 },
+      };
+
+  switch (event.name) {
+    case 'session.snapshot':
+      // Snapshots are handled by the snapshot reducer; we only track the
+      // sequence so the next deltas reject anything the snapshot covered.
+      break;
+    case 'session.lifecycle':
+      reduceLifecycle(session, event.payload.state, event.payload.attempt);
+      break;
+    case 'assistant.message.start':
+      session.messages = new Map(session.messages);
+      session.streamingMessages = new Set(session.streamingMessages);
+      reduceMessageStart(session, event.directory, event.payload);
+      if (event.payload.role === 'assistant') session.streamingMessages.add(event.payload.messageId);
+      break;
+    case 'assistant.message.delta':
+      session.parts = new Map(session.parts);
+      if (event.payload.partId) {
+        const part = session.parts.get(event.payload.partId);
+        if (part) session.parts.set(event.payload.partId, { ...part });
+      }
+      reduceAssistantDelta(session, event.payload, 'text');
+      break;
+    case 'assistant.message.end':
+      session.messages = new Map(session.messages);
+      session.streamingMessages = new Set(session.streamingMessages);
+      reduceMessageEnd(session, event.payload);
+      break;
+    case 'assistant.thinking.delta':
+      session.parts = new Map(session.parts);
+      if (event.payload.partId) {
+        const part = session.parts.get(event.payload.partId);
+        if (part) session.parts.set(event.payload.partId, { ...part });
+      }
+      reduceAssistantDelta(session, event.payload, 'thinking');
+      break;
+    case 'session.tool.start':
+      session.parts = new Map(session.parts);
+      session.partOrder = new Map(session.partOrder);
+      session.toolsByCallId = new Map(session.toolsByCallId);
+      reduceTool(session, 'start', event.payload);
+      break;
+    case 'session.tool.update':
+      session.parts = new Map(session.parts);
+      if (session.parts.has(event.payload.partId)) {
+        const part = session.parts.get(event.payload.partId);
+        if (part) session.parts.set(event.payload.partId, { ...part });
+      }
+      reduceTool(session, 'update', event.payload);
+      break;
+    case 'session.tool.end':
+      session.parts = new Map(session.parts);
+      if (session.parts.has(event.payload.partId)) {
+        const part = session.parts.get(event.payload.partId);
+        if (part) session.parts.set(event.payload.partId, { ...part });
+      }
+      reduceTool(session, 'end', event.payload);
+      break;
+    case 'session.queue':
+      session.queue = {
+        steering: event.payload.steering,
+        followUp: event.payload.followUp,
+      };
+      break;
+    case 'session.model':
+      session.model = event.payload.model;
+      break;
+    case 'session.thinking':
+      session.thinking = event.payload.thinking;
+      break;
+    case 'session.compaction':
+      // Compaction does not change the reducer state directly; consumers
+      // observe the event name through their own subscription.
+      break;
+    case 'session.error':
+      session.messages = new Map(session.messages);
+      session.streamingMessages = new Set(session.streamingMessages);
+      for (const messageId of session.streamingMessages) {
+        const message = session.messages.get(messageId);
+        if (message) session.messages.set(messageId, { ...message });
+      }
+      reduceError(session, event.payload.code, event.payload.message);
+      break;
+    case 'session.interrupted':
+      session.messages = new Map(session.messages);
+      session.streamingMessages = new Set(session.streamingMessages);
+      for (const messageId of session.streamingMessages) {
+        const message = session.messages.get(messageId);
+        if (message) session.messages.set(messageId, { ...message });
+      }
+      reduceInterrupted(session, event.payload.streaming);
+      break;
+    default: {
+      // Exhaustiveness check: unknown event names are silently ignored
+      // (they would have failed `isPiEvent` upstream anyway).
+      const exhaustive: never = event;
+      void exhaustive;
+    }
+  }
+
+  const next: PiReducerState = {
+    bySession: new Map(state.bySession),
+    lastSequence: new Map(state.lastSequence),
+  };
+  next.bySession.set(event.sessionId, session);
+  next.lastSequence.set(event.sessionId, event.sequence);
+  return { state: next, didApply: true, sessionId: event.sessionId };
+};
+
+/**
+ * Apply a list of events in order. Returns the final state, the total
+ * number of applied events, and the number of skipped (out-of-order)
+ * events.
+ */
+export const applyPiEvents = (
+  state: PiReducerState,
+  events: readonly PiSessionEvent[],
+): { state: PiReducerState; applied: number; skipped: number } => {
+  let applied = 0;
+  let skipped = 0;
+  let working = state;
+  for (const event of events) {
+    const result = applyPiEvent(working, event);
+    working = result.state;
+    if (result.didApply) applied += 1;
+    else skipped += 1;
+  }
+  return { state: working, applied, skipped };
+};
+
+// ---------------------------------------------------------------------------
+// Projections (read-only views for React subscribers)
+// ---------------------------------------------------------------------------
+
+export interface PiProjectedMessagePart {
+  id: string;
+  type: PiReducerMessagePart['type'];
+  text: string;
+  streaming: boolean;
+  tool?: PiReducerMessagePart['tool'];
+  attachment?: PiAttachment;
+}
+
+export interface PiProjectedMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  text: string;
+  thinking: string;
+  streaming: boolean;
+  createdAt: number;
+  durationMs?: number;
+  error?: { code: string; message?: string };
+  model?: PiModelRef;
+  thinkingLevel?: PiThinkingLevel;
+  parts: PiProjectedMessagePart[];
+}
+
+export interface PiProjectedSession {
+  sessionId: PiSessionId;
+  directory: string;
+  lifecycle: PiSessionLifecycleState;
+  model?: PiModelRef;
+  thinking?: PiThinkingLevel;
+  queue: { steering: number; followUp: number };
+  messages: PiProjectedMessage[];
+}
+
+/**
+ * Build an immutable projection of a session. The returned object is a
+ * new reference every time, so React selectors can rely on referential
+ * equality. The projection does not include sequence bookkeeping so the
+ * UI cannot accidentally leak it.
+ */
+export const projectSession = (session: PiReducerSessionState): PiProjectedSession => {
+  const messages = Array.from(session.messages.values())
+    .sort((a, b) => a.createdAt - b.createdAt)
+    .map<PiProjectedMessage>((message) => {
+      const order = session.partOrder.get(message.id) ?? [];
+      const parts: PiProjectedMessagePart[] = order
+        .map((partId) => session.parts.get(partId))
+        .filter((part): part is PiReducerMessagePart => Boolean(part))
+        .map<PiProjectedMessagePart>((part) => ({
+          id: part.id,
+          type: part.type,
+          text: part.text,
+          streaming: part.streaming,
+          ...(part.tool ? { tool: part.tool } : {}),
+          ...(part.attachment ? { attachment: part.attachment } : {}),
+        }));
+      return {
+        id: message.id,
+        role: message.role,
+        text: message.text,
+        thinking: message.thinking,
+        streaming: message.streaming,
+        createdAt: message.createdAt,
+        ...(message.durationMs !== undefined ? { durationMs: message.durationMs } : {}),
+        ...(message.error ? { error: message.error } : {}),
+        ...(message.model ? { model: message.model } : {}),
+        ...(message.thinkingLevel ? { thinkingLevel: message.thinkingLevel } : {}),
+        parts,
+      };
+    });
+
+  return {
+    sessionId: session.sessionId,
+    directory: session.directory,
+    lifecycle: session.lifecycle,
+    ...(session.model ? { model: session.model } : {}),
+    ...(session.thinking ? { thinking: session.thinking } : {}),
+    queue: { ...session.queue },
+    messages,
+  };
+};
+
+/**
+ * Hydrate a session state from a `PiSessionDetailResponse`. The result is
+ * ready to receive delta events with `fromSequence` strictly greater than
+ * the last sequence returned by the response.
+ */
+export const hydrateSessionFromDetail = (
+  detail: {
+    session: { id: string; directory: string };
+    lastSequence: number;
+    messages: Array<{
+      message: PiUserMessage | PiAssistantMessage;
+      parts: Array<{
+        id: string;
+        index: number;
+        type: 'text' | 'thinking' | 'tool' | 'attachment';
+        text?: string;
+        toolCallId?: string;
+        name?: string;
+        input?: unknown;
+        output?: unknown;
+        isError?: boolean;
+        state?: 'pending' | 'running' | 'completed' | 'error' | 'cancelled';
+        startedAt?: number;
+        endedAt?: number;
+        attachment?: PiAttachment;
+      }>;
+    }>;
+  },
+): { state: PiReducerState; session: PiReducerSessionState } => {
+  const state = createReducerState();
+  const session = getOrCreateSession(state, detail.session.id, detail.session.directory);
+  session.lastSequence = detail.lastSequence;
+
+  for (const { message, parts } of detail.messages) {
+    const reducerMessage: PiReducerMessage = {
+      id: message.id,
+      sessionId: detail.session.id,
+      directory: detail.session.directory,
+      role: message.role,
+      createdAt: message.createdAt,
+      text: message.text ?? '',
+      thinking: message.role === 'assistant' ? message.thinking ?? '' : '',
+      streaming: false,
+      ...(message.role === 'assistant' && message.durationMs !== undefined
+        ? { durationMs: message.durationMs }
+        : {}),
+      ...(message.role === 'assistant' && message.error ? { error: message.error } : {}),
+      ...(message.role === 'assistant' && message.model ? { model: message.model } : {}),
+      ...(message.role === 'assistant' && message.thinkingLevel
+        ? { thinkingLevel: message.thinkingLevel }
+        : {}),
+    };
+    session.messages.set(message.id, reducerMessage);
+    const partOrder: string[] = [];
+    for (const part of parts) {
+      const reducerPart: PiReducerMessagePart = {
+        id: part.id,
+        index: part.index,
+        type: part.type,
+        text: part.text ?? '',
+        streaming: false,
+        ...(part.type === 'text' || part.type === 'thinking' ? { lastContentIndex: Number.MAX_SAFE_INTEGER } : {}),
+        ...(part.type === 'tool'
+          ? {
+              tool: {
+                toolCallId: part.toolCallId ?? part.id,
+                name: part.name ?? 'unknown',
+                ...(part.input !== undefined ? { input: part.input } : {}),
+                ...(part.output !== undefined ? { output: part.output } : {}),
+                ...(part.isError !== undefined ? { isError: part.isError } : {}),
+                state: part.state ?? 'completed',
+                ...(part.startedAt !== undefined ? { startedAt: part.startedAt } : {}),
+                ...(part.endedAt !== undefined ? { endedAt: part.endedAt } : {}),
+              },
+            }
+          : {}),
+        ...(part.type === 'attachment' && part.attachment ? { attachment: part.attachment } : {}),
+      };
+      session.parts.set(part.id, reducerPart);
+      partOrder.push(part.id);
+      if (part.type === 'tool' && part.toolCallId) {
+        session.toolsByCallId.set(part.toolCallId, message.id);
+      }
+    }
+    session.partOrder.set(message.id, partOrder);
+  }
+
+  state.lastSequence.set(detail.session.id, detail.lastSequence);
+  return { state, session };
+};

--- a/packages/ui/src/lib/pi/index.ts
+++ b/packages/ui/src/lib/pi/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Public exports for the Pi shared UI module.
+ *
+ * Consumers should import from `@/lib/pi` (or the relative path) rather
+ * than reaching into individual files. The barrel keeps the module's
+ * surface small and stable: the workstream-9 deletion will eventually
+ * remove the OpenCode facade, but the `pi/` exports remain.
+ */
+
+export * from './types';
+export * from './protocol';
+export * from './client';
+export * from './transport';
+export * from './snapshot';
+export * from './event-reducer';
+export * from './bootstrap';
+export * from './reconnect';
+export * from './archive';
+export * from './attachments';
+export * from './model-provider';

--- a/packages/ui/src/lib/pi/model-provider.test.ts
+++ b/packages/ui/src/lib/pi/model-provider.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test } from "bun:test"
+import {
+  compareModelRefs,
+  findModel,
+  findProvider,
+  flattenProviderModels,
+  isThinkingAllowed,
+  listProviderModels,
+  modelRefKey,
+  pickFallbackThinking,
+  resolveNewSessionModel,
+  resolveNewSessionThinking,
+} from "./model-provider"
+import type { PiModel, PiProvider } from "./types"
+
+const provider = (id: string, models: PiModel[]): PiProvider => ({
+  id,
+  label: id.toUpperCase(),
+  authenticated: true,
+  models,
+})
+
+const model = (id: string, providerId: string, opts: Partial<PiModel> = {}): PiModel => ({
+  id,
+  providerId,
+  ...opts,
+})
+
+describe("compareModelRefs / modelRefKey", () => {
+  test("compares both fields", () => {
+    expect(compareModelRefs({ providerId: "p", modelId: "m" }, { providerId: "p", modelId: "m" })).toBe(true)
+    expect(compareModelRefs({ providerId: "p", modelId: "m" }, { providerId: "p", modelId: "x" })).toBe(false)
+    expect(compareModelRefs(undefined, undefined)).toBe(false)
+  })
+
+  test("builds a stable key", () => {
+    expect(modelRefKey({ providerId: "p", modelId: "m" })).toBe("p/m")
+    expect(modelRefKey(undefined)).toBe(undefined)
+  })
+})
+
+describe("listProviderModels / flattenProviderModels", () => {
+  test("sorts models by id", () => {
+    const p = provider("p", [model("z", "p"), model("a", "p"), model("m", "p")])
+    expect(listProviderModels(p).map((m) => m.id)).toEqual(["a", "m", "z"])
+  })
+
+  test("flattens with provider ordering preserved", () => {
+    const providers = [
+      provider("b", [model("b1", "b"), model("b2", "b")]),
+      provider("a", [model("a1", "a")]),
+    ]
+    const flat = flattenProviderModels(providers)
+    // providers sorted by label "A" before "B"
+    expect(flat.map((m) => m.id)).toEqual(["a1", "b1", "b2"])
+  })
+})
+
+describe("findProvider / findModel", () => {
+  const providers = [
+    provider("p1", [model("m1", "p1"), model("m2", "p1")]),
+    provider("p2", [model("m3", "p2")]),
+  ]
+
+  test("findProvider returns the provider by id", () => {
+    expect(findProvider(providers, "p1")?.id).toBe("p1")
+    expect(findProvider(providers, "missing")).toBe(undefined)
+  })
+
+  test("findModel locates a model across providers", () => {
+    expect(findModel(providers, "p2", "m3")?.id).toBe("m3")
+    expect(findModel(providers, "p1", "missing")).toBe(undefined)
+  })
+})
+
+describe("isThinkingAllowed / pickFallbackThinking", () => {
+  const explicit = model("m", "p", { supportsThinking: true, thinkingLevels: ["low", "high"] })
+  const unrestricted = model("u", "p")
+  const disallowed = model("d", "p", { supportsThinking: false })
+
+  test("allows off by default", () => {
+    expect(isThinkingAllowed(explicit, "off")).toBe(true)
+  })
+
+  test("respects explicit allow list", () => {
+    expect(isThinkingAllowed(explicit, "low")).toBe(true)
+    expect(isThinkingAllowed(explicit, "medium")).toBe(false)
+  })
+
+  test("allows thinking when no list is provided", () => {
+    expect(isThinkingAllowed(unrestricted, "medium")).toBe(true)
+  })
+
+  test("denies unsupported models", () => {
+    expect(isThinkingAllowed(disallowed, "low")).toBe(false)
+  })
+
+  test("pickFallbackThinking chooses the closest allowed level", () => {
+    // `explicit` allows low/high only, so xhigh falls back to the default order.
+    expect(pickFallbackThinking(explicit, "xhigh")).toBe("low")
+    // `unrestricted` has no thinking levels, so it allows xhigh.
+    expect(pickFallbackThinking(unrestricted, "xhigh")).toBe("xhigh")
+    // `disallowed` does not support thinking at all, so the fallback is `off`.
+    expect(pickFallbackThinking(disallowed, "low")).toBe("off")
+  })
+})
+
+describe("resolveNewSessionModel", () => {
+  const providers = [
+    provider("p1", [model("m1", "p1"), model("m2", "p1")]),
+  ]
+
+  test("explicit beats configured default beats Pi fallback", () => {
+    const result = resolveNewSessionModel({
+      providers,
+      explicit: { providerId: "p1", modelId: "m2" },
+      configuredDefault: { providerId: "p1", modelId: "m1" },
+      piFallback: { providerId: "p1", modelId: "m1" },
+    })
+    expect(result).toEqual({ providerId: "p1", modelId: "m2" })
+  })
+
+  test("returns Pi fallback when no defaults are configured", () => {
+    const result = resolveNewSessionModel({
+      providers,
+      piFallback: { providerId: "p1", modelId: "m1" },
+    })
+    expect(result).toEqual({ providerId: "p1", modelId: "m1" })
+  })
+
+  test("falls back when explicit is unknown", () => {
+    const result = resolveNewSessionModel({
+      providers,
+      explicit: { providerId: "ghost", modelId: "x" },
+      piFallback: { providerId: "p1", modelId: "m1" },
+    })
+    expect(result).toEqual({ providerId: "p1", modelId: "m1" })
+  })
+
+  test("preserves an unknown explicit choice when no fallback is configured", () => {
+    const result = resolveNewSessionModel({
+      providers,
+      explicit: { providerId: "ghost", modelId: "x" },
+    })
+    expect(result).toEqual({ providerId: "ghost", modelId: "x" })
+  })
+})
+
+describe("resolveNewSessionThinking", () => {
+  const providers = [
+    provider("p", [model("m", "p", { supportsThinking: true, thinkingLevels: ["low", "medium"] })]),
+  ]
+
+  test("explicit overrides configured default and Pi fallback", () => {
+    const result = resolveNewSessionThinking({
+      providers,
+      resolvedModel: { providerId: "p", modelId: "m" },
+      explicit: "low",
+      configuredDefault: "high",
+      piFallback: "medium",
+    })
+    expect(result).toBe("low")
+  })
+
+  test("falls back to a permitted level when explicit is unsupported", () => {
+    const result = resolveNewSessionThinking({
+      providers,
+      resolvedModel: { providerId: "p", modelId: "m" },
+      explicit: "high",
+    })
+    expect(result).toBe("medium")
+  })
+
+  test("preserves off when explicit is off", () => {
+    const result = resolveNewSessionThinking({
+      providers,
+      resolvedModel: { providerId: "p", modelId: "m" },
+      explicit: "off",
+    })
+    expect(result).toBe("off")
+  })
+})

--- a/packages/ui/src/lib/pi/model-provider.ts
+++ b/packages/ui/src/lib/pi/model-provider.ts
@@ -1,0 +1,144 @@
+/**
+ * Pi model / provider helpers.
+ *
+ * The Pi runtime owns the authoritative model catalog. The helpers here are
+ * the pure UI-side layer:
+ *
+ * - Sorting and grouping providers/models for the picker.
+ * - Comparing `PiModelRef` values.
+ * - Resolving the new-session model/thinking using the agreed precedence.
+ * - Building the new-session selection from PiChamber settings + Pi fallback.
+ *
+ * The helpers do not call the network; the bootstrap owner (`pi-bootstrap.ts`)
+ * feeds them the data they need.
+ */
+
+import type { PiModel, PiModelRef, PiProvider, PiThinkingLevel } from './types';
+
+const cmp = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0);
+
+export const compareModelRefs = (a: PiModelRef | undefined, b: PiModelRef | undefined): boolean => {
+  if (!a || !b) return false;
+  return a.providerId === b.providerId && a.modelId === b.modelId;
+};
+
+export const areModelRefsEqual = compareModelRefs;
+
+export const modelRefKey = (model: PiModelRef | undefined): string | undefined => {
+  if (!model) return undefined;
+  return `${model.providerId}/${model.modelId}`;
+};
+
+/** Return the models of a provider, sorted by label/id. */
+export const listProviderModels = (provider: PiProvider): PiModel[] => {
+  return [...provider.models].sort((a, b) => cmp(a.id, b.id));
+};
+
+/**
+ * Build the picker-friendly flat list of models. The list preserves
+ * provider ordering: all of provider A's models come before any of provider
+ * B's. The ordering lets the sidebar display "by provider" without a second
+ * pass.
+ */
+export const flattenProviderModels = (providers: PiProvider[]): PiModel[] => {
+  const sortedProviders = [...providers].sort((a, b) => cmp(a.label ?? a.id, b.label ?? b.id));
+  const result: PiModel[] = [];
+  for (const provider of sortedProviders) {
+    result.push(...listProviderModels(provider));
+  }
+  return result;
+};
+
+/** Look up a provider by id in the catalog. */
+export const findProvider = (
+  providers: PiProvider[],
+  providerId: string,
+): PiProvider | undefined => providers.find((provider) => provider.id === providerId);
+
+/** Look up a model by provider+model id. */
+export const findModel = (
+  providers: PiProvider[],
+  providerId: string,
+  modelId: string,
+): PiModel | undefined => findProvider(providers, providerId)?.models.find((model) => model.id === modelId);
+
+/**
+ * Build a stable "thinking allowed" lookup. Returns `true` for models that
+ * have an empty or missing `thinkingLevels` array because PiChamber follows
+ * Pi's default of allowing thinking when no list is provided.
+ */
+export const isThinkingAllowed = (
+  model: PiModel | undefined,
+  level: PiThinkingLevel | undefined,
+): boolean => {
+  if (!model || !level || level === 'off') return true;
+  if (model.supportsThinking === false) return false;
+  if (!model.thinkingLevels || model.thinkingLevels.length === 0) return true;
+  return model.thinkingLevels.includes(level);
+};
+
+/** Default-thinking fallback order. The new-session UI uses this. */
+export const DEFAULT_THINKING_ORDER: PiThinkingLevel[] = ['medium', 'low', 'high', 'xhigh', 'off'];
+
+export const pickFallbackThinking = (
+  model: PiModel | undefined,
+  preferred: PiThinkingLevel | undefined,
+): PiThinkingLevel | undefined => {
+  if (!model) return preferred;
+  if (preferred && isThinkingAllowed(model, preferred)) return preferred;
+  for (const level of DEFAULT_THINKING_ORDER) {
+    if (isThinkingAllowed(model, level)) return level;
+  }
+  return undefined;
+};
+
+/**
+ * Resolve the new-session model selection using the precedence documented
+ * in the migration plan: explicit UI selection beats PiChamber default,
+ * PiChamber default beats Pi fallback.
+ */
+export interface ResolveNewSessionModelInput {
+  providers: PiProvider[];
+  explicit?: PiModelRef;
+  configuredDefault?: PiModelRef;
+  piFallback?: PiModelRef;
+}
+
+export const resolveNewSessionModel = (input: ResolveNewSessionModelInput): PiModelRef | undefined => {
+  const sources: Array<PiModelRef | undefined> = [
+    input.explicit,
+    input.configuredDefault,
+    input.piFallback,
+  ];
+  for (const candidate of sources) {
+    if (!candidate) continue;
+    if (findModel(input.providers, candidate.providerId, candidate.modelId)) {
+      return candidate;
+    }
+  }
+  // The first non-null candidate is still authoritative even if Pi does not
+  // know about the model: the user picked it explicitly or PiChamber set it
+  // as a default. The provider UI will surface the unknown status when
+  // listing providers.
+  for (const candidate of sources) {
+    if (candidate) return candidate;
+  }
+  return undefined;
+};
+
+/** Same precedence as `resolveNewSessionModel` but for the thinking level. */
+export const resolveNewSessionThinking = (params: {
+  providers: PiProvider[];
+  resolvedModel?: PiModelRef;
+  explicit?: PiThinkingLevel;
+  configuredDefault?: PiThinkingLevel;
+  piFallback?: PiThinkingLevel;
+}): PiThinkingLevel | undefined => {
+  const candidate = params.explicit ?? params.configuredDefault ?? params.piFallback;
+  if (!candidate) return undefined;
+  if (candidate === 'off') return 'off';
+  const model = params.resolvedModel
+    ? findModel(params.providers, params.resolvedModel.providerId, params.resolvedModel.modelId)
+    : undefined;
+  return pickFallbackThinking(model, candidate);
+};

--- a/packages/ui/src/lib/pi/protocol.test.ts
+++ b/packages/ui/src/lib/pi/protocol.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test"
+import { isPiEvent, PI_EVENT_KINDS, PI_PUBLIC_PROTOCOL_VERSION } from "./protocol"
+
+describe("protocol constants", () => {
+  test("public protocol version is 1", () => {
+    expect(PI_PUBLIC_PROTOCOL_VERSION).toBe(1)
+  })
+
+  test("event kinds cover every canonical name", () => {
+    expect(PI_EVENT_KINDS).toContain("session.snapshot")
+    expect(PI_EVENT_KINDS).toContain("session.lifecycle")
+    expect(PI_EVENT_KINDS).toContain("assistant.message.start")
+    expect(PI_EVENT_KINDS).toContain("assistant.message.delta")
+    expect(PI_EVENT_KINDS).toContain("assistant.message.end")
+    expect(PI_EVENT_KINDS).toContain("assistant.thinking.delta")
+    expect(PI_EVENT_KINDS).toContain("session.tool.start")
+    expect(PI_EVENT_KINDS).toContain("session.tool.update")
+    expect(PI_EVENT_KINDS).toContain("session.tool.end")
+    expect(PI_EVENT_KINDS).toContain("session.queue")
+    expect(PI_EVENT_KINDS).toContain("session.model")
+    expect(PI_EVENT_KINDS).toContain("session.thinking")
+    expect(PI_EVENT_KINDS).toContain("session.compaction")
+    expect(PI_EVENT_KINDS).toContain("session.error")
+    expect(PI_EVENT_KINDS).toContain("session.interrupted")
+  })
+})
+
+describe("isPiEvent", () => {
+  test("accepts valid envelopes", () => {
+    const event = {
+      protocolVersion: 1,
+      kind: "event",
+      name: "session.lifecycle",
+      sequence: 1,
+      sessionId: "s1",
+      directory: "/work",
+      payload: { state: "busy" },
+    }
+    expect(isPiEvent(event)).toBe(true)
+  })
+
+  test("rejects unrelated objects", () => {
+    expect(isPiEvent(null)).toBe(false)
+    expect(isPiEvent(undefined)).toBe(false)
+    expect(isPiEvent({})).toBe(false)
+    expect(isPiEvent({ kind: "response" })).toBe(false)
+    expect(isPiEvent({ kind: "event", name: "unknown" })).toBe(false)
+    expect(isPiEvent({
+      protocolVersion: 1,
+      kind: "event",
+      name: "session.lifecycle",
+      sequence: -1,
+      sessionId: "s1",
+      directory: "/work",
+      payload: { state: "busy" },
+    })).toBe(false)
+    expect(isPiEvent({
+      protocolVersion: 2,
+      kind: "event",
+      name: "session.lifecycle",
+      sequence: 1,
+      sessionId: "s1",
+      directory: "/work",
+      payload: { state: "busy" },
+    })).toBe(false)
+  })
+
+  test("rejects strings and primitives", () => {
+    expect(isPiEvent("event")).toBe(false)
+    expect(isPiEvent(42)).toBe(false)
+    expect(isPiEvent(true)).toBe(false)
+  })
+})

--- a/packages/ui/src/lib/pi/protocol.ts
+++ b/packages/ui/src/lib/pi/protocol.ts
@@ -1,0 +1,554 @@
+/**
+ * Pi IPC event and command protocol — public /api/pi/ envelope shapes.
+ *
+ * The browser talks to the PiChamber server, never to the private daemon.
+ * The server proxies browser requests onto the daemon's private IPC. The
+ * shapes here are the public contract for the `/api/pi/` namespace; the
+ * daemon module owns the matching private protocol.
+ *
+ * The protocol guarantees:
+ *
+ * - Every session event has a monotonically increasing `sequence`.
+ * - `session.snapshot` is the reconnect baseline; it carries `lastSequence`.
+ * - Errors are stable codes, never empty success or fabricated idle state.
+ * - No credentials, pairing secrets, bearer tokens, or attachment bytes are
+ *   ever returned through this protocol.
+ *
+ * These shapes are intentionally typed as discriminated unions so the
+ * consumer can switch on `event` or `command` and trust the payload.
+ */
+
+import type {
+  PiAttachment,
+  PiAssistantMessage,
+  PiModel,
+  PiModelRef,
+  PiProvider,
+  PiResource,
+  PiSession,
+  PiSessionId,
+  PiSessionLifecycleState,
+  PiSessionSnapshot,
+  PiThinkingLevel,
+  PiUserMessage,
+} from './types';
+
+/** Public PiChamber protocol version. Bumped in lockstep with the daemon. */
+export const PI_PUBLIC_PROTOCOL_VERSION = 1 as const;
+
+/** Stable, non-secret error codes returned by the Pi runtime. */
+export type PiErrorCode =
+  | 'DAEMON_UNAVAILABLE'
+  | 'DAEMON_AUTH_FAILED'
+  | 'DAEMON_REQUEST_FAILED'
+  | 'DAEMON_TIMEOUT'
+  | 'DAEMON_PROTOCOL_MISMATCH'
+  | 'INVALID_ARGUMENT'
+  | 'INVALID_SESSION'
+  | 'INVALID_PROMPT'
+  | 'INVALID_MODEL'
+  | 'SESSION_INTERRUPTED'
+  | 'SESSION_TREE_NOT_FOUND'
+  | 'PROVIDER_NOT_FOUND'
+  | 'PROVIDER_AUTH_REQUIRED'
+  | 'RESOURCE_NOT_FOUND'
+  | 'ATTACHMENT_FAILED'
+  | 'ATTACHMENT_TOO_LARGE'
+  | 'ATTACHMENT_MISSING'
+  | 'DAEMON_ENDPOINT_UNVERIFIED'
+  | 'DAEMON_CREDENTIAL_UNAVAILABLE';
+
+/** A stable error object returned in response and event payloads. */
+export interface PiError {
+  code: PiErrorCode;
+  message?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Runtime health
+// ---------------------------------------------------------------------------
+
+/** `GET /api/pi/runtime` response. */
+export interface PiRuntimeHealth {
+  protocolVersion: number;
+  state: 'ready' | 'unavailable';
+  /** Capability names the daemon currently advertises. */
+  capabilities: string[];
+  /** Set when `state === 'unavailable'`. */
+  error?: PiError;
+}
+
+// ---------------------------------------------------------------------------
+// Sessions
+// ---------------------------------------------------------------------------
+
+export interface PiSessionListItem {
+  session: PiSession;
+  /** Last message preview for sidebar display. */
+  preview?: string;
+  /** Last message timestamp. */
+  updatedAt: number;
+}
+
+export interface PiSessionListResponse {
+  sessions: PiSessionListItem[];
+  /** Optional cursor for paginated loading. */
+  nextCursor?: string | null;
+}
+
+export interface PiSessionCreateInput {
+  parentId?: PiSessionId;
+  title?: string;
+  cwd: string;
+  model?: PiModelRef;
+  thinking?: PiThinkingLevel;
+}
+
+export interface PiSessionDetailResponse {
+  session: PiSession;
+  messages: PiMessageView[];
+  /** Last sequence number the daemon has published for this session. */
+  lastSequence: number;
+}
+
+/** A message view returned by the API, including part data. */
+export interface PiMessageView {
+  message: PiUserMessage | PiAssistantMessage;
+  parts: PiSessionMessagePart[];
+}
+
+export type PiSessionMessagePart =
+  | {
+      type: 'text';
+      id: string;
+      index: number;
+      text: string;
+    }
+  | {
+      type: 'thinking';
+      id: string;
+      index: number;
+      text: string;
+    }
+  | {
+      type: 'tool';
+      id: string;
+      index: number;
+      toolCallId: string;
+      name: string;
+      input?: unknown;
+      output?: unknown;
+      isError?: boolean;
+      state: 'pending' | 'running' | 'completed' | 'error' | 'cancelled';
+      startedAt?: number;
+      endedAt?: number;
+    }
+  | {
+      type: 'attachment';
+      id: string;
+      index: number;
+      attachment: PiAttachment;
+    };
+
+// ---------------------------------------------------------------------------
+// Session operations
+// ---------------------------------------------------------------------------
+
+export interface PiPromptInput {
+  sessionId: PiSessionId;
+  text: string;
+  /** Optional client-generated message id so SSE can reconcile in place. */
+  messageId?: string;
+  /** Model override for the new turn. */
+  model?: PiModelRef;
+  /** Thinking override for the new turn. */
+  thinking?: PiThinkingLevel;
+  /** Server-side attachments the user has already uploaded. */
+  attachments?: Array<{ id: string }>;
+}
+
+export interface PiPromptResult {
+  accepted: true;
+  /** The id the daemon assigned to the user message. */
+  messageId: string;
+}
+
+export type PiSteerInput = PiPromptInput;
+export type PiFollowUpInput = PiPromptInput;
+
+export interface PiAbortInput {
+  sessionId: PiSessionId;
+}
+
+export interface PiSetModelInput {
+  sessionId: PiSessionId;
+  model: PiModelRef;
+}
+
+export interface PiSetThinkingInput {
+  sessionId: PiSessionId;
+  thinking: PiThinkingLevel;
+}
+
+export interface PiCompactInput {
+  sessionId: PiSessionId;
+  /** Optional model override for the compacting turn. */
+  model?: PiModelRef;
+  thinking?: PiThinkingLevel;
+}
+
+export interface PiForkInput {
+  sessionId: PiSessionId;
+  messageId?: string;
+  cwd?: string;
+}
+
+export interface PiCloneInput {
+  sessionId: PiSessionId;
+  cwd?: string;
+}
+
+export interface PiRenameInput {
+  sessionId: PiSessionId;
+  title: string;
+}
+
+export interface PiDeleteInput {
+  sessionId: PiSessionId;
+  /** When true, do not throw on missing sessions. */
+  ignoreMissing?: boolean;
+}
+
+export interface PiArchiveInput {
+  sessionId: PiSessionId;
+  /** When true, archive; when false, unarchive (PiChamber-only metadata). */
+  archived: boolean;
+}
+
+export interface PiSessionTreeNode {
+  sessionId: PiSessionId;
+  parentId: PiSessionId | null;
+  title?: string;
+  updatedAt: number;
+  children: PiSessionTreeNode[];
+}
+
+export interface PiSessionTreeResponse {
+  rootId: PiSessionId;
+  nodes: PiSessionTreeNode[];
+}
+
+// ---------------------------------------------------------------------------
+// Providers
+// ---------------------------------------------------------------------------
+
+export interface PiProviderListResponse {
+  providers: PiProvider[];
+  /** Default model for new sessions (PiChamber or Pi fallback). */
+  default?: PiModelRef;
+}
+
+export interface PiProviderStatusResponse {
+  providerId: string;
+  authenticated: boolean;
+  error?: PiError;
+}
+
+export interface PiProviderLoginInput {
+  providerId: string;
+  /** API key submission. The browser POSTs the value once; the server writes
+   *  it to Pi's credential store and the browser never sees it again. */
+  apiKey?: string;
+  /** Optional OAuth / device-code payload. */
+  oauth?: {
+    code?: string;
+    callbackUrl?: string;
+  };
+}
+
+export interface PiProviderLogoutInput {
+  providerId: string;
+}
+
+export interface PiProviderSetModelsInput {
+  providerId: string;
+  models: PiModel[];
+}
+
+// ---------------------------------------------------------------------------
+// Resources
+// ---------------------------------------------------------------------------
+
+export interface PiResourceListResponse {
+  skills: PiResource[];
+  prompts: PiResource[];
+  agents: PiResource[];
+}
+
+// ---------------------------------------------------------------------------
+// Attachments
+// ---------------------------------------------------------------------------
+
+export interface PiAttachmentCreateInput {
+  /** Original client filename. Sanitized at the server. */
+  filename: string;
+  /** Mime type as advertised by the browser. */
+  mime: string;
+  /** Original bytes, base64 encoded. The server writes the file to temp storage. */
+  base64: string;
+}
+
+export interface PiAttachmentCreateResponse {
+  attachment: PiAttachment;
+}
+
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+/** Discriminator for the public event stream. */
+export type PiEventName =
+  | 'session.snapshot'
+  | 'session.lifecycle'
+  | 'assistant.message.start'
+  | 'assistant.message.delta'
+  | 'assistant.message.end'
+  | 'assistant.thinking.delta'
+  | 'session.tool.start'
+  | 'session.tool.update'
+  | 'session.tool.end'
+  | 'session.queue'
+  | 'session.model'
+  | 'session.thinking'
+  | 'session.compaction'
+  | 'session.error'
+  | 'session.interrupted';
+
+/** Common envelope for every public event. */
+export interface PiEventEnvelope<TName extends PiEventName, TPayload> {
+  protocolVersion: number;
+  kind: 'event';
+  name: TName;
+  sequence: number;
+  sessionId: PiSessionId;
+  directory: string;
+  payload: TPayload;
+}
+
+export type PiSessionSnapshotEvent = PiEventEnvelope<
+  'session.snapshot',
+  {
+    snapshot: PiSessionSnapshot;
+  }
+>;
+
+export type PiSessionLifecycleEvent = PiEventEnvelope<
+  'session.lifecycle',
+  {
+    state: PiSessionLifecycleState;
+    attempt?: number;
+    next?: number;
+    message?: string;
+  }
+>;
+
+export interface PiMessageStartPayload {
+  messageId: string;
+  role: 'assistant' | 'user';
+  parentId?: string;
+  /** When the assistant turn started, in ms epoch. */
+  startedAt: number;
+  model?: PiModelRef;
+  thinkingLevel?: PiThinkingLevel;
+}
+
+export interface PiMessageEndPayload {
+  messageId: string;
+  /** Final text/thinking of the assistant message. */
+  text?: string;
+  thinking?: string;
+  /** Final thinking level the daemon persisted. */
+  thinkingLevel?: PiThinkingLevel;
+  durationMs?: number;
+}
+
+export interface PiAssistantMessageDeltaPayload {
+  messageId: string;
+  /** Optional part identity when the daemon exposes multiple text parts. */
+  partId?: string;
+  /** Monotonic delta index within the assistant message. */
+  contentIndex: number;
+  delta: string;
+}
+
+export interface PiAssistantThinkingDeltaPayload {
+  messageId: string;
+  /** Optional part identity when the daemon exposes multiple thinking parts. */
+  partId?: string;
+  /** Monotonic delta index within the thinking stream. */
+  contentIndex: number;
+  delta: string;
+}
+
+export type PiAssistantMessageStartEvent = PiEventEnvelope<
+  'assistant.message.start',
+  PiMessageStartPayload
+>;
+
+export type PiAssistantMessageDeltaEvent = PiEventEnvelope<
+  'assistant.message.delta',
+  PiAssistantMessageDeltaPayload
+>;
+
+export type PiAssistantMessageEndEvent = PiEventEnvelope<
+  'assistant.message.end',
+  PiMessageEndPayload
+>;
+
+export type PiAssistantThinkingDeltaEvent = PiEventEnvelope<
+  'assistant.thinking.delta',
+  PiAssistantThinkingDeltaPayload
+>;
+
+export interface PiToolUpdatePayload {
+  toolCallId: string;
+  partId: string;
+  messageId: string;
+  name: string;
+  state: 'pending' | 'running' | 'completed' | 'error' | 'cancelled';
+  input?: unknown;
+  output?: unknown;
+  isError?: boolean;
+  startedAt?: number;
+  endedAt?: number;
+}
+
+export type PiSessionToolStartEvent = PiEventEnvelope<
+  'session.tool.start',
+  PiToolUpdatePayload
+>;
+
+export type PiSessionToolUpdateEvent = PiEventEnvelope<
+  'session.tool.update',
+  PiToolUpdatePayload
+>;
+
+export type PiSessionToolEndEvent = PiEventEnvelope<
+  'session.tool.end',
+  PiToolUpdatePayload
+>;
+
+export type PiSessionQueueEvent = PiEventEnvelope<
+  'session.queue',
+  {
+    steering: number;
+    followUp: number;
+  }
+>;
+
+export type PiSessionModelEvent = PiEventEnvelope<
+  'session.model',
+  {
+    model: PiModelRef;
+  }
+>;
+
+export type PiSessionThinkingEvent = PiEventEnvelope<
+  'session.thinking',
+  {
+    thinking: PiThinkingLevel;
+  }
+>;
+
+export type PiSessionCompactionEvent = PiEventEnvelope<
+  'session.compaction',
+  {
+    /** True when the compaction is starting; false when it has completed. */
+    running: boolean;
+  }
+>;
+
+export type PiSessionErrorEvent = PiEventEnvelope<
+  'session.error',
+  {
+    code: PiErrorCode;
+    message?: string;
+  }
+>;
+
+export type PiSessionInterruptedEvent = PiEventEnvelope<
+  'session.interrupted',
+  {
+    reason: 'daemon-restart' | 'daemon-crash' | 'runtime-change' | 'user-abort' | 'unknown';
+    /** True when the message is mid-stream at interruption time. */
+    streaming: boolean;
+  }
+>;
+
+/** Discriminated union of every event the public stream can publish. */
+export type PiSessionEvent =
+  | PiSessionSnapshotEvent
+  | PiSessionLifecycleEvent
+  | PiAssistantMessageStartEvent
+  | PiAssistantMessageDeltaEvent
+  | PiAssistantMessageEndEvent
+  | PiAssistantThinkingDeltaEvent
+  | PiSessionToolStartEvent
+  | PiSessionToolUpdateEvent
+  | PiSessionToolEndEvent
+  | PiSessionQueueEvent
+  | PiSessionModelEvent
+  | PiSessionThinkingEvent
+  | PiSessionCompactionEvent
+  | PiSessionErrorEvent
+  | PiSessionInterruptedEvent;
+
+// ---------------------------------------------------------------------------
+// Snapshot / protocol helpers
+// ---------------------------------------------------------------------------
+
+/** A snapshot is also a valid event for code that reduces both. */
+export const PI_EVENT_KINDS = [
+  'session.snapshot',
+  'session.lifecycle',
+  'assistant.message.start',
+  'assistant.message.delta',
+  'assistant.message.end',
+  'assistant.thinking.delta',
+  'session.tool.start',
+  'session.tool.update',
+  'session.tool.end',
+  'session.queue',
+  'session.model',
+  'session.thinking',
+  'session.compaction',
+  'session.error',
+  'session.interrupted',
+] as const satisfies readonly PiEventName[];
+
+/** Discriminator guard. */
+export const isPiEvent = (value: unknown): value is PiSessionEvent => {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as {
+    protocolVersion?: unknown;
+    name?: unknown;
+    kind?: unknown;
+    sequence?: unknown;
+    sessionId?: unknown;
+    directory?: unknown;
+    payload?: unknown;
+  };
+  return (
+    candidate.protocolVersion === PI_PUBLIC_PROTOCOL_VERSION
+    && candidate.kind === 'event'
+    && typeof candidate.name === 'string'
+    && Number.isSafeInteger(candidate.sequence)
+    && (candidate.sequence as number) >= 0
+    && typeof candidate.sessionId === 'string'
+    && candidate.sessionId.length > 0
+    && typeof candidate.directory === 'string'
+    && candidate.directory.length > 0
+    && Boolean(candidate.payload && typeof candidate.payload === 'object' && !Array.isArray(candidate.payload))
+    && (PI_EVENT_KINDS as readonly string[]).includes(candidate.name)
+  );
+};

--- a/packages/ui/src/lib/pi/reconnect.test.ts
+++ b/packages/ui/src/lib/pi/reconnect.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockFetchPiRuntimeHealth: any = mock(async () => ({
+  state: "ready",
+  protocolVersion: 1,
+  capabilities: [],
+}))
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockCreatePiEventStream: any = mock(() => ({
+  dispose: () => undefined,
+  reconnect: () => undefined,
+  eventsUrl: "ws://test/events",
+}))
+
+mock.module("./transport", () => ({
+  fetchPiRuntimeHealth: mockFetchPiRuntimeHealth,
+  createPiEventStream: mockCreatePiEventStream,
+  openRuntimeWebSocket: () => ({ addEventListener: () => undefined, close: () => undefined }),
+  getRuntimeUrlResolver: () => ({
+    api: (path: string) => `http://localhost${path}`,
+    sse: (path: string) => `http://localhost${path}`,
+    ws: (path: string) => `ws://localhost${path}`,
+    health: () => "http://localhost/health",
+    authenticatedAsset: (path: string) => `http://localhost${path}`,
+  }),
+}))
+
+const originalFetch = globalThis.fetch
+
+type FetchCall = { url: string; init?: RequestInit }
+const calls: FetchCall[] = []
+
+const installFetchMock = (responder: (call: FetchCall) => Response | Promise<Response>) => {
+  calls.length = 0
+  const fn = mock(async (url: string, init?: RequestInit) => {
+    const call: FetchCall = { url, init }
+    calls.push(call)
+    return responder(call)
+  })
+  globalThis.fetch = fn as unknown as typeof fetch
+}
+
+const jsonResponse = (body: unknown, init: ResponseInit = {}): Response => {
+  const status = init.status ?? 200
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+    ...init,
+  })
+}
+
+describe("reconnectPiSession", () => {
+  beforeEach(() => {
+    mockFetchPiRuntimeHealth.mockReset()
+    mockCreatePiEventStream.mockReset()
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  test("returns unavailable when the daemon is down", async () => {
+    mockFetchPiRuntimeHealth.mockResolvedValueOnce({
+      state: "unavailable",
+      protocolVersion: 1,
+      capabilities: [],
+      error: { code: "DAEMON_UNAVAILABLE" },
+    })
+    const { reconnectPiSession } = await import("./reconnect")
+    const result = await reconnectPiSession({
+      directory: "/work",
+      sessionId: "s1",
+      onEvent: () => {},
+    })
+    expect(result.phase).toBe("unavailable")
+    expect(result.error?.code).toBe("DAEMON_UNAVAILABLE")
+    expect(result.stream).toBeNull()
+  })
+
+  test("captures a snapshot and resumes from its sequence", async () => {
+    mockFetchPiRuntimeHealth.mockResolvedValueOnce({
+      state: "ready",
+      protocolVersion: 1,
+      capabilities: [],
+    })
+    mockCreatePiEventStream.mockReturnValueOnce({
+      dispose: () => undefined,
+      reconnect: () => undefined,
+      eventsUrl: "ws://test/events",
+    } as never)
+    installFetchMock((call) => {
+      const url = new URL(call.url, "http://localhost")
+      if (url.pathname === "/api/pi/sessions/s1") {
+        return jsonResponse({
+          session: { id: "s1", directory: "/work" },
+          messages: [],
+          lastSequence: 12,
+        })
+      }
+      return jsonResponse({}, { status: 500 })
+    })
+    const { reconnectPiSession } = await import("./reconnect")
+    const result = await reconnectPiSession({
+      directory: "/work",
+      sessionId: "s1",
+      lastKnownSequence: 5,
+      onEvent: () => {},
+    })
+    expect(result.phase).toBe("ready")
+    expect(result.lastSequence).toBe(12)
+    expect(result.stream).not.toBeNull()
+  })
+
+  test("returns failed when the session is not indexed", async () => {
+    mockFetchPiRuntimeHealth.mockResolvedValueOnce({
+      state: "ready",
+      protocolVersion: 1,
+      capabilities: [],
+    })
+    installFetchMock(() =>
+      jsonResponse({ error: { code: "INVALID_SESSION" } }, { status: 404 }),
+    )
+    const { reconnectPiSession } = await import("./reconnect")
+    const result = await reconnectPiSession({
+      directory: "/work",
+      sessionId: "missing",
+      onEvent: () => {},
+    })
+    expect(result.phase).toBe("failed")
+    expect(result.error?.code).toBe("INVALID_SESSION")
+  })
+})

--- a/packages/ui/src/lib/pi/reconnect.ts
+++ b/packages/ui/src/lib/pi/reconnect.ts
@@ -1,0 +1,215 @@
+/**
+ * Pi reconnect owner.
+ *
+ * The reconnect path owns the recovery sequence for a live session:
+ *
+ *   1. The stream reports a disconnect (or the user hides/returns the tab
+ *      and we miss a heartbeat). We mark the session `interrupted` so the
+ *      UI shows the warning instead of an idle spinner.
+ *   2. We re-attach the live stream. If the runtime is `ready`, we ask
+ *      the daemon for a fresh snapshot of the session and resume the
+ *      reducer from there.
+ *   3. If the daemon is `unavailable`, we do NOT fabricate an empty
+ *      session — we surface the unavailable state until the daemon
+ *      reports ready again.
+ *
+ * The owner is intentionally explicit about phases; the sync layer uses
+ * the result to drive UI states (loading spinner, retry button, etc.).
+ */
+
+import { fetchPiRuntimeHealth } from './transport';
+import { piClient, PiRequestError } from './client';
+import {
+  applySnapshot,
+  createSnapshotReducerState,
+  type PiSnapshotReducerState,
+} from './snapshot';
+import { hydrateSessionFromDetail, type PiReducerState } from './event-reducer';
+import {
+  createPiEventStream,
+  type PiStreamHandle,
+} from './transport';
+import type { PiSessionEvent } from './protocol';
+import type { PiSessionId } from './types';
+
+export type PiReconnectPhase =
+  | 'idle'
+  | 'health-check'
+  | 'snapshot-fetch'
+  | 'stream-attach'
+  | 'ready'
+  | 'failed'
+  | 'unavailable';
+
+export interface PiReconnectResult {
+  phase: PiReconnectPhase;
+  snapshotState: PiSnapshotReducerState;
+  /** Hydrated transcript state used by the sync-layer store. */
+  reducerState: PiReducerState;
+  stream: PiStreamHandle | null;
+  /** Last sequence the snapshot covered. `-1` if no snapshot was applied. */
+  lastSequence: number;
+  /** Error captured during reconnect, when phase is `failed`. */
+  error?: { code: string; message?: string; status?: number };
+}
+
+export interface PiReconnectOptions {
+  directory: string;
+  sessionId: PiSessionId;
+  runtimeKey?: string;
+  /** Sequence the client last successfully applied. `-1` if unknown. */
+  lastKnownSequence?: number;
+  /** Caller-supplied event handler. */
+  onEvent: (event: PiSessionEvent) => void;
+  onStreamDisconnect?: (reason: string) => void;
+  onStreamReconnect?: () => void;
+  onTransportSwitch?: () => void;
+  signal?: AbortSignal;
+  retry?: <T>(task: () => Promise<T>) => Promise<T>;
+}
+
+const toError = (error: unknown): { code: string; message?: string; status?: number } => {
+  if (error instanceof PiRequestError) {
+    return {
+      code: error.code,
+      ...(error.message ? { message: error.message } : {}),
+      ...(error.status !== undefined ? { status: error.status } : {}),
+    };
+  }
+  if (error instanceof Error) {
+    return { code: 'DAEMON_REQUEST_FAILED', message: error.message };
+  }
+  return { code: 'DAEMON_REQUEST_FAILED' };
+};
+
+/**
+ * Run a reconnect. The function returns the snapshot reducer state and
+ * a live stream handle. The caller is responsible for wiring the snapshot
+ * into the main reducer before applying events from `onEvent`.
+ */
+export const reconnectPiSession = async (options: PiReconnectOptions): Promise<PiReconnectResult> => {
+  const result: PiReconnectResult = {
+    phase: 'idle',
+    snapshotState: createSnapshotReducerState(),
+    reducerState: { bySession: new Map(), lastSequence: new Map() },
+    stream: null,
+    lastSequence: options.lastKnownSequence ?? -1,
+  };
+
+  const task = async <T>(work: () => Promise<T>): Promise<T> => (options.retry ? options.retry(work) : work());
+
+  // 1. Health probe first — a `unavailable` result is not a failure but a
+  //    distinct state the UI must render.
+  result.phase = 'health-check';
+  const health = await task(() => fetchPiRuntimeHealth(options.signal, options.runtimeKey));
+  if (health.state !== 'ready') {
+    result.phase = 'unavailable';
+    result.error = {
+      code: health.error?.code ?? 'DAEMON_UNAVAILABLE',
+      ...(health.error?.message ? { message: health.error.message } : {}),
+    };
+    return result;
+  }
+
+  // 2. Fetch the freshest snapshot the daemon has for the session. A
+  //    404 means the daemon has not yet indexed this session, which is
+  //    treated as `failed` so the UI can choose to navigate away.
+  result.phase = 'snapshot-fetch';
+  try {
+    const detail = await task(() => piClient.getSession(options.sessionId, {
+      directory: options.directory,
+      ...(options.runtimeKey ? { runtimeKey: options.runtimeKey } : {}),
+    }));
+    const hydrated = hydrateSessionFromDetail({
+      session: { id: detail.session.id, directory: detail.session.directory },
+      lastSequence: detail.lastSequence,
+      messages: detail.messages.map((entry) => ({
+        message: entry.message,
+        parts: entry.parts.map((part) => ({
+          id: part.id,
+          index: part.index,
+          type: part.type,
+          text: part.type === 'text' || part.type === 'thinking' ? part.text : undefined,
+          ...(part.type === 'tool'
+            ? {
+                toolCallId: part.toolCallId,
+                name: part.name,
+                ...(part.input !== undefined ? { input: part.input } : {}),
+                ...(part.output !== undefined ? { output: part.output } : {}),
+                ...(part.isError !== undefined ? { isError: part.isError } : {}),
+                state: part.state,
+                ...(part.startedAt !== undefined ? { startedAt: part.startedAt } : {}),
+                ...(part.endedAt !== undefined ? { endedAt: part.endedAt } : {}),
+              }
+            : {}),
+          ...(part.type === 'attachment' ? { attachment: part.attachment } : {}),
+        })),
+      })),
+    });
+    result.reducerState = hydrated.state;
+    // Synthesize a snapshot event from the detail response. We use the
+    // event reducer's snapshot path so the reconnect logic stays in one
+    // place.
+    const snapshotEvent: PiSessionEvent = {
+      protocolVersion: 1,
+      kind: 'event',
+      name: 'session.snapshot',
+      sequence: detail.lastSequence,
+      sessionId: detail.session.id,
+      directory: detail.session.directory,
+      payload: {
+        snapshot: {
+          sessionId: detail.session.id,
+          directory: detail.session.directory,
+          lastSequence: detail.lastSequence,
+          isStreaming: false,
+          queue: { steering: 0, followUp: 0 },
+          lifecycle: 'idle',
+        },
+      },
+    };
+    const applied = applySnapshot(result.snapshotState, snapshotEvent.payload.snapshot);
+    result.snapshotState = applied.state;
+    result.lastSequence = detail.lastSequence;
+  } catch (error) {
+    const wrapped = toError(error);
+    if (wrapped.code === 'INVALID_SESSION') {
+      result.phase = 'failed';
+      result.error = wrapped;
+      return result;
+    }
+    // A transient failure during snapshot fetch becomes `failed`; the
+    // caller decides whether to retry.
+    result.phase = 'failed';
+    result.error = wrapped;
+    return result;
+  }
+
+  // 3. Attach the stream with the snapshot's sequence as the resume
+  //    watermark. Events with a sequence <= lastSequence will be silently
+  //    dropped by the reducer, which is the correct behavior.
+  result.phase = 'stream-attach';
+  try {
+    result.stream = createPiEventStream(
+      {
+        onEvent: options.onEvent,
+        onDisconnect: (reason) => options.onStreamDisconnect?.(reason),
+        onReconnect: () => options.onStreamReconnect?.(),
+        onTransportSwitch: () => options.onTransportSwitch?.(),
+      },
+      {
+        fromSequence: result.lastSequence,
+        sessionId: options.sessionId,
+        ...(options.runtimeKey ? { runtimeKey: options.runtimeKey } : {}),
+        signal: options.signal,
+      },
+    );
+  } catch (error) {
+    result.phase = 'failed';
+    result.error = toError(error);
+    return result;
+  }
+
+  result.phase = 'ready';
+  return result;
+};

--- a/packages/ui/src/lib/pi/snapshot.test.ts
+++ b/packages/ui/src/lib/pi/snapshot.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test"
+import {
+  applySnapshot,
+  createSnapshotReducerState,
+  projectSnapshot,
+  resetSnapshot,
+} from "./snapshot"
+import type { PiSessionSnapshot } from "./types"
+
+const snapshot = (
+  sessionId: string,
+  lastSequence: number,
+  directory = "/work",
+  extras: Partial<PiSessionSnapshot> = {},
+): PiSessionSnapshot => ({
+  sessionId,
+  directory,
+  lastSequence,
+  isStreaming: false,
+  lifecycle: "idle",
+  ...extras,
+})
+
+describe("applySnapshot", () => {
+  test("accepts strictly newer snapshots", () => {
+    const state = createSnapshotReducerState()
+    const first = applySnapshot(state, snapshot("s1", 5))
+    expect(first.didUpdate).toBe(true)
+    const second = applySnapshot(first.state, snapshot("s1", 5))
+    expect(second.didUpdate).toBe(false)
+    const third = applySnapshot(second.state, snapshot("s1", 6))
+    expect(third.didUpdate).toBe(true)
+  })
+
+  test("rejects older snapshots without mutating references", () => {
+    const state = createSnapshotReducerState()
+    const first = applySnapshot(state, snapshot("s1", 5))
+    const second = applySnapshot(first.state, snapshot("s1", 3))
+    expect(second.didUpdate).toBe(false)
+    expect(second.state).toBe(first.state)
+  })
+
+  test("tracks multiple sessions independently", () => {
+    const state = createSnapshotReducerState()
+    const a = applySnapshot(state, snapshot("a", 1))
+    const b = applySnapshot(a.state, snapshot("b", 10))
+    expect(b.state.bySession.size).toBe(2)
+    expect(b.state.lastSequence.get("a")).toBe(1)
+    expect(b.state.lastSequence.get("b")).toBe(10)
+  })
+})
+
+describe("resetSnapshot", () => {
+  test("removes the session from both maps", () => {
+    const state = createSnapshotReducerState()
+    const seeded = applySnapshot(state, snapshot("s1", 5))
+    const cleared = resetSnapshot(seeded.state, "s1")
+    expect(cleared.bySession.has("s1")).toBe(false)
+    expect(cleared.lastSequence.has("s1")).toBe(false)
+  })
+
+  test("returns the same reference when nothing to clear", () => {
+    const state = createSnapshotReducerState()
+    const cleared = resetSnapshot(state, "missing")
+    expect(cleared).toBe(state)
+  })
+})
+
+describe("projectSnapshot", () => {
+  test("copies the stable projection shape", () => {
+    const projected = projectSnapshot(
+      snapshot("s1", 7, "/repo", { isStreaming: true, lifecycle: "busy", lastText: "Hi" }),
+    )
+    expect(projected.lastSequence).toBe(7)
+    expect(projected.isStreaming).toBe(true)
+    expect(projected.lifecycle).toBe("busy")
+    expect(projected.lastText).toBe("Hi")
+  })
+})

--- a/packages/ui/src/lib/pi/snapshot.ts
+++ b/packages/ui/src/lib/pi/snapshot.ts
@@ -1,0 +1,100 @@
+/**
+ * Snapshot reducer helpers — apply a `session.snapshot` event to the running
+ * per-session state.
+ *
+ * Snapshots are the reconnect baseline. The reducer here is intentionally
+ * minimal: it replaces the running state with the snapshot's projection
+ * when the snapshot's `lastSequence` is greater than the current watermark,
+ * and is otherwise a no-op.
+ *
+ * The reducer keeps its own mutable scratch object so callers do not
+ * accidentally share state between sessions. Components consume the
+ * returned `PiSessionSnapshotView` instead of the raw snapshot, so they
+ * cannot read `lastSequence` or `lifecycle` from a stale baseline.
+ */
+
+import type { PiSessionSnapshot } from './types';
+
+export interface PiSessionSnapshotView {
+  sessionId: string;
+  directory: string;
+  isStreaming: boolean;
+  lastSequence: number;
+  queue: { steering: number; followUp: number };
+  model?: PiSessionSnapshot['model'];
+  thinking?: PiSessionSnapshot['thinking'];
+  lastText?: string;
+  lastThinking?: string;
+  lastToolPart?: PiSessionSnapshot['lastToolPart'];
+  lifecycle: PiSessionSnapshot['lifecycle'];
+}
+
+export const projectSnapshot = (snapshot: PiSessionSnapshot): PiSessionSnapshotView => ({
+  sessionId: snapshot.sessionId,
+  directory: snapshot.directory,
+  isStreaming: snapshot.isStreaming,
+  lastSequence: snapshot.lastSequence,
+  queue: snapshot.queue ?? { steering: 0, followUp: 0 },
+  ...(snapshot.model ? { model: snapshot.model } : {}),
+  ...(snapshot.thinking ? { thinking: snapshot.thinking } : {}),
+  ...(snapshot.lastText ? { lastText: snapshot.lastText } : {}),
+  ...(snapshot.lastThinking ? { lastThinking: snapshot.lastThinking } : {}),
+  ...(snapshot.lastToolPart ? { lastToolPart: snapshot.lastToolPart } : {}),
+  lifecycle: snapshot.lifecycle,
+});
+
+export interface PiSnapshotReducerState {
+  /** Last snapshot the reducer has accepted, by session id. */
+  bySession: Map<string, PiSessionSnapshotView>;
+  /** Last sequence per session; `-1` means "no snapshot yet". */
+  lastSequence: Map<string, number>;
+}
+
+export const createSnapshotReducerState = (): PiSnapshotReducerState => ({
+  bySession: new Map(),
+  lastSequence: new Map(),
+});
+
+/**
+ * Apply a snapshot. Returns the new state and a `didUpdate` flag. When
+ * `didUpdate` is `false`, the caller MUST NOT touch subscribers because the
+ * reference would be the same and the reducer rejected a stale or
+ * out-of-order snapshot.
+ */
+export const applySnapshot = (
+  state: PiSnapshotReducerState,
+  snapshot: PiSessionSnapshot,
+): { state: PiSnapshotReducerState; didUpdate: boolean } => {
+  const previous = state.lastSequence.get(snapshot.sessionId) ?? -1;
+  if (snapshot.lastSequence <= previous) {
+    return { state, didUpdate: false };
+  }
+  const next: PiSnapshotReducerState = {
+    bySession: new Map(state.bySession),
+    lastSequence: new Map(state.lastSequence),
+  };
+  next.bySession.set(snapshot.sessionId, projectSnapshot(snapshot));
+  next.lastSequence.set(snapshot.sessionId, snapshot.lastSequence);
+  return { state: next, didUpdate: true };
+};
+
+/**
+ * Replace the snapshot for a session (e.g. on a forced disconnect). Unlike
+ * `applySnapshot` this accepts the replacement unconditionally because the
+ * caller has the authority to do so.
+ */
+export const resetSnapshot = (
+  state: PiSnapshotReducerState,
+  sessionId: string,
+): PiSnapshotReducerState => {
+  if (!state.bySession.has(sessionId) && !state.lastSequence.has(sessionId)) {
+    return state;
+  }
+  const next: PiSnapshotReducerState = {
+    bySession: new Map(state.bySession),
+    lastSequence: new Map(state.lastSequence),
+  };
+  next.bySession.delete(sessionId);
+  next.lastSequence.delete(sessionId);
+  return next;
+};

--- a/packages/ui/src/lib/pi/transport.ts
+++ b/packages/ui/src/lib/pi/transport.ts
@@ -1,0 +1,449 @@
+/**
+ * Browser transport for the public Pi event stream.
+ *
+ * The browser only talks to the PiChamber server. HTTP uses `runtimeFetch`,
+ * while realtime URLs are resolved through the shared runtime URL helpers and
+ * WebSockets are opened through `openRuntimeWebSocket` so relay mode remains
+ * transparent to this module.
+ */
+
+import { openRuntimeWebSocket } from '@/lib/relay/runtime-socket';
+import { refreshRuntimeUrlAuthToken } from '@/lib/runtime-auth';
+import { runtimeFetch } from '@/lib/runtime-fetch';
+import { getRuntimeKey } from '@/lib/runtime-switch';
+import { getRuntimeUrlResolver } from '@/lib/runtime-url';
+import { isPiEvent, PI_PUBLIC_PROTOCOL_VERSION, type PiSessionEvent } from './protocol';
+
+const DEFAULT_HEARTBEAT_TIMEOUT_MS = 30_000;
+const RECONNECT_BACKOFF_BASE_MS = 250;
+const RECONNECT_BACKOFF_CAP_VISIBLE_MS = 5_000;
+const RECONNECT_BACKOFF_CAP_HIDDEN_OR_OFFLINE_MS = 60_000;
+const RECONNECT_BACKOFF_MAX_EXPONENT = 8;
+const WS_READY_TIMEOUT_MS = 2_000;
+
+const debug = (..._args: unknown[]): void => {
+  // Keep diagnostics payload-free by default. A caller can observe lifecycle
+  // callbacks without making the hot path retain prompt or transcript data.
+  void _args;
+};
+
+const resolveStreamQuery = (query: { fromSequence?: number; sessionId?: string }): Record<string, string> => {
+  const params: Record<string, string> = {};
+  if (typeof query.fromSequence === 'number' && Number.isFinite(query.fromSequence)) {
+    params.fromSequence = String(Math.max(0, Math.floor(query.fromSequence)));
+  }
+  if (typeof query.sessionId === 'string' && query.sessionId.length > 0) {
+    params.sessionId = query.sessionId;
+  }
+  return params;
+};
+
+const resolveStreamUrl = (
+  transport: 'ws' | 'sse',
+  query: { fromSequence?: number; sessionId?: string },
+): string => {
+  const resolver = getRuntimeUrlResolver();
+  const params = resolveStreamQuery(query);
+  return transport === 'ws'
+    ? resolver.websocket('/api/pi/events', params)
+    : resolver.sse('/api/pi/events', params);
+};
+
+const resolveHealthPath = (): string => '/api/pi/runtime';
+
+export interface PiStreamHandlers {
+  onEvent: (event: PiSessionEvent) => void;
+  onReconnect?: () => void;
+  onDisconnect?: (reason: string) => void;
+  onTransportSwitch?: () => void;
+}
+
+export interface PiStreamOptions {
+  fromSequence?: number;
+  sessionId?: string;
+  transport?: 'auto' | 'ws' | 'sse';
+  heartbeatTimeoutMs?: number;
+  reconnectDelayMs?: number;
+  signal?: AbortSignal;
+  /** Runtime identity captured by the owner; old-runtime events are rejected. */
+  runtimeKey?: string;
+}
+
+export interface PiStreamHandle {
+  dispose: () => void;
+  reconnect: (reason?: string) => void;
+  readonly eventsUrl: string;
+}
+
+export const fetchPiRuntimeHealth = async (
+  signal?: AbortSignal,
+  runtimeKey?: string,
+): Promise<{
+  state: 'ready' | 'unavailable';
+  protocolVersion: number;
+  capabilities: string[];
+  error?: { code: string; message?: string };
+}> => {
+  let response: Response;
+  try {
+    response = await runtimeFetch(resolveHealthPath(), signal ? { signal } : {});
+  } catch (error) {
+    return {
+      state: 'unavailable',
+      protocolVersion: PI_PUBLIC_PROTOCOL_VERSION,
+      capabilities: [],
+      error: { code: error instanceof DOMException && error.name === 'AbortError' ? 'DAEMON_TIMEOUT' : 'DAEMON_UNAVAILABLE' },
+    };
+  }
+
+  if (runtimeKey && runtimeKey !== getRuntimeKey()) {
+    return {
+      state: 'unavailable',
+      protocolVersion: PI_PUBLIC_PROTOCOL_VERSION,
+      capabilities: [],
+      error: { code: 'DAEMON_UNAVAILABLE', message: 'Runtime changed during request' },
+    };
+  }
+
+  if (!response.ok) {
+    return {
+      state: 'unavailable',
+      protocolVersion: PI_PUBLIC_PROTOCOL_VERSION,
+      capabilities: [],
+      error: {
+        code: response.status === 401 || response.status === 403 ? 'DAEMON_AUTH_FAILED' : 'DAEMON_UNAVAILABLE',
+      },
+    };
+  }
+
+  const payload = (await response.json().catch(() => null)) as
+    | { state?: unknown; protocolVersion?: unknown; capabilities?: unknown; error?: { code?: unknown; message?: unknown } }
+    | null;
+  if (!payload || typeof payload !== 'object') {
+    return {
+      state: 'unavailable',
+      protocolVersion: PI_PUBLIC_PROTOCOL_VERSION,
+      capabilities: [],
+      error: { code: 'DAEMON_PROTOCOL_MISMATCH' },
+    };
+  }
+
+  const errorCode = typeof payload.error?.code === 'string' ? payload.error.code : undefined;
+  return {
+    state: payload.state === 'ready' ? 'ready' : 'unavailable',
+    protocolVersion: typeof payload.protocolVersion === 'number' ? payload.protocolVersion : PI_PUBLIC_PROTOCOL_VERSION,
+    capabilities: Array.isArray(payload.capabilities)
+      ? payload.capabilities.filter((value): value is string => typeof value === 'string')
+      : [],
+    ...(errorCode
+      ? { error: { code: errorCode, ...(typeof payload.error?.message === 'string' ? { message: payload.error.message } : {}) } }
+      : {}),
+  };
+};
+
+type ConnectionCleanup = () => void;
+
+const createSseConnection = (
+  query: Record<string, string>,
+  signal: AbortSignal,
+  onReady: () => void,
+  onEvent: (event: PiSessionEvent) => void,
+  onDisconnect: (reason: string) => void,
+): ConnectionCleanup => {
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+  if (signal.aborted) controller.abort();
+  else signal.addEventListener('abort', abort, { once: true });
+
+  void runtimeFetch('/api/pi/events', {
+    headers: { Accept: 'text/event-stream' },
+    query,
+    signal: controller.signal,
+  })
+    .then(async (response) => {
+      if (!response.ok || !response.body) {
+        onDisconnect(`sse-status-${response.status}`);
+        return;
+      }
+
+      onReady();
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      let dataLines: string[] = [];
+
+      const dispatchData = () => {
+        if (dataLines.length === 0) return;
+        const data = dataLines.join('\n').trim();
+        dataLines = [];
+        if (!data) return;
+        try {
+          const parsed: unknown = JSON.parse(data);
+          if (isPiEvent(parsed)) onEvent(parsed);
+        } catch {
+          debug('pi-transport:bad-sse-frame');
+        }
+      };
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) {
+          dispatchData();
+          onDisconnect('sse-eof');
+          return;
+        }
+        buffer += decoder.decode(value, { stream: true });
+        let newline = buffer.indexOf('\n');
+        while (newline !== -1) {
+          const line = buffer.slice(0, newline).replace(/\r$/, '');
+          buffer = buffer.slice(newline + 1);
+          if (line.length === 0) dispatchData();
+          else if (line.startsWith('data:')) dataLines.push(line.slice(5).replace(/^ /, ''));
+          newline = buffer.indexOf('\n');
+        }
+      }
+    })
+    .catch((error: unknown) => {
+      if (controller.signal.aborted) return;
+      const message = error instanceof Error ? error.message.slice(0, 80) : 'fetch-failed';
+      onDisconnect(`sse-error:${message}`);
+    })
+    .finally(() => signal.removeEventListener('abort', abort));
+
+  return abort;
+};
+
+const createWsConnection = (
+  url: string,
+  signal: AbortSignal,
+  onReady: () => void,
+  onEvent: (event: PiSessionEvent) => void,
+  onDisconnect: (reason: string) => void,
+  readyTimeoutMs: number,
+): ConnectionCleanup => {
+  const socket = openRuntimeWebSocket(url);
+  let closed = false;
+  let ready = false;
+  let readyTimer: ReturnType<typeof setTimeout> | null = null;
+  const close = () => {
+    if (closed) return;
+    closed = true;
+    if (readyTimer) clearTimeout(readyTimer);
+    readyTimer = null;
+    try {
+      socket.close();
+    } catch {
+      // The socket may already be closed by the runtime.
+    }
+  };
+  readyTimer = setTimeout(() => {
+    if (ready || closed) return;
+    onDisconnect('ws-ready-timeout');
+    close();
+  }, readyTimeoutMs);
+  const abort = () => close();
+  if (signal.aborted) close();
+  else signal.addEventListener('abort', abort, { once: true });
+
+  socket.onopen = () => {
+    ready = true;
+    if (readyTimer) clearTimeout(readyTimer);
+    readyTimer = null;
+    onReady();
+  };
+  socket.onmessage = (raw) => {
+    const data = typeof raw.data === 'string' ? raw.data : undefined;
+    if (!data) return;
+    try {
+      const parsed: unknown = JSON.parse(data);
+      if (isPiEvent(parsed)) onEvent(parsed);
+    } catch {
+      debug('pi-transport:bad-ws-frame');
+    }
+  };
+  socket.onerror = () => {
+    if (!closed) onDisconnect('ws-error');
+  };
+  socket.onclose = (event) => {
+    signal.removeEventListener('abort', abort);
+    if (!closed) onDisconnect(`ws-close-${event?.code ?? 0}`);
+  };
+  return close;
+};
+
+const isVisible = (): boolean => typeof document === 'undefined' || document.visibilityState === 'visible';
+const isOnline = (): boolean => typeof navigator === 'undefined' || navigator.onLine !== false;
+
+export const createPiEventStream = (
+  handlers: PiStreamHandlers,
+  options: PiStreamOptions = {},
+): PiStreamHandle => {
+  const internalController = new AbortController();
+  const externalSignal = options.signal;
+  if (externalSignal) {
+    if (externalSignal.aborted) internalController.abort();
+    else externalSignal.addEventListener('abort', () => internalController.abort(), { once: true });
+  }
+  const signal = internalController.signal;
+  const expectedRuntimeKey = options.runtimeKey;
+  const isCurrentRuntime = () => !expectedRuntimeKey || expectedRuntimeKey === getRuntimeKey();
+
+  let disposed = false;
+  let attempt = 0;
+  let lastSequence = typeof options.fromSequence === 'number' && Number.isFinite(options.fromSequence)
+    ? Math.max(0, Math.floor(options.fromSequence))
+    : 0;
+  let mode: 'ws' | 'sse' = options.transport === 'sse' ? 'sse' : 'ws';
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let heartbeatTimer: ReturnType<typeof setTimeout> | null = null;
+  let activeAbort: ConnectionCleanup | null = null;
+  let generation = 0;
+  let healthyConnection = false;
+
+  const clearTimers = () => {
+    if (reconnectTimer) clearTimeout(reconnectTimer);
+    if (heartbeatTimer) clearTimeout(heartbeatTimer);
+    reconnectTimer = null;
+    heartbeatTimer = null;
+  };
+
+  const invalidateConnection = () => {
+    generation += 1;
+    activeAbort?.();
+    activeAbort = null;
+    if (heartbeatTimer) clearTimeout(heartbeatTimer);
+    heartbeatTimer = null;
+  };
+
+  const resetHeartbeat = (connectionId: number) => {
+    if (heartbeatTimer) clearTimeout(heartbeatTimer);
+    heartbeatTimer = setTimeout(() => {
+      if (connectionId === generation) handleDisconnect('heartbeat-timeout', connectionId);
+    }, options.heartbeatTimeoutMs ?? DEFAULT_HEARTBEAT_TIMEOUT_MS);
+  };
+
+  const markReady = (connectionId: number) => {
+    if (disposed || signal.aborted || connectionId !== generation) return;
+    attempt = 0;
+    healthyConnection = true;
+    resetHeartbeat(connectionId);
+    handlers.onReconnect?.();
+  };
+
+  const computeBackoff = () => {
+    const cap = isVisible() && isOnline()
+      ? RECONNECT_BACKOFF_CAP_VISIBLE_MS
+      : RECONNECT_BACKOFF_CAP_HIDDEN_OR_OFFLINE_MS;
+    const exponent = Math.min(RECONNECT_BACKOFF_MAX_EXPONENT, attempt);
+    const base = Math.min(cap, RECONNECT_BACKOFF_BASE_MS * 2 ** exponent);
+    return (attempt === 0 && options.reconnectDelayMs !== undefined)
+      ? Math.max(0, options.reconnectDelayMs)
+      : base + Math.floor(Math.random() * 100);
+  };
+
+  const scheduleReconnect = (reason: string) => {
+    if (disposed || signal.aborted || reconnectTimer) return;
+    handlers.onDisconnect?.(reason);
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null;
+      attempt += 1;
+      void connect();
+    }, computeBackoff());
+  };
+
+  const handleDisconnect = (reason: string, connectionId: number) => {
+    if (disposed || signal.aborted || connectionId !== generation) return;
+    invalidateConnection();
+    if (!healthyConnection && mode === 'ws' && options.transport !== 'ws') {
+      mode = 'sse';
+      handlers.onTransportSwitch?.();
+    }
+    healthyConnection = false;
+    if (reason === 'runtime-change') {
+      handlers.onDisconnect?.(reason);
+      return;
+    }
+    scheduleReconnect(reason);
+  };
+
+  const handleEvent = (event: PiSessionEvent, connectionId: number) => {
+    if (disposed || signal.aborted || connectionId !== generation) return;
+    if (!isCurrentRuntime()) {
+      handleDisconnect('runtime-change', connectionId);
+      return;
+    }
+    if (event.sequence > lastSequence) lastSequence = event.sequence;
+    resetHeartbeat(connectionId);
+    handlers.onEvent(event);
+  };
+
+  const connect = async (): Promise<void> => {
+    if (disposed || signal.aborted) return;
+    if (!isCurrentRuntime()) {
+      handlers.onDisconnect?.('runtime-change');
+      return;
+    }
+    const connectionId = generation + 1;
+    generation = connectionId;
+
+    if (mode === 'ws') {
+      try {
+        await refreshRuntimeUrlAuthToken();
+      } catch {
+        if (connectionId !== generation || disposed || signal.aborted) return;
+        if (options.transport !== 'ws') {
+          mode = 'sse';
+          handlers.onTransportSwitch?.();
+          invalidateConnection();
+          void connect();
+          return;
+        }
+        handleDisconnect('ws-auth-token-unavailable', connectionId);
+        return;
+      }
+    }
+
+    if (connectionId !== generation || disposed || signal.aborted) return;
+    if (!isCurrentRuntime()) {
+      handleDisconnect('runtime-change', connectionId);
+      return;
+    }
+    const url = resolveStreamUrl(mode, {
+      fromSequence: lastSequence,
+      ...(options.sessionId ? { sessionId: options.sessionId } : {}),
+    });
+    const onReady = () => markReady(connectionId);
+    const onEvent = (event: PiSessionEvent) => handleEvent(event, connectionId);
+    const onDisconnect = (reason: string) => handleDisconnect(reason, connectionId);
+    activeAbort = mode === 'ws'
+      ? createWsConnection(url, signal, onReady, onEvent, onDisconnect, WS_READY_TIMEOUT_MS)
+      : createSseConnection(resolveStreamQuery({
+          fromSequence: lastSequence,
+          ...(options.sessionId ? { sessionId: options.sessionId } : {}),
+        }), signal, onReady, onEvent, onDisconnect);
+  };
+
+  void connect();
+
+  return {
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      clearTimers();
+      invalidateConnection();
+      internalController.abort();
+    },
+    reconnect: (reason = 'manual') => {
+      if (disposed || signal.aborted) return;
+      clearTimers();
+      invalidateConnection();
+      scheduleReconnect(reason);
+    },
+    get eventsUrl() {
+      return resolveStreamUrl(mode, {
+        fromSequence: lastSequence,
+        ...(options.sessionId ? { sessionId: options.sessionId } : {}),
+      });
+    },
+  };
+};

--- a/packages/ui/src/lib/pi/types.ts
+++ b/packages/ui/src/lib/pi/types.ts
@@ -1,0 +1,276 @@
+/**
+ * Pi-native session and message data shapes.
+ *
+ * These types are the PiChamber-owned replacements for the legacy OpenCode SDK
+ * types. The shapes intentionally mirror the workstream-0 protocol contract:
+ * every session-scoped record carries the session id, the events are sequenced,
+ * and the daemon-side identities are Pi session ids. They do not preserve any
+ * OpenCode endpoint, event, or type-alias naming.
+ *
+ * The data model deliberately keeps a small, stable surface:
+ *
+ * - `PiSession` is what projects/sidebar/message-load code reads.
+ * - `PiMessage` and `PiMessagePart` are the unit of streaming; deltas assemble
+ *   into finalized messages once the daemon publishes `assistant.message.end`.
+ * - `PiAssistantMessage` and `PiUserMessage` keep the metadata Pi persists.
+ * - `PiSnapshot` is the reconnect baseline; it carries the last sequence so
+ *   the UI knows it has no events to apply yet.
+ *
+ * The shapes are intentionally compatible with the existing `State` reducer in
+ * `packages/ui/src/sync/` so that bootstrap can start to ship without forcing
+ * a synchronous UI cutover; see `state-shape.ts` for the legacy interop type.
+ */
+
+/**
+ * Stable Pi session identity. Pi persists a unique `sessionId` per agent
+ * session; the directory is the canonical workspace that owns the session.
+ */
+export type PiSessionId = string;
+
+/** A normalized directory that owns a Pi session. */
+export type PiDirectory = string;
+
+/**
+ * The PiChamber-side `PiSession` record. We keep the original Pi name fields
+ * and add the PiChamber-visible directory + model selection so the sidebar and
+ * message loaders can index without re-querying the daemon.
+ */
+export interface PiSession {
+  id: PiSessionId;
+  /** Canonical directory the session belongs to (server-confirmed). */
+  directory: PiDirectory;
+  title?: string;
+  parentId?: PiSessionId | null;
+  createdAt: number;
+  updatedAt: number;
+  /**
+   * The model the session is currently using. After the user changes model or
+   * thinking inside the session, this becomes the authoritative choice and
+   * PiChamber does not reset it.
+   */
+  model?: PiModelRef;
+  thinking?: PiThinkingLevel;
+  /**
+   * The Pi `agent` is preserved for reference; PiChamber does not expose it
+   * as a user-facing agent selector the way OpenCode did.
+   */
+  agent?: string;
+  /** When the session is hidden from the PiChamber sidebar without modifying Pi JSONL. */
+  archived?: boolean;
+  /** Last archived timestamp (ms epoch). Matches the workstream-0 archive contract. */
+  timeArchived?: number;
+  /** Total message count from the most recent authoritative snapshot. */
+  messageCount?: number;
+}
+
+/** A reference to a model the user can pick in PiChamber. */
+export interface PiModelRef {
+  providerId: string;
+  modelId: string;
+}
+
+/** Pi thinking levels; PiChamber does not introduce a new vocabulary. */
+export type PiThinkingLevel = 'off' | 'low' | 'medium' | 'high' | 'xhigh';
+
+/** Common message envelope. Use a discriminant in UI code that switches on role. */
+export type PiMessage = PiUserMessage | PiAssistantMessage;
+
+interface PiMessageBase {
+  id: string;
+  sessionId: PiSessionId;
+  directory: PiDirectory;
+  createdAt: number;
+  /** Optional parent message when this message is the result of a fork/clone. */
+  parentId?: string | null;
+}
+
+export interface PiUserMessage extends PiMessageBase {
+  role: 'user';
+  text: string;
+  /**
+   * Server-local attachment paths. The base64 inline attachment model is
+   * removed; PiChamber writes a temp file on the server and gives the path to
+   * Pi. The `id` is the temporary-file id; the `name` is the original client
+   * filename (sanitized at the server).
+   */
+  attachments?: PiAttachment[];
+}
+
+export interface PiAssistantMessage extends PiMessageBase {
+  role: 'assistant';
+  text: string;
+  thinking: string;
+  /**
+   * The Pi model that produced this message. After a model change this
+   * becomes the message's model, even if the user later picks a different
+   * default for new sessions.
+   */
+  model?: PiModelRef;
+  thinkingLevel?: PiThinkingLevel;
+  /** Wall-clock duration of the producing turn in milliseconds. */
+  durationMs?: number;
+  /**
+   * `error` is set when the assistant message ended in an interruption
+   * (daemon crash, runtime change, explicit `session.interrupted`).
+   */
+  error?: PiAssistantError;
+  /** True while the assistant is still streaming this message. */
+  streaming?: boolean;
+}
+
+export interface PiAssistantError {
+  code: string;
+  message?: string;
+}
+
+/** Server-local attachment metadata written by PiChamber from a browser upload. */
+export interface PiAttachment {
+  /** Server-side temp-file id (used to look up the path on the server). */
+  id: string;
+  /** Original client-side filename, sanitized. */
+  name: string;
+  /** Resolved mime type, normalized to `text/plain` when applicable. */
+  mime: string;
+  /** Local size in bytes after sanitization. */
+  size: number;
+  /**
+   * Server-local absolute path. Browsers never receive this value through
+   * `getMessage`; the daemon hands it only to Pi tools.
+   */
+  path: string;
+}
+
+/**
+ * Message parts. Pi streams deltas with `contentIndex` against the running
+ * message; the reducer assembles those into a finalized `text`/`thinking`
+ * value when the daemon publishes `assistant.message.end`.
+ */
+export type PiMessagePart = PiTextPart | PiThinkingPart | PiToolPart | PiAttachmentPart;
+
+export type PiPartId = string;
+
+interface PiPartBase {
+  id: PiPartId;
+  messageId: string;
+  sessionId: PiSessionId;
+  /** Order within a message. Pi preserves monotonic per-message order. */
+  index: number;
+  createdAt: number;
+}
+
+export interface PiTextPart extends PiPartBase {
+  type: 'text';
+  text: string;
+  /**
+   * True while the daemon is still streaming text. Becomes `false` after
+   * `assistant.message.end`. UI components can key off this for streaming
+   * animations; they should not treat it as authoritative.
+   */
+  streaming?: boolean;
+}
+
+export interface PiThinkingPart extends PiPartBase {
+  type: 'thinking';
+  text: string;
+  streaming?: boolean;
+}
+
+export interface PiToolPart extends PiPartBase {
+  type: 'tool';
+  toolCallId: string;
+  name: string;
+  /**
+   * `input` is the JSON arguments passed to the tool. The shape is tool-specific.
+   */
+  input?: unknown;
+  output?: unknown;
+  /** Set to true when the tool returned an error. */
+  isError?: boolean;
+  /** Tool execution state from Pi. */
+  state: 'pending' | 'running' | 'completed' | 'error' | 'cancelled';
+  startedAt?: number;
+  endedAt?: number;
+}
+
+export interface PiAttachmentPart extends PiPartBase {
+  type: 'attachment';
+  attachment: PiAttachment;
+}
+
+/**
+ * A snapshot of a single session's live state at a point in time. Snapshots
+ * are the reconnect baseline: a client connects, receives a `session.snapshot`
+ * event, and resumes deltas after the snapshot's `lastSequence`.
+ */
+export interface PiSessionSnapshot {
+  sessionId: PiSessionId;
+  directory: PiDirectory;
+  /**
+   * Last sequence number the daemon has published for this session at the
+   * time the snapshot was taken. Clients use it as the reconnect watermark.
+   */
+  lastSequence: number;
+  /** True while the assistant turn is still running. */
+  isStreaming: boolean;
+  /** Pi queue depths; the reducer exposes them in the UI sidebar status. */
+  queue?: { steering: number; followUp: number };
+  /** The active model/thinking for this session at snapshot time. */
+  model?: PiModelRef;
+  thinking?: PiThinkingLevel;
+  /** Last finalized assistant text/thinking at snapshot time. */
+  lastText?: string;
+  lastThinking?: string;
+  /** Last finalized tool part (if any) at snapshot time. */
+  lastToolPart?: PiToolPart;
+  /** The current session lifecycle phase. */
+  lifecycle: PiSessionLifecycleState;
+}
+
+export type PiSessionLifecycleState =
+  | 'idle'
+  | 'busy'
+  | 'retry'
+  | 'error'
+  | 'interrupted';
+
+/**
+ * Provider metadata returned by `GET /api/pi/providers`. Status is reported
+ * as a string code so credentials are never returned to the browser.
+ */
+export interface PiProvider {
+  id: string;
+  label: string;
+  /** Whether the provider currently has working credentials. */
+  authenticated: boolean;
+  /** Optional human-readable error code describing why a provider is unavailable. */
+  error?: { code: string; message?: string };
+  models: PiModel[];
+}
+
+export interface PiModel {
+  id: string;
+  providerId: string;
+  label?: string;
+  contextWindow?: number;
+  /** Model supports reasoning output. */
+  supportsThinking?: boolean;
+  /** Allowed thinking levels for this model. */
+  thinkingLevels?: PiThinkingLevel[];
+}
+
+/**
+ * Pi resource (skill, prompt template, AGENTS.md scope). The UI lists these
+ * via `GET /api/pi/resources`. PiChamber does not write a separate copy of
+ * these on disk; the SDK reads them through Pi's normal discovery.
+ */
+export interface PiResource {
+  kind: 'skill' | 'prompt' | 'agents';
+  name: string;
+  description?: string;
+  /** Where Pi found this resource. */
+  location: 'global' | 'project' | 'package' | 'path';
+  /** Absolute path on disk. Not returned to the browser for some kinds. */
+  path?: string;
+  /** Body for prompt templates. */
+  content?: string;
+}

--- a/packages/ui/src/sync/pi-bootstrap.ts
+++ b/packages/ui/src/sync/pi-bootstrap.ts
@@ -1,0 +1,85 @@
+/**
+ * Pi sync-layer bootstrap owner.
+ *
+ * This module is the sync-context glue that ties the pi-bootstrap helpers
+ * to the existing per-directory zustand store. It exposes a single function
+ * (`bootstrapPiDirectoryForStore`) that runs the bootstrap, applies the
+ * initial events to the store, and returns a controller the sync-context
+ * can use to dispose the live stream.
+ *
+ * The store contract here is intentionally minimal: the function only
+ * needs a `setEvents` setter so we can apply events as they arrive. The
+ * sync-context layer owns the actual store reference; this owner owns
+ * the lifecycle of the stream.
+ */
+
+import { bootstrapPiDirectory, type PiBootstrapResult } from '@/lib/pi/bootstrap';
+import type { PiSessionEvent } from '@/lib/pi/protocol';
+import type { PiSessionId } from '@/lib/pi/types';
+import type { PiReducerState } from '@/lib/pi/event-reducer';
+
+export interface PiSyncBootstrapController {
+  /** Dispose the live stream and cancel any pending work. */
+  dispose: () => void;
+  /** The bootstrap result, retained for diagnostics. */
+  result: PiBootstrapResult | null;
+}
+
+export interface PiSyncBootstrapStore {
+  /** Replace the reducer state with the bootstrap snapshot. */
+  setReducerState: (state: PiReducerState) => void;
+  /** Apply a sequenced event to the running state. */
+  applyEvent: (event: PiSessionEvent) => void;
+  /** Apply a batch of sequenced events. */
+  applyEvents: (events: readonly PiSessionEvent[]) => void;
+  /** Optional accessor for the current reducer state (used by stores that
+   *  keep it outside of zustand). */
+  getReducerState?: () => PiReducerState;
+}
+
+export interface PiSyncBootstrapInput {
+  directory: string;
+  store: PiSyncBootstrapStore;
+  selectedSessionId?: PiSessionId;
+  lastKnownSequence?: number;
+  runtimeKey?: string;
+  signal?: AbortSignal;
+  retry?: <T>(task: () => Promise<T>) => Promise<T>;
+}
+
+/**
+ * Run a bootstrap and wire the resulting stream into the supplied store.
+ * The returned controller exposes `dispose`; sync-context calls it when
+ * the directory unmounts or the runtime changes.
+ */
+export const bootstrapPiDirectoryForStore = async (
+  input: PiSyncBootstrapInput,
+): Promise<PiSyncBootstrapController> => {
+  let stream: PiBootstrapResult['stream'] = null;
+  let result: PiBootstrapResult | null = null;
+
+  try {
+    result = await bootstrapPiDirectory({
+      directory: input.directory,
+      selectedSessionId: input.selectedSessionId,
+      fromSequence: input.lastKnownSequence,
+      runtimeKey: input.runtimeKey,
+      signal: input.signal,
+      retry: input.retry,
+      onEvent: (event: PiSessionEvent) => input.store.applyEvent(event),
+    });
+    stream = result.stream;
+    if (result.reducerState.bySession.size > 0 || result.lastSequence.size > 0) {
+      input.store.setReducerState(result.reducerState);
+    }
+  } catch {
+    // bootstrap already records its own errors; nothing to do here.
+  }
+
+  return {
+    dispose: () => {
+      stream?.dispose();
+    },
+    result,
+  };
+};

--- a/packages/ui/src/sync/pi-event-reducer.ts
+++ b/packages/ui/src/sync/pi-event-reducer.ts
@@ -1,0 +1,52 @@
+/**
+ * Pi session sync owners — the sync-layer wrappers for the pi/ helpers.
+ *
+ * These modules translate between the Pi-native bootstrap/reducer helpers in
+ * `packages/ui/src/lib/pi/` and the existing sync-layer zustand stores. The
+ * sync-context layer subscribes its directory stores to events emitted by
+ * these owners.
+ *
+ * The split keeps the pi/ helpers pure and easy to test, while the
+ * zustand-aware wrappers live next to the existing sync code that already
+ * consumes Zustand stores.
+ */
+
+import {
+  applyPiEvent,
+  applyPiEvents,
+  createReducerState,
+  projectSession,
+  type PiReducerState,
+} from '@/lib/pi/event-reducer';
+import type { PiSessionEvent } from '@/lib/pi/protocol';
+import type { PiSessionId } from '@/lib/pi/types';
+
+/** A self-contained reducer over a list of events. Pure; no zustand. */
+export const reduceEvents = (
+  state: PiReducerState,
+  events: readonly PiSessionEvent[],
+): PiReducerState => applyPiEvents(state, events).state;
+
+/** Convenience reducer for a single event. */
+export const reduceEvent = (
+  state: PiReducerState,
+  event: PiSessionEvent,
+): PiReducerState => applyPiEvent(state, event).state;
+
+/** Project a single session id from the reducer. */
+export const projectReducerSession = (state: PiReducerState, sessionId: PiSessionId) => {
+  const session = state.bySession.get(sessionId);
+  return session ? projectSession(session) : undefined;
+};
+
+/** Project every session known to the reducer. */
+export const projectReducerSessions = (state: PiReducerState) => {
+  const projections = new Map<PiSessionId, ReturnType<typeof projectSession>>();
+  for (const [id, session] of state.bySession.entries()) {
+    projections.set(id, projectSession(session));
+  }
+  return projections;
+};
+
+/** Initialize a fresh reducer state. */
+export const createPiReducerState = createReducerState;

--- a/packages/ui/src/sync/pi-reconnect.ts
+++ b/packages/ui/src/sync/pi-reconnect.ts
@@ -1,0 +1,79 @@
+/**
+ * Pi sync-layer reconnect owner.
+ *
+ * The reconnect owner is the sync-context glue for the pi/ helpers:
+ *
+ * - It runs the reconnect sequence (health probe → snapshot fetch → stream
+ *   attach) and surfaces the hydrated snapshot to the store.
+ * - It then forwards live events through the same store setter as the
+ *   bootstrap path.
+ * - It reports stream disconnects through the transport owner without
+ *   inventing a daemon sequence number or authoritative session event.
+ *
+ * The store contract is the same as the bootstrap owner.
+ */
+
+import { reconnectPiSession, type PiReconnectResult } from '@/lib/pi/reconnect';
+import type { PiSessionEvent } from '@/lib/pi/protocol';
+import type { PiSessionId } from '@/lib/pi/types';
+import type { PiReducerState } from '@/lib/pi/event-reducer';
+
+export interface PiSyncReconnectController {
+  dispose: () => void;
+  result: PiReconnectResult | null;
+}
+
+export interface PiSyncReconnectInput {
+  directory: string;
+  sessionId: PiSessionId;
+  runtimeKey?: string;
+  lastKnownSequence?: number;
+  store: {
+    setReducerState: (state: PiReducerState) => void;
+    applyEvent: (event: PiSessionEvent) => void;
+    applyEvents: (events: readonly PiSessionEvent[]) => void;
+  };
+  signal?: AbortSignal;
+  retry?: <T>(task: () => Promise<T>) => Promise<T>;
+}
+
+export const reconnectPiSessionForStore = async (
+  input: PiSyncReconnectInput,
+): Promise<PiSyncReconnectController> => {
+  let stream: PiReconnectResult['stream'] = null;
+  let result: PiReconnectResult | null = null;
+  try {
+    result = await reconnectPiSession({
+      directory: input.directory,
+      sessionId: input.sessionId,
+      runtimeKey: input.runtimeKey,
+      lastKnownSequence: input.lastKnownSequence,
+      signal: input.signal,
+      retry: input.retry,
+      onEvent: (event: PiSessionEvent) => input.store.applyEvent(event),
+      // A transport disconnect is not an authoritative Pi session event.
+      // Do not advance the daemon sequence watermark with a fabricated event;
+      // the UI can show transport-unavailable state through its connection
+      // owner and the daemon's sequenced `session.interrupted` event remains
+      // authoritative after reconnect.
+      onStreamDisconnect: () => undefined,
+    });
+
+    if (result.phase === 'ready' && result.stream) {
+      stream = result.stream;
+      // Apply the hydrated transcript plus its sequence watermark. The
+      // snapshot sidecar remains available for lifecycle-only projections,
+      // but the main reducer must retain the authoritative message records.
+      input.store.setReducerState(result.reducerState);
+    }
+  } catch {
+    // reconnect records its own errors; nothing to do here.
+  }
+
+  return {
+    dispose: () => {
+      stream?.dispose();
+    },
+    result,
+  };
+};

--- a/packages/ui/src/sync/pi-snapshot.ts
+++ b/packages/ui/src/sync/pi-snapshot.ts
@@ -1,0 +1,47 @@
+/**
+ * Pi sync-layer snapshot owner.
+ *
+ * The snapshot owner is a thin zustand-aware wrapper over `pi/snapshot.ts`.
+ * The store consumers subscribe to its per-session projection; the live
+ * reducer events advance the same projection.
+ */
+
+import {
+  applySnapshot as applySnapshotReducer,
+  createSnapshotReducerState as createSnapshotState,
+  projectSnapshot,
+  resetSnapshot,
+  type PiSessionSnapshotView,
+  type PiSnapshotReducerState,
+} from '@/lib/pi/snapshot';
+import type { PiSessionSnapshot } from '@/lib/pi/types';
+
+export {
+  applySnapshotReducer,
+  createSnapshotState,
+  projectSnapshot,
+  resetSnapshot,
+};
+export type { PiSessionSnapshotView, PiSnapshotReducerState };
+
+/**
+ * Convenience helper for stores that hold an immutable snapshot map.
+ * Returns a new map only when the snapshot's sequence is strictly greater
+ * than the previously accepted sequence.
+ */
+export const upsertSnapshot = (
+  state: PiSnapshotReducerState,
+  snapshot: PiSessionSnapshot,
+): PiSnapshotReducerState => applySnapshotReducer(state, snapshot).state;
+
+/** Return the snapshot view for a single session id, or `undefined`. */
+export const getSnapshotView = (
+  state: PiSnapshotReducerState,
+  sessionId: string,
+): PiSessionSnapshotView | undefined => state.bySession.get(sessionId);
+
+/** Last accepted sequence per session id; `-1` for sessions with no snapshot. */
+export const getLastSequence = (
+  state: PiSnapshotReducerState,
+  sessionId: string,
+): number => state.lastSequence.get(sessionId) ?? -1;

--- a/packages/ui/src/sync/pi.ts
+++ b/packages/ui/src/sync/pi.ts
@@ -1,0 +1,39 @@
+/**
+ * Sync-layer Pi owner exports.
+ *
+ * The sync-context layer consumes these wrappers rather than the pure
+ * helpers under `packages/ui/src/lib/pi/`. Keeping the two surfaces
+ * separate means the pure helpers stay easy to unit-test while the
+ * zustand-aware wrappers can evolve with the sync layer.
+ */
+
+export {
+  bootstrapPiDirectoryForStore,
+  type PiSyncBootstrapController,
+  type PiSyncBootstrapInput,
+  type PiSyncBootstrapStore,
+} from './pi-bootstrap';
+
+export {
+  reconnectPiSessionForStore,
+  type PiSyncReconnectController,
+  type PiSyncReconnectInput,
+} from './pi-reconnect';
+
+export {
+  applySnapshotReducer,
+  createSnapshotState,
+  getLastSequence,
+  getSnapshotView,
+  projectSnapshot,
+  resetSnapshot,
+  upsertSnapshot,
+} from './pi-snapshot';
+
+export {
+  createPiReducerState,
+  projectReducerSession,
+  projectReducerSessions,
+  reduceEvent,
+  reduceEvents,
+} from './pi-event-reducer';


### PR DESCRIPTION
## Summary
Adds the Pi-native shared UI data-layer foundation for PiChamber.
## Changes
- Adds typed Pi session, message, provider, resource, attachment, and protocol contracts.
- Aligns event names with the canonical Pi protocol:
  - `assistant.message.*`
  - `assistant.thinking.delta`
  - `session.tool.*`
- Adds authenticated runtime HTTP/SSE/WebSocket transport with relay support and reconnect handling.
- Adds `PiService`, bootstrap, reconnect, snapshot, and sequenced event reducers.
- Adds runtime-switch protection to reject stale requests and events.
- Preserves hydrated transcripts during reconnect.
- Adds immutable reducer updates and duplicate delta protection.
- Adds sync-layer integration wrappers and documentation.
- Keeps `OpencodeService` unchanged; UI consumer migration remains a follow-up.
## Validation
- Pi UI tests: 74 passed.
- Pi daemon and route tests: 5 passed.
- UI type-check, lint, and build passed.
- Server JavaScript syntax checks passed.
- `git diff --check` passed.
## Remaining Scope
This PR provides the shared foundation only. The main UI has not yet been migrated to consume the Pi-native modules, and live relay end-to-end validation remains future work.