### PR TITLE
Add Pi session runtime registry

### DIFF
--- a/packages/web/server/lib/pi/session-daemon/DOCUMENTATION.md
+++ b/packages/web/server/lib/pi/session-daemon/DOCUMENTATION.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This module is the Pi-owned session-daemon foundation. A detached local daemon process creates one `AgentSessionRuntime` with the Pi SDK, keeps it behind a private local socket, and maps a small event subset to the PiChamber IPC contract. Browsers never connect to it.
+This module is the Pi-owned session-daemon foundation. A detached local daemon process creates an `AgentSessionRuntime` with the Pi SDK, tracks it in a registry keyed by Pi session identity and cwd, keeps it behind a private local socket, and maps a small event subset to the PiChamber IPC contract. Browsers never connect to it.
 
 ## Entrypoints
 
@@ -11,6 +11,7 @@ This module is the Pi-owned session-daemon foundation. A detached local daemon p
   - `createSessionDaemon(options)` starts/stops the authenticated local socket daemon and validates its endpoint and setup inputs.
 - `daemon-process.js` is the detached private-process entrypoint. It reads the daemon credential from its owner-only sidecar, starts the socket, writes non-secret identity state only after readiness, and removes only its own state on signal shutdown.
 - `ipc-client.js` is the server-only authenticated request client. It owns JSONL framing and never exposes endpoint or credential values to callers.
+- `runtime-registry.js` owns active runtime identities and session-local subscriptions. It rebinds the subscription after an SDK session replacement, rejects identity conflicts rather than displacing another runtime, and attempts every tracked disposal even when another disposal fails.
 - `supervisor.js` resolves server-only overrides, creates the credential, serializes start/reuse/stop through an owner-only lock, validates daemon identity through `runtime.health`, and starts or stops the detached process.
 - `../routes.js` registers the authenticated public `GET /api/pi/runtime` adapter. It returns only protocol/state/capabilities or a stable unavailable code.
 - `*.test.js` uses temporary cwd, agent, data, and runtime directories; it never loads a developer's Pi home, credentials, or sessions.
@@ -25,10 +26,11 @@ This module is the Pi-owned session-daemon foundation. A detached local daemon p
 - Frames are LF-delimited JSON. They have a 1 MiB maximum buffered size. A malformed, oversized, unauthenticated, or invalid request closes the connection.
 - The current spike supports `runtime.health` and `sessions.prompt`. It maps text/thinking deltas, tool lifecycle, queue changes, and agent lifecycle to the canonical event names in `docs/pichamber-pi-workstream-0.md`.
 - Each event and reconnect snapshot has a monotonic sequence. A reconnect receives `session.snapshot`; unavailable runtimes are not represented as empty sessions.
+- Registry keys combine the SDK session ID with its cwd. A replacement subscription is rebound to the replacement session so old-session events cannot be published under the new identity. A collision is a visible error; it never replaces or disposes an unrelated runtime.
 - The daemon owns the runtime after clients disconnect. Disconnecting the web-server client cannot stop active Pi work.
 
 ## Deliberate limits
 
-This is not a session/UI migration. `GET /api/pi/runtime` is the only public adapter and the daemon still has one runtime/session rather than a directory-scoped registry. It does not expose project/session collection operations, provider operations, queue policy, replay persistence, or recovery after a forced daemon crash. Those remain later daemon and API work.
+This is not a session/UI migration. `GET /api/pi/runtime` is the only public adapter. The registry currently tracks the daemon's initial runtime; project/session collection operations that select, create, or reuse registry entries are not exposed yet. Provider operations, queue policy, idle disposal, replay persistence, malformed-JSONL reporting, and recovery after a forced daemon crash remain later daemon and API work.
 
 The Pi SDK is pinned exactly at `0.84.1`. Any Pi 0.x minor upgrade requires a deliberate SDK/release-note review and repeat of this module's disposable-runtime smoke validation.

--- a/packages/web/server/lib/pi/session-daemon/runtime-registry.js
+++ b/packages/web/server/lib/pi/session-daemon/runtime-registry.js
@@ -1,0 +1,121 @@
+class SessionRuntimeRegistryError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.code = code;
+  }
+}
+
+const identityKey = ({ cwd, sessionId }) => JSON.stringify([cwd, sessionId]);
+
+const getIdentity = (runtime, session, fallbackCwd) => {
+  const cwd = typeof runtime?.cwd === 'string' && runtime.cwd.length > 0 ? runtime.cwd : fallbackCwd;
+  const sessionId = session?.sessionId;
+  if (typeof cwd !== 'string' || cwd.length === 0 || typeof sessionId !== 'string' || sessionId.length === 0) {
+    throw new SessionRuntimeRegistryError('INVALID_SESSION_RUNTIME', 'The Pi session runtime identity is invalid.');
+  }
+  return { cwd, sessionId, key: identityKey({ cwd, sessionId }) };
+};
+
+/**
+ * Owns active Pi SDK runtime identities and session-local event subscriptions.
+ * Runtime replacement is serialized by the SDK; this registry rebinds only
+ * after the SDK has installed the replacement session.
+ */
+export function createSessionRuntimeRegistry({ onSessionEvent = () => {} } = {}) {
+  const recordsByKey = new Map();
+  const recordsByRuntime = new Map();
+
+  const subscribe = (record, session) => {
+    if (typeof session?.subscribe !== 'function') {
+      throw new SessionRuntimeRegistryError('INVALID_SESSION_RUNTIME', 'The Pi session runtime cannot subscribe to session events.');
+    }
+    record.session = session;
+    record.unsubscribe = session.subscribe((event) => {
+      onSessionEvent({ cwd: record.identity.cwd, sessionId: record.identity.sessionId }, event);
+    });
+  };
+
+  const rebind = async (record, session) => {
+    const nextIdentity = getIdentity(record.runtime, session, record.identity.cwd);
+    const conflictingRecord = recordsByKey.get(nextIdentity.key);
+    if (conflictingRecord && conflictingRecord !== record) {
+      throw new SessionRuntimeRegistryError('SESSION_RUNTIME_CONFLICT', 'A Pi runtime already owns this session and directory.');
+    }
+
+    record.unsubscribe?.();
+    recordsByKey.delete(record.identity.key);
+    record.identity = nextIdentity;
+    recordsByKey.set(nextIdentity.key, record);
+    subscribe(record, session);
+  };
+
+  const register = (runtime, { cwd } = {}) => {
+    const existingRecord = recordsByRuntime.get(runtime);
+    if (existingRecord) return { ...existingRecord.identity };
+
+    const identity = getIdentity(runtime, runtime?.session, cwd);
+    const conflictingRecord = recordsByKey.get(identity.key);
+    if (conflictingRecord && conflictingRecord.runtime !== runtime) {
+      throw new SessionRuntimeRegistryError('SESSION_RUNTIME_CONFLICT', 'A Pi runtime already owns this session and directory.');
+    }
+
+    const record = { runtime, identity, session: undefined, unsubscribe: undefined };
+    recordsByKey.set(identity.key, record);
+    recordsByRuntime.set(runtime, record);
+    try {
+      subscribe(record, runtime.session);
+      if (typeof runtime.setRebindSession === 'function') {
+        runtime.setRebindSession((session) => rebind(record, session));
+      }
+    } catch (error) {
+      record.unsubscribe?.();
+      recordsByKey.delete(identity.key);
+      recordsByRuntime.delete(runtime);
+      throw error;
+    }
+    return { ...identity };
+  };
+
+  const dispose = async (runtime) => {
+    const record = recordsByRuntime.get(runtime);
+    if (!record) return false;
+
+    record.unsubscribe?.();
+    try {
+      await runtime.dispose?.();
+    } catch (error) {
+      subscribe(record, record.session);
+      throw error;
+    }
+
+    runtime.setRebindSession?.(undefined);
+    recordsByKey.delete(record.identity.key);
+    recordsByRuntime.delete(runtime);
+    return true;
+  };
+
+  const disposeAll = async () => {
+    const errors = [];
+    for (const record of [...recordsByRuntime.values()]) {
+      try {
+        await dispose(record.runtime);
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    if (errors.length > 0) {
+      throw new AggregateError(errors, 'One or more Pi session runtimes could not be disposed.');
+    }
+  };
+
+  return {
+    register,
+    dispose,
+    disposeAll,
+    get size() {
+      return recordsByKey.size;
+    },
+  };
+}
+
+export { SessionRuntimeRegistryError };

--- a/packages/web/server/lib/pi/session-daemon/runtime-registry.test.js
+++ b/packages/web/server/lib/pi/session-daemon/runtime-registry.test.js
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+
+import { createSessionRuntimeRegistry, SessionRuntimeRegistryError } from './runtime-registry.js';
+
+class FakeSession {
+  constructor(sessionId) {
+    this.sessionId = sessionId;
+    this.listeners = new Set();
+  }
+
+  subscribe(listener) {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  emit(event) {
+    for (const listener of this.listeners) listener(event);
+  }
+}
+
+class FakeRuntime {
+  constructor({ cwd, sessionId }) {
+    this.cwd = cwd;
+    this.session = new FakeSession(sessionId);
+    this.rebindSession = undefined;
+    this.disposed = false;
+  }
+
+  setRebindSession(rebindSession) {
+    this.rebindSession = rebindSession;
+  }
+
+  async replace({ cwd = this.cwd, sessionId }) {
+    this.cwd = cwd;
+    this.session = new FakeSession(sessionId);
+    await this.rebindSession?.(this.session);
+  }
+
+  async dispose() {
+    this.disposed = true;
+  }
+}
+
+describe('Pi session runtime registry', () => {
+  it('keys runtime ownership by session identity and cwd, then rebinds events after replacement', async () => {
+    const events = [];
+    const registry = createSessionRuntimeRegistry({
+      onSessionEvent: (identity, event) => events.push({ identity, event }),
+    });
+    const runtime = new FakeRuntime({ cwd: '/projects/one', sessionId: 'session-one' });
+    const originalSession = runtime.session;
+
+    expect(registry.register(runtime)).toEqual({
+      cwd: '/projects/one',
+      sessionId: 'session-one',
+      key: JSON.stringify(['/projects/one', 'session-one']),
+    });
+    originalSession.emit({ type: 'agent_start' });
+
+    await runtime.replace({ cwd: '/projects/two', sessionId: 'session-two' });
+    originalSession.emit({ type: 'agent_settled' });
+    runtime.session.emit({ type: 'agent_settled' });
+
+    expect(events).toEqual([
+      { identity: { cwd: '/projects/one', sessionId: 'session-one' }, event: { type: 'agent_start' } },
+      { identity: { cwd: '/projects/two', sessionId: 'session-two' }, event: { type: 'agent_settled' } },
+    ]);
+    expect(registry.size).toBe(1);
+  });
+
+  it('does not let a session replacement displace a separately tracked runtime', async () => {
+    const registry = createSessionRuntimeRegistry();
+    const firstRuntime = new FakeRuntime({ cwd: '/projects/one', sessionId: 'session-one' });
+    const secondRuntime = new FakeRuntime({ cwd: '/projects/two', sessionId: 'session-two' });
+    registry.register(firstRuntime);
+    registry.register(secondRuntime);
+
+    await expect(secondRuntime.replace({ cwd: '/projects/one', sessionId: 'session-one' })).rejects.toMatchObject({
+      code: 'SESSION_RUNTIME_CONFLICT',
+    });
+    expect(registry.size).toBe(2);
+  });
+
+  it('keeps a failed runtime tracked while disposing unrelated runtimes', async () => {
+    const registry = createSessionRuntimeRegistry();
+    const failingRuntime = new FakeRuntime({ cwd: '/projects/one', sessionId: 'session-one' });
+    failingRuntime.dispose = async () => { throw new Error('disposal failed'); };
+    const healthyRuntime = new FakeRuntime({ cwd: '/projects/two', sessionId: 'session-two' });
+    registry.register(failingRuntime);
+    registry.register(healthyRuntime);
+
+    await expect(registry.disposeAll()).rejects.toBeInstanceOf(AggregateError);
+    expect(failingRuntime.disposed).toBe(false);
+    expect(healthyRuntime.disposed).toBe(true);
+    expect(registry.size).toBe(1);
+  });
+
+  it('rejects invalid runtime identities', () => {
+    const registry = createSessionRuntimeRegistry();
+
+    expect(() => registry.register({ session: new FakeSession('session-one') })).toThrow(SessionRuntimeRegistryError);
+    try {
+      registry.register(new FakeRuntime({ cwd: '/projects/one', sessionId: '' }));
+      throw new Error('Expected invalid runtime identity to be rejected.');
+    } catch (error) {
+      expect(error).toMatchObject({ code: 'INVALID_SESSION_RUNTIME' });
+    }
+  });
+});

--- a/packages/web/server/lib/pi/session-daemon/session-daemon.js
+++ b/packages/web/server/lib/pi/session-daemon/session-daemon.js
@@ -10,6 +10,8 @@ import {
   SessionManager,
 } from '@earendil-works/pi-coding-agent';
 
+import { createSessionRuntimeRegistry } from './runtime-registry.js';
+
 const PROTOCOL_VERSION = 1;
 const MAX_FRAME_BYTES = 1024 * 1024;
 
@@ -80,19 +82,19 @@ export function createSessionDaemon({
 
   let server;
   let runtime;
-  let unsubscribe;
+  let runtimeRegistry;
   let sequence = 0;
   let started = false;
   const clients = new Set();
 
-  const publish = (event, payload) => {
+  const publish = (event, payload, sessionId = runtime?.session?.sessionId) => {
     const message = {
       protocolVersion: PROTOCOL_VERSION,
       kind: 'event',
       event,
       sequence: ++sequence,
       payload: {
-        sessionId: runtime?.session?.sessionId,
+        sessionId,
         ...payload,
       },
     };
@@ -114,47 +116,56 @@ export function createSessionDaemon({
   };
 
   const disposeRuntime = async () => {
-    unsubscribe?.();
-    unsubscribe = undefined;
-    await runtime?.dispose?.();
+    if (runtimeRegistry) {
+      const hadTrackedRuntime = runtimeRegistry.size > 0;
+      await runtimeRegistry.disposeAll();
+      if (!hadTrackedRuntime) await runtime?.dispose?.();
+      runtimeRegistry = undefined;
+    } else {
+      await runtime?.dispose?.();
+    }
     runtime = undefined;
   };
 
-  const bindSession = () => {
-    unsubscribe?.();
-    unsubscribe = runtime.session.subscribe((event) => {
-      switch (event.type) {
-        case 'message_update': {
-          const update = event.assistantMessageEvent;
-          if (update.type === 'text_delta') {
-            publish('assistant.message.delta', { contentIndex: update.contentIndex, delta: update.delta });
-          } else if (update.type === 'thinking_delta') {
-            publish('assistant.thinking.delta', { contentIndex: update.contentIndex, delta: update.delta });
-          }
-          break;
+  const publishSessionEvent = (sessionId, event) => {
+    switch (event.type) {
+      case 'message_update': {
+        const update = event.assistantMessageEvent;
+        if (update.type === 'text_delta') {
+          publish('assistant.message.delta', { contentIndex: update.contentIndex, delta: update.delta }, sessionId);
+        } else if (update.type === 'thinking_delta') {
+          publish('assistant.thinking.delta', { contentIndex: update.contentIndex, delta: update.delta }, sessionId);
         }
-        case 'tool_execution_start':
-          publish('session.tool.start', { toolCallId: event.toolCallId, toolName: event.toolName });
-          break;
-        case 'tool_execution_update':
-          publish('session.tool.update', { toolCallId: event.toolCallId, toolName: event.toolName });
-          break;
-        case 'tool_execution_end':
-          publish('session.tool.end', { toolCallId: event.toolCallId, toolName: event.toolName, isError: event.isError });
-          break;
-        case 'queue_update':
-          publish('session.queue', { steering: event.steering.length, followUp: event.followUp.length });
-          break;
-        case 'agent_start':
-          publish('session.lifecycle', { state: 'running' });
-          break;
-        case 'agent_settled':
-          publish('session.lifecycle', { state: 'idle' });
-          break;
-        default:
-          break;
+        break;
       }
+      case 'tool_execution_start':
+        publish('session.tool.start', { toolCallId: event.toolCallId, toolName: event.toolName }, sessionId);
+        break;
+      case 'tool_execution_update':
+        publish('session.tool.update', { toolCallId: event.toolCallId, toolName: event.toolName }, sessionId);
+        break;
+      case 'tool_execution_end':
+        publish('session.tool.end', { toolCallId: event.toolCallId, toolName: event.toolName, isError: event.isError }, sessionId);
+        break;
+      case 'queue_update':
+        publish('session.queue', { steering: event.steering.length, followUp: event.followUp.length }, sessionId);
+        break;
+      case 'agent_start':
+        publish('session.lifecycle', { state: 'running' }, sessionId);
+        break;
+      case 'agent_settled':
+        publish('session.lifecycle', { state: 'idle' }, sessionId);
+        break;
+      default:
+        break;
+    }
+  };
+
+  const bindSession = () => {
+    runtimeRegistry = createSessionRuntimeRegistry({
+      onSessionEvent: ({ sessionId }, event) => publishSessionEvent(sessionId, event),
     });
+    runtimeRegistry.register(runtime, { cwd });
   };
 
   const handleRequest = (socket, message) => {

--- a/packages/web/server/lib/pi/session-daemon/session-daemon.test.js
+++ b/packages/web/server/lib/pi/session-daemon/session-daemon.test.js
@@ -10,8 +10,8 @@ import { createSessionDaemon } from './session-daemon.js';
 const credential = 'a-private-daemon-credential';
 
 class FakeSession {
-  constructor() {
-    this.sessionId = 'pi-session-1';
+  constructor(sessionId = 'pi-session-1') {
+    this.sessionId = sessionId;
     this.isStreaming = false;
     this.listeners = new Set();
   }
@@ -26,6 +26,25 @@ class FakeSession {
   }
 
   async prompt() {}
+}
+
+class FakeRuntime {
+  constructor({ cwd, session }) {
+    this.cwd = cwd;
+    this.session = session;
+    this.rebindSession = undefined;
+  }
+
+  setRebindSession(rebindSession) {
+    this.rebindSession = rebindSession;
+  }
+
+  async replaceSession(session) {
+    this.session = session;
+    await this.rebindSession?.(session);
+  }
+
+  async dispose() {}
 }
 
 function connectClient(endpoint) {
@@ -161,6 +180,39 @@ describe('Pi session daemon spike', () => {
     });
     expect((await delta).sequence).toBeGreaterThan(reconnectSnapshot.sequence);
     await reconnectingClient.close();
+  });
+
+  it('rebinds daemon events to the replacement Pi session identity', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'pichamber-pi-daemon-'));
+    const endpoint = join(root, 'daemon.sock');
+    const firstSession = new FakeSession('pi-session-1');
+    const runtime = new FakeRuntime({ cwd: root, session: firstSession });
+    daemon = createSessionDaemon({
+      endpoint,
+      credential,
+      cwd: root,
+      createRuntime: async () => runtime,
+    });
+    await daemon.start();
+
+    const client = connectClient(endpoint);
+    await client.authenticate();
+    const replacementSession = new FakeSession('pi-session-2');
+    await runtime.replaceSession(replacementSession);
+    firstSession.emit({
+      type: 'message_update',
+      assistantMessageEvent: { type: 'text_delta', contentIndex: 0, delta: 'stale' },
+    });
+    const delta = client.next((message) => message.event === 'assistant.message.delta');
+    replacementSession.emit({
+      type: 'message_update',
+      assistantMessageEvent: { type: 'text_delta', contentIndex: 0, delta: 'current' },
+    });
+
+    await expect(delta).resolves.toMatchObject({
+      payload: { sessionId: 'pi-session-2', contentIndex: 0, delta: 'current' },
+    });
+    await client.close();
   });
 
   it('rejects non-local endpoints and unauthenticated clients before a request can reach the runtime', async () => {


### PR DESCRIPTION
## Intent

Track each private Pi session runtime by its SDK session identity and cwd, so session-local event subscriptions follow SDK session replacement without publishing stale events under a new session.

## Non-goals

This does not add browser-facing routes, session selection/collection commands, idle disposal policy, malformed-session handling, or crash recovery.

## Affected surfaces

- `packages/web` private session daemon: runtime ownership, session event delivery, and shutdown cleanup.
- No public HTTP/WebSocket contract, persisted format, or rendered UI changes.
- Electron receives no shell change; it continues to use the shared web backend boundary.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` runtime boundaries | The change owns agent-runtime lifecycle in the web server. | Keeps the daemon private and browser-independent; no Electron sidecar or renderer capability was added. |
| `openchamber-change-discipline` | Adds server modules and changes the daemon lifecycle contract. | Uses focused ownership, documents the module invariant, traces cleanup failure behavior, and runs focused tests plus required checks. |
| `sync-state-invariants` | Session replacement and streamed events can otherwise apply stale state. | Event listeners capture the identity at bind time; replacement detaches the old listener before binding the new session, and conflicts cannot displace an unrelated runtime. |
| `packages/web/README.md` and `session-daemon/DOCUMENTATION.md` | They define the owning package and private-daemon constraints. | Updated the owning module documentation and retained the local authenticated socket boundary. |

## Validation

| Check | Result |
|---|---|
| `bun run --cwd packages/web test server/lib/pi/session-daemon/runtime-registry.test.js server/lib/pi/session-daemon/session-daemon.test.js server/lib/pi/session-daemon/supervisor.test.js server/lib/pi/routes.test.js` | Passed: 4 files, 11 tests. |
| `bun run type-check:web` | Passed. |
| `bun run lint:web` | Passed. |
| `node --check` on changed daemon JS/test files | Passed. |
| `git diff --check` | Passed. |
| `bun run dead-code` | Completed; reported existing unused symbols/types, with no registry entries in the report. |

## Visual evidence

No rendered behavior changed: this modifies only the private server daemon and its tests.

## Risks and failure behavior

A replacement event cannot be attributed to the prior session because the old subscription is removed before the replacement subscription is installed. A duplicate identity is rejected rather than replacing or disposing another runtime. Shutdown attempts every tracked runtime even if a prior disposal fails; a failed runtime remains tracked and the caller receives an error rather than a false successful cleanup result. The remaining session operations, recovery, and public API work are intentionally outside this change.
