### PR TITLE
Complete Pi daemon recovery lifecycle

### DIFF
--- a/docs/pichamber-pi-workstream-1.md
+++ b/docs/pichamber-pi-workstream-1.md
@@ -2,7 +2,7 @@
 
 ## Status and scope
 
-This record covers the initial daemon-lifecycle implementation following the completed boundary and SDK spike in [the Workstream 0 record](./pichamber-pi-workstream-0.md). It makes the private Pi runtime independently supervised by the web server and exposes only authenticated public health. It is not a session/UI cutover and does not create a supported OpenCode/Pi runtime choice.
+This record covers the completed daemon-lifecycle work following the boundary and SDK spike in [the Workstream 0 record](./pichamber-pi-workstream-0.md). It makes the private Pi runtime independently supervised by the web server, records active runtimes by authoritative Pi identity plus cwd, and exposes only authenticated public health. It is not a session/UI cutover and does not create a supported OpenCode/Pi runtime choice.
 
 ## Implemented ownership
 
@@ -13,6 +13,8 @@ This record covers the initial daemon-lifecycle implementation following the com
 | Private client | `ipc-client.js` | The server reaches the daemon with its local credential over JSONL IPC. The module owns framing/timeouts and gives callers stable errors rather than an empty runtime result. |
 | Public health adapter | `packages/web/server/lib/pi/routes.js` | `GET /api/pi/runtime` is registered before the generic OpenCode proxy and returns only `protocolVersion`, `state`, `capabilities`, or a stable unavailable error code. It never returns endpoint, key, PID, cwd, agent directory, or session data. |
 | Web lifecycle | `packages/web/server/index.js` | The server starts the daemon after its listener is ready and attempts a graceful daemon stop before HTTP shutdown. A startup failure leaves the route available with `503`/`DAEMON_*`, not a fabricated idle or empty response. |
+| Runtime registry and idle lifecycle | `packages/web/server/lib/pi/session-daemon/runtime-registry.js`, `session-daemon.js` | Active SDK runtimes use `{ cwd, sessionId }` identity. Replacement detaches the old listener before binding the new session; duplicate ownership is rejected. An `agent_settled` runtime is disposed after the daemon's five-minute idle timeout, without deleting Pi JSONL, and is recreated from the remembered session file on the next private prompt. |
+| JSONL validation and crash recovery | `session-jsonl.js`, `daemon-process.js`, `supervisor.js` | The daemon validates every cwd-scoped Pi JSONL candidate rather than accepting Pi discovery's best-effort omission. Malformed/unreadable files produce stable failure codes in the owner-only state sidecar. After a forced crash, the supervisor removes a stale POSIX socket only after the recorded PID is dead and the socket is unreachable through the authenticated client. |
 
 ## Local files and permissions
 
@@ -31,15 +33,16 @@ An existing socket that cannot be authenticated and matched to the state PID is 
 ## Runtime behavior
 
 - The supervisor honors `OPENCHAMBER_DATA_DIR`, `OPENCHAMBER_PI_AGENT_DIR`, and `OPENCHAMBER_PI_SESSION_DAEMON_ENDPOINT` only on the server.
-- The Pi runtime now uses `SessionManager.create(cwd)` without overriding Pi's default session directory, preserving Pi's normal cwd-scoped session discovery.
+- The Pi runtime resolves its cwd-scoped session directory from the configured Pi agent directory, preserving Pi's normal `sessions/<encoded-cwd>` discovery layout while honoring the server-only agent override.
 - The private health response includes a daemon PID only for supervisor identity verification. The public adapter strips it.
+- A valid owner-only failure sidecar makes health explicitly unavailable with `MALFORMED_SESSION_JSONL` or `SESSION_JSONL_UNREADABLE`; it never becomes an empty session list or synthetic idle state.
 - The server's existing authenticated `/api` middleware protects `/api/pi/runtime`; the adapter is registered before the generic OpenCode `/api/*` proxy.
 - Shutdown is best-effort only after the same private health/identity verification. It cannot signal an arbitrary PID from a stale sidecar.
 
 ## Deliberate limits
 
-This foundation still has one active runtime/session in the daemon. It does not yet implement the Workstream 1 registry and directory-scoping responsibilities, Pi session list/create/open/delete/tree/fork/clone operations, session replacement rebinding, idle runtime disposal, malformed-JSONL reporting, queue policy, replay persistence, or forced-crash interruption/recovery. The only public Pi route is runtime health; session routes and public event streaming are later contract work.
+The daemon currently restores only the single last-active runtime after idle disposal. Pi session collection/mutation commands, queue policy, replay persistence, session routes, and public event streaming are later IPC/API work. The only public Pi route remains runtime health.
 
 ## Validation evidence
 
-Focused tests use temporary PiChamber data roots, XDG runtime directories, project directories, and Pi agent directories with `PI_OFFLINE=1`. They verify real detached daemon start/reuse/health/stop, sidecar key mode, no secret in health output, socket authentication/reconnect behavior, and public health response redaction/unavailable status. They do not exercise Windows pipe ACLs, a live model provider, full server startup, or the deferred registry/recovery operations.
+Focused tests use temporary PiChamber data roots, XDG runtime directories, project directories, and Pi agent directories with `PI_OFFLINE=1`. They verify real detached daemon start/reuse/health/stop, sidecar key mode, no secret in health output, socket authentication/reconnect behavior, identity-plus-cwd registry rebinding/conflict behavior, idle disposal without JSONL deletion and rehydration, malformed/unreadable JSONL failures, forced-`SIGKILL` crash recovery, and public health response redaction/unavailable status. They do not exercise Windows pipe ACLs, a live model provider, full server startup, or future IPC/API commands.

--- a/docs/pichamber-pimigration.md
+++ b/docs/pichamber-pimigration.md
@@ -482,8 +482,8 @@ This is a dependency-based implementation timeline, not a calendar commitment. E
 | Window | Deliverable | Exit gate |
 | --- | --- | --- |
 | Completed foundation | Boundary and lifecycle prerequisites | The Workstream 0 spike, private daemon lifecycle, and shared-client foundations are recorded separately. They are prerequisites only and do not satisfy a later workstream exit gate. |
-| Next dependency gate | Daemon registry and recovery | Workstream 1’s identity-plus-cwd registry, replacement rebinding, idle disposal, malformed-session failure, and crash recovery have focused tests. |
-| Then | Complete IPC and authenticated API | Workstream 2’s command/event families, queue policy, snapshot resume, and authenticated public adapters pass focused daemon, route, and transport tests. |
+| Completed workstream | Daemon registry and recovery | Workstream 1’s identity-plus-cwd registry, replacement rebinding, idle disposal, malformed-session failure, and crash recovery have focused tests. |
+| Next dependency gate | Complete IPC and authenticated API | Workstream 2’s command/event families, queue policy, snapshot resume, and authenticated public adapters pass focused daemon, route, and transport tests. |
 | Then | Pi-native web UI cutover | Workstream 3’s service/store replacement powers session list, transcript, prompt, steer/follow-up, abort, model/thinking, tree/fork/clone, reconnect, and interrupted/error states in the web UI. |
 | Subsequent | Pi settings, providers, resources | Pi auth/models/settings integration, PiChamber defaults, provider UI, trust, AGENTS.md, native skills/templates, Magic Prompts, and extension-disabled policy work end to end. |
 | Subsequent | Core server workspace integrations | Filesystem, terminal, Git, temporary path attachments, direct local/VPS connection, trusted-device auth, and Electron daemon lifecycle are usable. |

--- a/packages/ui/src/lib/pi/protocol.ts
+++ b/packages/ui/src/lib/pi/protocol.ts
@@ -56,7 +56,10 @@ export type PiErrorCode =
   | 'ATTACHMENT_TOO_LARGE'
   | 'ATTACHMENT_MISSING'
   | 'DAEMON_ENDPOINT_UNVERIFIED'
-  | 'DAEMON_CREDENTIAL_UNAVAILABLE';
+  | 'DAEMON_CREDENTIAL_UNAVAILABLE'
+  | 'MALFORMED_SESSION_JSONL'
+  | 'SESSION_JSONL_UNREADABLE'
+  | 'RUNTIME_DISPOSAL_FAILED';
 
 /** A stable error object returned in response and event payloads. */
 export interface PiError {

--- a/packages/web/server/lib/pi/session-daemon/DOCUMENTATION.md
+++ b/packages/web/server/lib/pi/session-daemon/DOCUMENTATION.md
@@ -12,6 +12,7 @@ This module is the Pi-owned session-daemon foundation. A detached local daemon p
 - `daemon-process.js` is the detached private-process entrypoint. It reads the daemon credential from its owner-only sidecar, starts the socket, writes non-secret identity state only after readiness, and removes only its own state on signal shutdown.
 - `ipc-client.js` is the server-only authenticated request client. It owns JSONL framing and never exposes endpoint or credential values to callers.
 - `runtime-registry.js` owns active runtime identities and session-local subscriptions. It rebinds the subscription after an SDK session replacement, rejects identity conflicts rather than displacing another runtime, and attempts every tracked disposal even when another disposal fails.
+- `session-jsonl.js` validates the cwd-scoped Pi JSONL directory before session discovery. Pi's SDK deliberately skips malformed discovery entries; this boundary maps malformed, missing, and unreadable candidates to stable explicit failures instead of an empty result.
 - `supervisor.js` resolves server-only overrides, creates the credential, serializes start/reuse/stop through an owner-only lock, validates daemon identity through `runtime.health`, and starts or stops the detached process.
 - `../routes.js` registers the authenticated public `GET /api/pi/runtime` adapter. It returns only protocol/state/capabilities or a stable unavailable code.
 - `*.test.js` uses temporary cwd, agent, data, and runtime directories; it never loads a developer's Pi home, credentials, or sessions.
@@ -27,10 +28,13 @@ This module is the Pi-owned session-daemon foundation. A detached local daemon p
 - The current spike supports `runtime.health` and `sessions.prompt`. It maps text/thinking deltas, tool lifecycle, queue changes, and agent lifecycle to the canonical event names in `docs/pichamber-pi-workstream-0.md`.
 - Each event and reconnect snapshot has a monotonic sequence. A reconnect receives `session.snapshot`; unavailable runtimes are not represented as empty sessions.
 - Registry keys combine the SDK session ID with its cwd. A replacement subscription is rebound to the replacement session so old-session events cannot be published under the new identity. A collision is a visible error; it never replaces or disposes an unrelated runtime.
+- After `agent_settled`, the daemon disposes an idle runtime after five minutes (injectable for tests). Disposal never deletes Pi JSONL; the daemon remembers the selected session file and recreates that runtime on the next private prompt. A new agent start cancels a pending disposal.
+- A startup validation failure writes only a stable failure code to the owner-only non-secret state sidecar. It never records a transcript, session path, or credential. The supervisor surfaces that code as unavailable instead of claiming an empty or idle session.
+- After a forced crash, the supervisor removes an existing POSIX socket only when its recorded daemon PID is dead, the endpoint is a socket, and the endpoint is unreachable through the authenticated client. An endpoint that responds or cannot be classified remains `DAEMON_ENDPOINT_UNVERIFIED`.
 - The daemon owns the runtime after clients disconnect. Disconnecting the web-server client cannot stop active Pi work.
 
 ## Deliberate limits
 
-This is not a session/UI migration. `GET /api/pi/runtime` is the only public adapter. The registry currently tracks the daemon's initial runtime; project/session collection operations that select, create, or reuse registry entries are not exposed yet. Provider operations, queue policy, idle disposal, replay persistence, malformed-JSONL reporting, and recovery after a forced daemon crash remain later daemon and API work.
+This is not a session/UI migration. `GET /api/pi/runtime` is the only public adapter. Project/session collection operations that select, create, or reuse registry entries, provider operations, queue policy, and replay persistence belong to the later IPC/API work. The current private prompt is retained only as the lifecycle smoke path; it is not a browser contract.
 
 The Pi SDK is pinned exactly at `0.84.1`. Any Pi 0.x minor upgrade requires a deliberate SDK/release-note review and repeat of this module's disposable-runtime smoke validation.

--- a/packages/web/server/lib/pi/session-daemon/daemon-process.js
+++ b/packages/web/server/lib/pi/session-daemon/daemon-process.js
@@ -20,19 +20,28 @@ const exitWithFailure = (code) => {
   process.exitCode = code;
 };
 
-const writeState = async () => {
+const writeState = async (state) => {
   const temporaryPath = `${stateFile}.${process.pid}.tmp`;
-  const state = JSON.stringify({
-    protocolVersion: 1,
-    pid: process.pid,
-    endpoint,
-    startedAt: new Date().toISOString(),
-  });
-  await writeFile(temporaryPath, state, { mode: 0o600 });
+  await writeFile(temporaryPath, JSON.stringify(state), { mode: 0o600 });
   await chmod(temporaryPath, 0o600);
   await rename(temporaryPath, stateFile);
   await chmod(stateFile, 0o600);
 };
+
+const writeReadyState = () => writeState({
+  protocolVersion: 1,
+  pid: process.pid,
+  endpoint,
+  startedAt: new Date().toISOString(),
+});
+
+const writeFailureState = (code) => writeState({
+  protocolVersion: 1,
+  pid: process.pid,
+  endpoint,
+  state: 'failed',
+  error: { code },
+});
 
 const removeOwnState = async () => {
   try {
@@ -58,14 +67,22 @@ if (!endpoint || !credentialFile || !stateFile || !cwd) {
       healthMetadata: { daemonPid: process.pid },
     });
     await daemon.start();
-    await writeState();
-  } catch {
+    await writeReadyState();
+  } catch (error) {
     try {
       await daemon?.stop();
     } catch {
       // Process exit closes the local listener if startup cleanup also failed.
     }
-    await removeOwnState();
+    if (error?.code === 'MALFORMED_SESSION_JSONL' || error?.code === 'SESSION_JSONL_UNREADABLE') {
+      try {
+        await writeFailureState(error.code);
+      } catch {
+        // The supervisor will report the generic startup failure when the sidecar cannot be written.
+      }
+    } else {
+      await removeOwnState();
+    }
     exitWithFailure(1);
   }
 

--- a/packages/web/server/lib/pi/session-daemon/ipc-client.js
+++ b/packages/web/server/lib/pi/session-daemon/ipc-client.js
@@ -35,7 +35,7 @@ export const requestSessionDaemon = ({ endpoint, credential, command, payload, t
   const fail = (code) => finish(reject, new SessionDaemonClientError(code));
 
   timer = setTimeout(() => fail('DAEMON_UNAVAILABLE'), timeoutMs);
-  socket.once('error', () => fail('DAEMON_UNAVAILABLE'));
+  socket.once('error', (error) => fail(error?.code === 'ECONNREFUSED' ? 'DAEMON_CONNECTION_REFUSED' : 'DAEMON_UNAVAILABLE'));
   socket.on('connect', () => {
     socket.write(`${JSON.stringify({ kind: 'authenticate', credential })}\n`);
   });

--- a/packages/web/server/lib/pi/session-daemon/session-daemon.js
+++ b/packages/web/server/lib/pi/session-daemon/session-daemon.js
@@ -11,6 +11,7 @@ import {
 } from '@earendil-works/pi-coding-agent';
 
 import { createSessionRuntimeRegistry } from './runtime-registry.js';
+import { getPiSessionDirectory, validatePiSessionJsonlDirectory, validatePiSessionJsonlFile } from './session-jsonl.js';
 
 const PROTOCOL_VERSION = 1;
 const MAX_FRAME_BYTES = 1024 * 1024;
@@ -32,7 +33,7 @@ export function isLocalSessionDaemonEndpoint(endpoint, platform = process.platfo
   return isAbsolute(endpoint);
 }
 
-async function createPiSessionRuntime({ cwd, agentDir = getAgentDir() }) {
+async function createPiSessionRuntime({ cwd, agentDir = getAgentDir(), sessionFile }) {
   const createRuntime = async ({ cwd: runtimeCwd, agentDir: runtimeAgentDir, sessionManager, sessionStartEvent }) => {
     const services = await createAgentSessionServices({
       cwd: runtimeCwd,
@@ -57,7 +58,9 @@ async function createPiSessionRuntime({ cwd, agentDir = getAgentDir() }) {
   return createAgentSessionRuntime(createRuntime, {
     cwd,
     agentDir,
-    sessionManager: SessionManager.create(cwd),
+    sessionManager: sessionFile
+      ? SessionManager.open(sessionFile, getPiSessionDirectory({ cwd, agentDir }), cwd)
+      : SessionManager.create(cwd, getPiSessionDirectory({ cwd, agentDir })),
   });
 }
 
@@ -68,6 +71,7 @@ export function createSessionDaemon({
   agentDir = getAgentDir(),
   createRuntime = createPiSessionRuntime,
   healthMetadata = {},
+  idleTimeoutMs = 5 * 60 * 1_000,
   platform = process.platform,
 } = {}) {
   if (!isLocalSessionDaemonEndpoint(endpoint, platform)) {
@@ -79,10 +83,16 @@ export function createSessionDaemon({
   if (typeof cwd !== 'string' || cwd.length === 0) {
     throw new SessionDaemonProtocolError('INVALID_CWD', 'The session daemon working directory is invalid.');
   }
+  if (!Number.isFinite(idleTimeoutMs) || idleTimeoutMs < 0) {
+    throw new SessionDaemonProtocolError('INVALID_IDLE_TIMEOUT', 'The session daemon idle timeout is invalid.');
+  }
 
   let server;
   let runtime;
   let runtimeRegistry;
+  let runtimeStartPromise;
+  let idleDisposeTimer;
+  let dormantSession;
   let sequence = 0;
   let started = false;
   const clients = new Set();
@@ -101,21 +111,41 @@ export function createSessionDaemon({
     for (const client of clients) writeFrame(client, message);
   };
 
+  const getSessionState = () => runtime
+    ? { sessionId: runtime.session.sessionId, isStreaming: runtime.session.isStreaming }
+    : { sessionId: dormantSession?.sessionId, isStreaming: false };
+
+  const rememberRuntimeSession = () => {
+    const sessionId = runtime?.session?.sessionId;
+    if (typeof sessionId !== 'string' || sessionId.length === 0) return;
+    dormantSession = {
+      sessionId,
+      sessionFile: runtime.session.sessionManager?.getSessionFile?.(),
+    };
+  };
+
   const publishSnapshot = (socket) => {
+    const session = getSessionState();
     writeFrame(socket, {
       protocolVersion: PROTOCOL_VERSION,
       kind: 'event',
       event: 'session.snapshot',
       sequence: ++sequence,
       payload: {
-        sessionId: runtime.session.sessionId,
-        isStreaming: runtime.session.isStreaming,
+        sessionId: session.sessionId,
+        isStreaming: session.isStreaming,
         lastSequence: sequence,
       },
     });
   };
 
+  const clearIdleDisposal = () => {
+    if (idleDisposeTimer) clearTimeout(idleDisposeTimer);
+    idleDisposeTimer = undefined;
+  };
+
   const disposeRuntime = async () => {
+    clearIdleDisposal();
     if (runtimeRegistry) {
       const hadTrackedRuntime = runtimeRegistry.size > 0;
       await runtimeRegistry.disposeAll();
@@ -125,6 +155,34 @@ export function createSessionDaemon({
       await runtime?.dispose?.();
     }
     runtime = undefined;
+  };
+
+  const startRuntime = async ({ sessionFile } = {}) => {
+    if (sessionFile) await validatePiSessionJsonlFile(sessionFile);
+    runtime = await createRuntime({ cwd, agentDir, ...(sessionFile ? { sessionFile } : {}) });
+    bindSession();
+    rememberRuntimeSession();
+    return runtime;
+  };
+
+  const ensureRuntime = () => {
+    if (runtime) return Promise.resolve(runtime);
+    if (!runtimeStartPromise) {
+      runtimeStartPromise = startRuntime({ sessionFile: dormantSession?.sessionFile }).finally(() => {
+        runtimeStartPromise = undefined;
+      });
+    }
+    return runtimeStartPromise;
+  };
+
+  const scheduleIdleDisposal = (sessionId) => {
+    clearIdleDisposal();
+    idleDisposeTimer = setTimeout(() => {
+      idleDisposeTimer = undefined;
+      if (!runtime || runtime.session.sessionId !== sessionId || runtime.session.isStreaming) return;
+      rememberRuntimeSession();
+      void disposeRuntime().catch(() => publish('session.error', { code: 'RUNTIME_DISPOSAL_FAILED' }, sessionId));
+    }, idleTimeoutMs);
   };
 
   const publishSessionEvent = (sessionId, event) => {
@@ -151,10 +209,12 @@ export function createSessionDaemon({
         publish('session.queue', { steering: event.steering.length, followUp: event.followUp.length }, sessionId);
         break;
       case 'agent_start':
+        clearIdleDisposal();
         publish('session.lifecycle', { state: 'running' }, sessionId);
         break;
       case 'agent_settled':
         publish('session.lifecycle', { state: 'idle' }, sessionId);
+        scheduleIdleDisposal(sessionId);
         break;
       default:
         break;
@@ -181,7 +241,7 @@ export function createSessionDaemon({
           requestId: message.requestId,
           result: {
             state: 'ready',
-            sessionId: runtime.session.sessionId,
+            sessionId: getSessionState().sessionId,
             lastSequence: sequence,
             ...(Number.isInteger(healthMetadata.daemonPid) ? { daemonPid: healthMetadata.daemonPid } : {}),
           },
@@ -192,8 +252,8 @@ export function createSessionDaemon({
         if (typeof text !== 'string' || text.length === 0 || Buffer.byteLength(text) > 64 * 1024) {
           throw new SessionDaemonProtocolError('INVALID_PROMPT', 'The session prompt is invalid.');
         }
-        void runtime.session.prompt(text).catch(() => {
-          publish('session.error', { code: 'PROMPT_FAILED' });
+        void ensureRuntime().then((activeRuntime) => activeRuntime.session.prompt(text)).catch((error) => {
+          publish('session.error', { code: error?.code ?? 'PROMPT_FAILED' }, getSessionState().sessionId);
         });
         writeFrame(socket, {
           protocolVersion: PROTOCOL_VERSION,
@@ -271,8 +331,8 @@ export function createSessionDaemon({
     },
     async start() {
       if (started) return;
-      runtime = await createRuntime({ cwd, agentDir });
-      bindSession();
+      await validatePiSessionJsonlDirectory({ cwd, agentDir });
+      await startRuntime();
 
       try {
         if (platform !== 'win32') {

--- a/packages/web/server/lib/pi/session-daemon/session-daemon.test.js
+++ b/packages/web/server/lib/pi/session-daemon/session-daemon.test.js
@@ -10,10 +10,11 @@ import { createSessionDaemon } from './session-daemon.js';
 const credential = 'a-private-daemon-credential';
 
 class FakeSession {
-  constructor(sessionId = 'pi-session-1') {
+  constructor(sessionId = 'pi-session-1', sessionFile) {
     this.sessionId = sessionId;
     this.isStreaming = false;
     this.listeners = new Set();
+    this.sessionManager = { getSessionFile: () => sessionFile };
   }
 
   subscribe(listener) {
@@ -33,6 +34,7 @@ class FakeRuntime {
     this.cwd = cwd;
     this.session = session;
     this.rebindSession = undefined;
+    this.disposed = false;
   }
 
   setRebindSession(rebindSession) {
@@ -44,7 +46,9 @@ class FakeRuntime {
     await this.rebindSession?.(session);
   }
 
-  async dispose() {}
+  async dispose() {
+    this.disposed = true;
+  }
 }
 
 function connectClient(endpoint) {
@@ -180,6 +184,48 @@ describe('Pi session daemon spike', () => {
     });
     expect((await delta).sequence).toBeGreaterThan(reconnectSnapshot.sequence);
     await reconnectingClient.close();
+  });
+
+  it('disposes an idle runtime without deleting its Pi JSONL and restores it on demand', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'pichamber-pi-daemon-'));
+    const endpoint = join(root, 'daemon.sock');
+    const sessionFile = join(root, 'session.jsonl');
+    await writeFile(sessionFile, `{"type":"session","id":"pi-session-1","cwd":"${root}"}\n`);
+    const firstRuntime = new FakeRuntime({
+      cwd: root,
+      session: new FakeSession('pi-session-1', sessionFile),
+    });
+    const restoredRuntime = new FakeRuntime({
+      cwd: root,
+      session: new FakeSession('pi-session-1', sessionFile),
+    });
+    const runtimeCalls = [];
+    daemon = createSessionDaemon({
+      endpoint,
+      credential,
+      cwd: root,
+      idleTimeoutMs: 10,
+      createRuntime: async (options) => {
+        runtimeCalls.push(options);
+        return runtimeCalls.length === 1 ? firstRuntime : restoredRuntime;
+      },
+    });
+    await daemon.start();
+
+    const client = connectClient(endpoint);
+    await client.authenticate();
+    firstRuntime.session.emit({ type: 'agent_settled' });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(firstRuntime.disposed).toBe(true);
+    await expect(stat(sessionFile)).resolves.toMatchObject({ isFile: expect.any(Function) });
+
+    await client.request('sessions.prompt', { text: 'resume after idle' });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(runtimeCalls).toEqual([
+      { cwd: root, agentDir: expect.any(String) },
+      { cwd: root, agentDir: expect.any(String), sessionFile },
+    ]);
+    await client.close();
   });
 
   it('rebinds daemon events to the replacement Pi session identity', async () => {

--- a/packages/web/server/lib/pi/session-daemon/session-jsonl.js
+++ b/packages/web/server/lib/pi/session-daemon/session-jsonl.js
@@ -1,0 +1,70 @@
+import { createReadStream } from 'node:fs';
+import { mkdir, readdir } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { createInterface } from 'node:readline';
+
+class SessionJsonlError extends Error {
+  constructor(code) {
+    super('A Pi session JSONL file could not be read.');
+    this.code = code;
+  }
+}
+
+const malformed = () => new SessionJsonlError('MALFORMED_SESSION_JSONL');
+const unreadable = () => new SessionJsonlError('SESSION_JSONL_UNREADABLE');
+
+/**
+ * Validates the JSONL files Pi discovers for a cwd before granting that
+ * discovery result authority. Pi's discovery intentionally skips malformed
+ * files; the daemon must instead surface them as an explicit failure.
+ */
+export async function validatePiSessionJsonlFile(filePath) {
+  let sawHeader = false;
+  try {
+    const input = createReadStream(filePath, { encoding: 'utf8' });
+    const lines = createInterface({ input, crlfDelay: Infinity });
+    for await (const line of lines) {
+      if (!line.trim()) continue;
+      let entry;
+      try {
+        entry = JSON.parse(line);
+      } catch {
+        throw malformed();
+      }
+      if (!entry || Array.isArray(entry) || typeof entry !== 'object') throw malformed();
+      if (!sawHeader) {
+        if (entry.type !== 'session' || typeof entry.id !== 'string' || entry.id.length === 0 || typeof entry.cwd !== 'string') {
+          throw malformed();
+        }
+        sawHeader = true;
+      }
+    }
+  } catch (error) {
+    if (error instanceof SessionJsonlError) throw error;
+    throw unreadable();
+  }
+  if (!sawHeader) throw malformed();
+}
+
+export const getPiSessionDirectory = ({ cwd, agentDir }) => {
+  const resolvedCwd = resolve(cwd);
+  const safePath = `--${resolvedCwd.replace(/^[/\\]/, '').replace(/[/\\:]/g, '-')}--`;
+  return join(resolve(agentDir), 'sessions', safePath);
+};
+
+export async function validatePiSessionJsonlDirectory({ cwd, agentDir }) {
+  let sessionDirectory;
+  let entries;
+  try {
+    sessionDirectory = getPiSessionDirectory({ cwd, agentDir });
+    await mkdir(sessionDirectory, { recursive: true, mode: 0o700 });
+    entries = await readdir(sessionDirectory, { withFileTypes: true });
+  } catch {
+    throw unreadable();
+  }
+
+  for (const entry of entries) {
+    if (!entry.name.endsWith('.jsonl')) continue;
+    await validatePiSessionJsonlFile(join(sessionDirectory, entry.name));
+  }
+}

--- a/packages/web/server/lib/pi/session-daemon/session-jsonl.test.js
+++ b/packages/web/server/lib/pi/session-daemon/session-jsonl.test.js
@@ -1,0 +1,49 @@
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { getPiSessionDirectory, validatePiSessionJsonlDirectory, validatePiSessionJsonlFile } from './session-jsonl.js';
+
+const validHeader = (cwd) => JSON.stringify({
+  type: 'session',
+  version: 3,
+  id: 'session-one',
+  timestamp: '2026-01-01T00:00:00.000Z',
+  cwd,
+});
+
+describe('Pi session JSONL validation', () => {
+  it('accepts valid Pi session JSONL files', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'pichamber-pi-jsonl-'));
+    const cwd = join(root, 'project');
+    const agentDir = join(root, 'agent');
+    const sessionDirectory = getPiSessionDirectory({ cwd, agentDir });
+    await mkdir(sessionDirectory, { recursive: true });
+    await writeFile(join(sessionDirectory, 'valid.jsonl'), `${validHeader(cwd)}\n`);
+
+    await expect(validatePiSessionJsonlDirectory({ cwd, agentDir })).resolves.toBeUndefined();
+  });
+
+  it('reports malformed JSONL rather than silently omitting the session', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'pichamber-pi-jsonl-'));
+    const cwd = join(root, 'project');
+    const agentDir = join(root, 'agent');
+    const sessionDirectory = getPiSessionDirectory({ cwd, agentDir });
+    await mkdir(sessionDirectory, { recursive: true });
+    await writeFile(join(sessionDirectory, 'corrupt.jsonl'), `${validHeader(cwd)}\nnot-json\n`);
+
+    await expect(validatePiSessionJsonlDirectory({ cwd, agentDir })).rejects.toMatchObject({
+      code: 'MALFORMED_SESSION_JSONL',
+    });
+  });
+
+  it('reports unreadable session files explicitly', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'pichamber-pi-jsonl-'));
+
+    await expect(validatePiSessionJsonlFile(join(root, 'missing.jsonl'))).rejects.toMatchObject({
+      code: 'SESSION_JSONL_UNREADABLE',
+    });
+  });
+});

--- a/packages/web/server/lib/pi/session-daemon/supervisor.js
+++ b/packages/web/server/lib/pi/session-daemon/supervisor.js
@@ -31,14 +31,21 @@ const getWindowsOwnerKey = () => {
   }
 };
 
-const isValidState = (state) => (
+const hasValidStateIdentity = (state) => (
   state
   && state.protocolVersion === PROTOCOL_VERSION
   && Number.isInteger(state.pid)
   && state.pid > 0
   && typeof state.endpoint === 'string'
-  && typeof state.startedAt === 'string'
 );
+
+const isValidState = (state) => hasValidStateIdentity(state) && typeof state.startedAt === 'string';
+
+const isValidFailureState = (state) => hasValidStateIdentity(state)
+  && state.state === 'failed'
+  && typeof state.error?.code === 'string';
+
+const isPermanentStartupFailure = (code) => code === 'MALFORMED_SESSION_JSONL' || code === 'SESSION_JSONL_UNREADABLE';
 
 const isPidAlive = (processLike, pid) => {
   try {
@@ -106,24 +113,9 @@ export const createPiSessionDaemonSupervisor = ({
     await mkdir(paths.piDataDir, { recursive: true, mode: 0o700 });
     await chmod(paths.piDataDir, 0o700);
     while (true) {
+      let handle;
       try {
-        const handle = await open(paths.lockFile, 'wx', 0o600);
-        try {
-          await handle.writeFile(JSON.stringify({ pid: processLike.pid, claimedAt: new Date().toISOString() }));
-          await chmod(paths.lockFile, 0o600);
-        } finally {
-          await handle.close();
-        }
-        try {
-          return await operation();
-        } finally {
-          try {
-            const claim = JSON.parse(await readFile(paths.lockFile, 'utf8'));
-            if (claim?.pid === processLike.pid) await rm(paths.lockFile, { force: true });
-          } catch {
-            // A missing or already-replaced lock must not remove another owner.
-          }
-        }
+        handle = await open(paths.lockFile, 'wx', 0o600);
       } catch (error) {
         if (error?.code !== 'EEXIST') throw new PiSessionDaemonUnavailableError('DAEMON_LOCK_UNAVAILABLE');
         try {
@@ -134,6 +126,24 @@ export const createPiSessionDaemonSupervisor = ({
         }
         if (Date.now() >= deadline) throw new PiSessionDaemonUnavailableError('DAEMON_LOCK_TIMEOUT');
         await wait(RETRY_DELAY_MS);
+        continue;
+      }
+
+      try {
+        await handle.writeFile(JSON.stringify({ pid: processLike.pid, claimedAt: new Date().toISOString() }));
+        await chmod(paths.lockFile, 0o600);
+      } finally {
+        await handle.close();
+      }
+      try {
+        return await operation();
+      } finally {
+        try {
+          const claim = JSON.parse(await readFile(paths.lockFile, 'utf8'));
+          if (claim?.pid === processLike.pid) await rm(paths.lockFile, { force: true });
+        } catch {
+          // A missing or already-replaced lock must not remove another owner.
+        }
       }
     }
   };
@@ -142,6 +152,15 @@ export const createPiSessionDaemonSupervisor = ({
     try {
       const state = JSON.parse(await readFile(paths.stateFile, 'utf8'));
       return isValidState(state) ? state : null;
+    } catch {
+      return null;
+    }
+  };
+
+  const readFailureState = async () => {
+    try {
+      const state = JSON.parse(await readFile(paths.stateFile, 'utf8'));
+      return isValidFailureState(state) ? state : null;
     } catch {
       return null;
     }
@@ -182,6 +201,8 @@ export const createPiSessionDaemonSupervisor = ({
   const probe = async (credential) => {
     const state = await readState();
     if (!state || state.endpoint !== paths.endpoint) {
+      const failure = await readFailureState();
+      if (failure?.endpoint === paths.endpoint) throw new PiSessionDaemonUnavailableError(failure.error.code);
       throw new PiSessionDaemonUnavailableError('DAEMON_UNAVAILABLE');
     }
     try {
@@ -192,7 +213,11 @@ export const createPiSessionDaemonSupervisor = ({
       return { state, health };
     } catch (error) {
       if (error instanceof PiSessionDaemonUnavailableError) throw error;
-      throw new PiSessionDaemonUnavailableError(error instanceof SessionDaemonClientError ? error.code : 'DAEMON_UNAVAILABLE');
+      throw new PiSessionDaemonUnavailableError(
+        error instanceof SessionDaemonClientError && error.code !== 'DAEMON_CONNECTION_REFUSED'
+          ? error.code
+          : 'DAEMON_UNAVAILABLE',
+      );
     }
   };
 
@@ -208,10 +233,31 @@ export const createPiSessionDaemonSupervisor = ({
   };
 
   const removeStaleState = async (state) => {
-    const current = await readState();
+    const current = await readState() ?? await readFailureState();
     if (current?.pid === state?.pid && current.endpoint === paths.endpoint) {
       await rm(paths.stateFile, { force: true });
     }
+  };
+
+  const recoverVerifiedStaleEndpoint = async (state, credential) => {
+    if (platform === 'win32' || !state || isPidAlive(processLike, state.pid)) return false;
+    try {
+      const endpoint = await lstat(paths.endpoint);
+      if (!endpoint.isSocket()) return false;
+    } catch (error) {
+      if (error?.code === 'ENOENT') return false;
+      throw new PiSessionDaemonUnavailableError('DAEMON_ENDPOINT_UNREADABLE');
+    }
+
+    try {
+      await request({ endpoint: paths.endpoint, credential, command: 'runtime.health' });
+      return false;
+    } catch (error) {
+      if (!(error instanceof SessionDaemonClientError) || error.code !== 'DAEMON_CONNECTION_REFUSED') return false;
+    }
+
+    await rm(paths.endpoint, { force: false });
+    return true;
   };
 
   const start = async () => {
@@ -225,13 +271,16 @@ export const createPiSessionDaemonSupervisor = ({
         if (!(error instanceof PiSessionDaemonUnavailableError)) throw error;
       }
 
-      const staleState = await readState();
+      const staleState = await readState() ?? await readFailureState();
       if (staleState && isPidAlive(processLike, staleState.pid)) {
         throw new PiSessionDaemonUnavailableError('DAEMON_UNAVAILABLE');
       }
       if (await endpointExists()) {
-        // Do not unlink a socket we could not authenticate and identify.
-        throw new PiSessionDaemonUnavailableError('DAEMON_ENDPOINT_UNVERIFIED');
+        const recovered = await recoverVerifiedStaleEndpoint(staleState, credential);
+        if (!recovered) {
+          // Do not unlink a socket we could not authenticate and identify.
+          throw new PiSessionDaemonUnavailableError('DAEMON_ENDPOINT_UNVERIFIED');
+        }
       }
       if (staleState) await removeStaleState(staleState);
       await mkdir(dirname(paths.stateFile), { recursive: true, mode: 0o700 });
@@ -261,7 +310,8 @@ export const createPiSessionDaemonSupervisor = ({
         try {
           const started = await probe(credential);
           return { state: 'ready', reused: false, protocolVersion: PROTOCOL_VERSION, capabilities: started.health.capabilities ?? [] };
-        } catch {
+        } catch (error) {
+          if (error instanceof PiSessionDaemonUnavailableError && isPermanentStartupFailure(error.code)) throw error;
           await wait(RETRY_DELAY_MS);
         }
       }

--- a/packages/web/server/lib/pi/session-daemon/supervisor.test.js
+++ b/packages/web/server/lib/pi/session-daemon/supervisor.test.js
@@ -1,9 +1,23 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { mkdtemp, mkdir, readFile, stat } from 'node:fs/promises';
+import { mkdtemp, mkdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { getPiSessionDirectory } from './session-jsonl.js';
 import { createPiSessionDaemonSupervisor } from './supervisor.js';
+
+const waitForExit = async (pid) => {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    try {
+      process.kill(pid, 0);
+    } catch (error) {
+      if (error?.code === 'ESRCH') return;
+      throw error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error('The daemon process did not exit.');
+};
 
 describe('Pi session daemon supervisor', () => {
   let supervisor;
@@ -12,6 +26,56 @@ describe('Pi session daemon supervisor', () => {
     await supervisor?.stop().catch(() => {});
     supervisor = undefined;
   });
+
+  it('recovers from a forced daemon crash only after verifying the stale socket is unreachable', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'pichamber-pi-supervisor-'));
+    const cwd = join(root, 'project');
+    const agentDir = join(root, 'agent');
+    await Promise.all([mkdir(cwd), mkdir(agentDir)]);
+    const env = {
+      ...process.env,
+      PI_OFFLINE: '1',
+      OPENCHAMBER_DATA_DIR: join(root, 'data'),
+      OPENCHAMBER_PI_AGENT_DIR: agentDir,
+      XDG_RUNTIME_DIR: join(root, 'runtime'),
+    };
+
+    supervisor = createPiSessionDaemonSupervisor({ env, cwd });
+    await supervisor.start();
+    const state = JSON.parse(await readFile(supervisor.paths.stateFile, 'utf8'));
+    process.kill(state.pid, 'SIGKILL');
+    await waitForExit(state.pid);
+
+    await expect(supervisor.health()).resolves.toMatchObject({
+      state: 'unavailable',
+      error: { code: 'DAEMON_UNAVAILABLE' },
+    });
+    await expect(supervisor.start()).resolves.toMatchObject({ state: 'ready', reused: false });
+  }, 20_000);
+
+  it('reports malformed Pi session JSONL as a stable startup failure', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'pichamber-pi-supervisor-'));
+    const cwd = join(root, 'project');
+    const agentDir = join(root, 'agent');
+    await Promise.all([mkdir(cwd), mkdir(agentDir)]);
+    const sessionDirectory = getPiSessionDirectory({ cwd, agentDir });
+    await mkdir(sessionDirectory, { recursive: true });
+    await writeFile(join(sessionDirectory, 'corrupt.jsonl'), '{"type":"session"}\nnot-json\n');
+    const env = {
+      ...process.env,
+      PI_OFFLINE: '1',
+      OPENCHAMBER_DATA_DIR: join(root, 'data'),
+      OPENCHAMBER_PI_AGENT_DIR: agentDir,
+      XDG_RUNTIME_DIR: join(root, 'runtime'),
+    };
+
+    supervisor = createPiSessionDaemonSupervisor({ env, cwd });
+    await expect(supervisor.start()).rejects.toMatchObject({ code: 'MALFORMED_SESSION_JSONL' });
+    await expect(supervisor.health()).resolves.toMatchObject({
+      state: 'unavailable',
+      error: { code: 'MALFORMED_SESSION_JSONL' },
+    });
+  }, 20_000);
 
   it('starts, reuses, health-checks, and stops a private daemon without exposing its credential', async () => {
     const root = await mkdtemp(join(tmpdir(), 'pichamber-pi-supervisor-'));


### PR DESCRIPTION
## Intent

Complete the private Pi daemon lifecycle gate: validate discovered session JSONL explicitly, dispose idle runtimes without touching Pi transcripts, restore the selected session on demand, and recover safely after a forced daemon crash.

## Non-goals

This PR does not add public Pi session routes, browser event streaming, session collection/mutation commands, queue policy, or replay persistence. Those belong to the subsequent IPC/API contract work.

## Affected surfaces

- `packages/web` private session daemon: JSONL discovery validation, idle runtime ownership, local IPC restoration, daemon failure state, and supervised crash recovery.
- `packages/ui/src/lib/pi/protocol.ts`: adds stable error-code types for the explicit daemon failures.
- Owner documentation and migration delivery records.
- No rendered UI, public route behavior beyond existing unavailable health codes, Electron shell, mobile surface, or persisted Pi JSONL schema changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` runtime boundaries and correctness invariants | The private web daemon owns runtime lifecycle and failure semantics. | Keeps the socket private, never logs/transmits session paths or credentials, preserves Pi JSONL, and exposes failure rather than empty/idle success. |
| `openchamber-change-discipline` | Adds server source files and extends a shared error contract. | Uses focused daemon modules, updates owner docs/records, documents cleanup behavior, and runs focused plus workspace checks. |
| `sync-state-invariants` | Session identity, replacement, recovery, and persisted JSONL failures affect authoritative state. | Validates JSONL before discovery authority, restores the remembered session file, and preserves explicit unavailable failure state. |
| `ui-api-decoupling` and implementation map | The public protocol type reflects daemon-originated health failures. | Makes no new browser route or transport; the existing authenticated health adapter remains the only public surface. |
| `packages/web/README.md` and `session-daemon/DOCUMENTATION.md` | Define package ownership and private-daemon constraints. | Updated the owning module documentation and Workstream 1 record. |

## Validation

| Check | Result |
|---|---|
| `bun run --cwd packages/web test server/lib/pi/session-daemon/session-jsonl.test.js server/lib/pi/session-daemon/session-daemon.test.js server/lib/pi/session-daemon/runtime-registry.test.js server/lib/pi/session-daemon/supervisor.test.js server/lib/pi/routes.test.js` | Passed: 5 files, 17 tests; includes real detached daemon `SIGKILL` recovery under `PI_OFFLINE=1`. |
| `bun run type-check` | Passed: web, UI, Electron, and mobile workspaces. |
| `bun run lint` | Passed: web, UI, Electron, and mobile workspaces. |
| `bun run docs:validate` | Passed: 450 pages, 45 sidebar links. |
| `node --check` on changed daemon modules and `git diff --check` | Passed. |
| `bun run dead-code` | Completed; no new `session-jsonl` entries. Existing unrelated unused-symbol/type report remains. |

No packaged browser/Electron/mobile build or live-provider smoke test was run; the change is private server lifecycle code and focused tests use `PI_OFFLINE=1`.

## Visual evidence

No rendered behavior changed. This PR modifies private server lifecycle and documentation only.

## Risks and failure behavior

Malformed or unreadable Pi JSONL now leaves a stable owner-only failure sidecar and health unavailable rather than silently omitting a session. Idle disposal releases only the in-memory runtime; it does not delete or rewrite session JSONL, and the next private prompt recreates the remembered session. Crash cleanup unlinks a POSIX socket only after the recorded PID is dead, the endpoint is a socket, and connection is refused; any responding, non-socket, or otherwise unverified endpoint remains protected with `DAEMON_ENDPOINT_UNVERIFIED`. Windows pipe cleanup remains unchanged and unverified.
