### PR TITLE
Release 0.1.0 (Electron desktop only)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,16 @@ on:
         required: false
         default: false
         type: boolean
+      publish_npm:
+        description: 'Also publish @pichamber/web to npm (off for desktop-only releases)'
+        required: false
+        default: false
+        type: boolean
+      publish_mobile:
+        description: 'Also build and upload mobile artifacts (off for desktop-only releases)'
+        required: false
+        default: false
+        type: boolean
 
 env:
   CARGO_INCREMENTAL: 0
@@ -83,6 +93,7 @@ jobs:
 
   publish-npm:
     needs: create-release
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.publish_npm == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -287,11 +298,6 @@ jobs:
         working-directory: packages/electron
         run: bun run build:web-assets
 
-      - name: Prepare bundled OpenCode CLI
-        working-directory: packages/electron
-        shell: bash
-        run: |
-
       - name: Bundle main process
         working-directory: packages/electron
         run: bun run bundle:main
@@ -491,7 +497,7 @@ jobs:
 
   mobile-release:
     needs: create-release
-    if: ${{ github.event.inputs.dry_run != 'true' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.publish_mobile == 'true' && github.event.inputs.dry_run != 'true' }}
     uses: ./.github/workflows/mobile-release.yml
     with:
       version_name: ${{ needs.create-release.outputs.version }}
@@ -501,7 +507,7 @@ jobs:
     secrets: inherit
 
   finalize-release:
-    needs: [create-release, build-desktop-electron-macos, build-desktop-electron-windows, build-desktop-electron-linux, publish-electron-linux, publish-npm, combine-electron-manifests, mobile-release]
+    needs: [create-release, build-desktop-electron-macos, build-desktop-electron-windows, build-desktop-electron-linux, publish-electron-linux, combine-electron-manifests]
     runs-on: ubuntu-latest
     env:
       DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-08-17
+
+First public **PiChamber** release. This tag publishes **Electron desktop** builds only (macOS, Windows, Linux AppImage). `@pichamber/web` is not published to npm, and mobile artifacts are not attached.
+
+Desktop starts the PiChamber backend in-process and runs a Pi-native session daemon. It does not require a separately installed Pi CLI or server.
+
 ### Protocol hard rename: OpenChamber identifiers → PiChamber (breaking)
 
 Phase 1 protocol preservation is revoked. Remaining in-repo OpenChamber runtime identifiers are renamed to PiChamber with **no compatibility aliases**:
@@ -27,31 +33,12 @@ This is the metadata-only Phase 1 stabilization of [OpenChamber](https://github.
 
 - **VS Code extension removed:** the `packages/vscode` extension (extension host, webview, and its `pichamber.*` command namespace) was removed from the repository; the runtime contract no longer includes a VS Code platform.
 - **PWA-specific localStorage keys:** the four PWA keys were renamed to `pichamber.*` (`pichamber.pwaName`, `pichamber.pwaOrientation`, `pichamber.mobileKeyboardMode`, `pichamber.pwaRecentSessions`) in this stabilization pass. The shared UI constants and the literal `<script>` strings in `packages/web/index.html` are now locked by a focused contract test.
-- **Application data root:** every PiChamber-owned file (settings, themes, projects, walkthroughs, goals, quota credentials, passkeys, managed-process records, install IDs) resolves through one canonical resolver at `~/.config/pichamber`, overridable by `OPENCHAMBER_DATA_DIR`. Web, CLI, and Electron share the same default and the same override semantics. Web `GET /api/fs/home` exposes `pichamberDataDir` so the shared UI can resolve `projects/` beneath the authoritative root rather than reconstructing `<home>/.config/pichamber` on its own.
+- **Application data root:** every PiChamber-owned file (settings, themes, projects, walkthroughs, goals, quota credentials, passkeys, managed-process records, install IDs) resolves through one canonical resolver at `~/.config/pichamber`, overridable by `PICHAMBER_DATA_DIR`. Web, CLI, and Electron share the same default and the same override semantics. Web `GET /api/fs/home` exposes `pichamberDataDir` so the shared UI can resolve `projects/` beneath the authoritative root rather than reconstructing `<home>/.config/pichamber` on its own.
 - **Package ownership detection:** global-bin detection in `package-manager.js` now probes only `pichamber` / `pichamber.cmd`, and `isPackageInstalledWith()` validates `@pichamber/web` rather than a generic `openchamber` substring.
-- **Default update checks:** the hosted update check no longer defaults to a placeholder host. Web/CLI versions come from the authoritative npm `@pichamber/web` `dist-tags.latest`, release notes from the PiChamber changelog after the npm cross-check, GitHub assets from `RyderAsKing/PiChamber`, and Android selects the canonical PiChamber APK and refuses AAB-only/unrelated releases. `OPENCHAMBER_UPDATE_API_URL` remains an opt-in override for deployment integrations.
+- **Default update checks:** desktop update checks use GitHub Releases for `RyderAsKing/PiChamber`. `PICHAMBER_UPDATE_API_URL` remains an opt-in override for deployment integrations.
 - **Process identity:** `cli-process.js` now recognizes only the `pichamber` / `pichamber.cmd` / `pichamber.exe` executable tokens and the `@pichamber/web/bin/cli.js`, `@pichamber/web/server/index.js`, `PiChamber/packages/web/bin/cli.js`, and `PiChamber/packages/web/server/index.js` entrypoints. OpenChamber-only paths, `pichamber` appearing in usernames, hostnames, project files, or unrelated package names, and generic `cli.js` / `server/index.js` paths are no longer accepted.
 
-**Phase 1 non-goals (intentionally deferred to later phases):**
-
-- `/api/openchamber/*` remains the sole active HTTP route prefix.
-- `openchamber:*` custom events, `__openchamber*` window globals, and `openchamber-ui://` / `openchamber://` URL schemes are unchanged.
-- `OPENCHAMBER_*` environment variables are unchanged.
-- No automatic import or fallback read of legacy `~/.config/openchamber` data is provided. Legacy-data migration is out of scope.
-- OpenCode runtime behavior (SDK calls, proxy, SSE) is unchanged.
-
-### Deferred to later phases (intentional, to keep upgrades non-breaking)
-
-- Env var rename: `OPENCHAMBER_*` → `PICHAMBER_*` (and aliases).
-- URL scheme rename: `openchamber-ui://` → `pichamber-ui://`.
-- Electron `appId` / bundle id rename (`dev.openchamber.desktop` → `dev.pichamber.desktop`).
-- Mobile `capacitor.config.ts` `appId` (`com.openchamber.app` → `com.pichamber.app`).
-- Workspace localStorage key rename (`openchamber_*` → `pichamber_*`) for keys outside the four PWA keys above.
-- HTTP route rename: `/api/openchamber/*` → `/api/pichamber/*`.
-- Custom-event / window-global renames (`openchamber:*`, `__openchamber*`).
-- `.agents/skills/openchamber-change-discipline/` directory rename (kept as-is to preserve skill loaders and references).
-- SSH secret name migration (`openchamberPassword` / `openchamber_password` → `pichamberPassword`) continues to be served as a read fallback to `pichamberPassword` for backwards compatibility.
-
+The Phase 1 “keep OpenChamber protocol names” non-goals above were revoked by the hard rename in this same `0.1.0` cut. There is still no automatic import of legacy `~/.config/openchamber` data.
 
 - **Observability panel:** a new panel near to the chat brings the active goal, tasks, subagents, pinned context, MCP servers, and context usage into one live view. The session list also shows how long an agent has been working.
 - **Scheduled Tasks:** projects can now define recurring tasks as Markdown files in `.agents/loops`; opening the task list discovers file changes without a restart, and loop tasks can be edited, enabled, disabled, deleted, or run from the app (thanks to @makeittech).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,19 @@ bun run --cwd packages/electron verify:linux-appimage
 
 The final AppImage verifier checks desktop identity and the architecture of Electron and packaged native modules.
 
+## Desktop releases
+
+PiChamber's public GitHub Release path is **Electron desktop** (macOS, Windows, Linux AppImage). npm (`@pichamber/web`) and mobile artifacts are opt-in workflow inputs and stay off unless a later release explicitly enables them.
+
+To cut a version:
+
+1. Bump workspace versions: `bun run version:bump 0.1.0` (does not bump `packages/mobile`).
+2. Move notes from `CHANGELOG.md` `[Unreleased]` into a `## [0.1.0] - YYYY-MM-DD` section. The release workflow fails if that heading is missing.
+3. Merge the bump to `main`.
+4. Push tag `v0.1.0`, or run the **Release** workflow with `version=0.1.0`. Tag pushes skip npm and mobile.
+
+The draft GitHub Release is published after macOS, Windows, and Linux desktop jobs succeed.
+
 ## Before Submitting
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ PiChamber runs a Pi-native session daemon on the host, provides an authenticated
 
 ### Desktop — macOS, Windows, and Linux
 
-Download the latest release from [GitHub Releases](https://github.com/RyderAsKing/PiChamber/releases/latest). Desktop includes the Pi SDK integration; it does not require a separately installed Pi CLI or server.
+Download the latest **desktop** release from [GitHub Releases](https://github.com/RyderAsKing/PiChamber/releases/latest). The first public line (`0.1.0`) ships Electron only. Desktop includes the Pi SDK integration; it does not require a separately installed Pi CLI or server.
 
 Linux releases are available as x86_64 and ARM64 AppImages. Make the downloaded AppImage executable and keep it in a writable location for in-app updates:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pichamber-monorepo",
-  "version": "1.18.1",
+  "version": "0.1.0",
   "description": "PiChamber monorepo workspace for web, ui, and desktop runtimes",
   "private": true,
   "type": "module",

--- a/packages/electron/README.md
+++ b/packages/electron/README.md
@@ -25,6 +25,8 @@ bun run electron:build
 
 Packaging builds web assets, bundles the Electron main process, rebuilds native modules, and runs electron-builder. It stages only the web UI and native desktop resources; Pi sessions are served by the in-process PiChamber server.
 
+GitHub Releases for this package are produced by `.github/workflows/release.yml`. Desktop is the default published artifact; npm and mobile jobs stay disabled unless a workflow dispatch explicitly enables them. See `CONTRIBUTING.md` for the version/tag steps.
+
 ## Platform rules
 
 - Keep native windows, menus, updater, deep-link, SSH, and IPC behavior in this package.

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pichamber/electron",
-  "version": "1.18.1",
+  "version": "0.1.0",
   "private": true,
   "description": "Electron desktop runtime for PiChamber",
   "author": "PiChamber",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pichamber/ui",
-  "version": "1.18.1",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "main": "src/main.tsx",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pichamber/web",
-  "version": "1.18.1",
+  "version": "0.1.0",
   "private": false,
   "type": "module",
   "main": "./server/index.js",

--- a/scripts/test-release-build.sh
+++ b/scripts/test-release-build.sh
@@ -117,9 +117,9 @@ run_with_act() {
     ACT_CMD+=" --container-architecture linux/amd64"
     ACT_CMD+=" --artifact-server-path $REPO_ROOT/.act-artifacts"
 
-    # Filter to specific job for faster testing
-    # publish-npm works in Linux containers; build-desktop-macos needs macOS
-    ACT_CMD+=" --job publish-npm"
+    # Filter to a Linux-container job for faster testing.
+    # Desktop packaging for macOS/Windows still needs native runners.
+    ACT_CMD+=" --job create-release"
 
     if [[ "$VERBOSE" == true ]]; then
         ACT_CMD+=" --verbose"


### PR DESCRIPTION
## Intent

Cut the first public PiChamber version as **0.1.0** and make GitHub Releases publish **Electron desktop** artifacts only (macOS, Windows, Linux AppImage).

## Non-goals

- Publishing `@pichamber/web` to npm
- Building or attaching iOS/Android artifacts
- Changing Electron packaging/signing implementation beyond dropping a leftover empty OpenCode CLI step

## Affected surfaces

- `.github/workflows/release.yml`: npm and mobile jobs run only when workflow_dispatch explicitly enables them; `finalize-release` waits only on desktop jobs
- Workspace versions (`package.json`, `packages/{ui,web,electron}`) bumped to `0.1.0`; `packages/mobile` unchanged
- `CHANGELOG.md` `[0.1.0]` section required by the release notes extractor
- README / CONTRIBUTING / Electron README document the desktop-only first release

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md / change discipline | Workflow, package versions, and docs are package-contract changes | Smallest complete cut: version + changelog + release job graph |
| desktop-shell | Electron is the desktop release target | Packaging jobs stay; native backend remains in-process; no sidecar |
| CONTRIBUTING.md | Release handoff | Desktop release steps added |

## Validation

| Check | Result |
|---|---|
| Changelog extractor for `[0.1.0]` | Passes locally |
| `bun run --cwd packages/electron test:architecture` | 33 passed |
| `bun run --cwd packages/electron test:updater` | 18 passed |
| Signed/notarized macOS, Windows NSIS, Linux AppImage in CI | Not run locally; Release workflow after `v0.1.0` is the proof |

## Visual evidence

No rendered UI change. Version strings and GitHub Release notes/assets only.

## Risks and failure behavior

- macOS job still requires Apple signing/notarization secrets; missing secrets fail that matrix and block finalize.
- Tag-triggered releases skip npm/mobile even if those jobs exist in the file.
- Electron artifact names use `0.1.0` from `packages/electron/package.json`; the GitHub tag must match.


Made with [Cursor](https://cursor.com)