### PR TITLE
Fix macOS release when Apple certificate cannot be imported

### DIFF
--- a/.github/workflows/build-macos-arm64-dmg.yml
+++ b/.github/workflows/build-macos-arm64-dmg.yml
@@ -38,26 +38,11 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Install Apple Certificate
+        id: apple_cert
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-        run: |
-          KEYCHAIN_PATH=$RUNNER_TEMP/electron-signing.keychain-db
-          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
-
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-
-          echo "$APPLE_CERTIFICATE" | base64 --decode > $RUNNER_TEMP/certificate.p12
-          security import $RUNNER_TEMP/certificate.p12 \
-            -P "$APPLE_CERTIFICATE_PASSWORD" \
-            -A -t cert -f pkcs12 \
-            -k "$KEYCHAIN_PATH"
-
-          security list-keychain -d user -s "$KEYCHAIN_PATH"
-          security set-key-partition-list -S apple-tool:,apple:,codesign: \
-            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+        run: bash packages/electron/scripts/install-apple-certificate.sh
 
       - name: Build Electron app (arm64)
         working-directory: packages/electron
@@ -66,11 +51,19 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           ELECTRON_BUILDER_ARCH: arm64
+          MAC_SIGNED: ${{ steps.apple_cert.outputs.signed }}
         run: |
           bun run build:web-assets
           bun run bundle:main
           bun run rebuild:native
-          ./node_modules/.bin/electron-builder --mac --arm64 --publish=never
+          if [ "$MAC_SIGNED" = "true" ]; then
+            ./node_modules/.bin/electron-builder --mac --arm64 --publish=never
+          else
+            unset APPLE_ID APPLE_APP_SPECIFIC_PASSWORD APPLE_TEAM_ID
+            export CSC_IDENTITY_AUTO_DISCOVERY=false
+            ./node_modules/.bin/electron-builder --mac --arm64 --publish=never \
+              -c.mac.identity=null -c.mac.notarize=false
+          fi
 
       - name: Prepare DMG artifact
         run: |

--- a/.github/workflows/release-desktop-smoke.yml
+++ b/.github/workflows/release-desktop-smoke.yml
@@ -76,26 +76,11 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Install Apple Certificate
+        id: apple_cert
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-        run: |
-          KEYCHAIN_PATH=$RUNNER_TEMP/electron-signing.keychain-db
-          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
-
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-
-          echo "$APPLE_CERTIFICATE" | base64 --decode > $RUNNER_TEMP/certificate.p12
-          security import $RUNNER_TEMP/certificate.p12 \
-            -P "$APPLE_CERTIFICATE_PASSWORD" \
-            -A -t cert -f pkcs12 \
-            -k "$KEYCHAIN_PATH"
-
-          security list-keychain -d user -s "$KEYCHAIN_PATH"
-          security set-key-partition-list -S apple-tool:,apple:,codesign: \
-            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+        run: bash packages/electron/scripts/install-apple-certificate.sh
 
       - name: Build Electron app
         working-directory: packages/electron
@@ -104,6 +89,7 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           ELECTRON_BUILDER_ARCH: ${{ matrix.arch }}
+          MAC_SIGNED: ${{ steps.apple_cert.outputs.signed }}
         run: |
           bun run build:web-assets
           bun run bundle:main
@@ -111,9 +97,17 @@ jobs:
           # recompile native deps on its own. Rebuild against the target
           # Electron ABI before packaging, matching the release workflow.
           bun run rebuild:native
-          bunx electron-builder --mac --${{ matrix.arch }} --publish=never
+          if [ "$MAC_SIGNED" = "true" ]; then
+            bunx electron-builder --mac --${{ matrix.arch }} --publish=never
+          else
+            unset APPLE_ID APPLE_APP_SPECIFIC_PASSWORD APPLE_TEAM_ID
+            export CSC_IDENTITY_AUTO_DISCOVERY=false
+            bunx electron-builder --mac --${{ matrix.arch }} --publish=never \
+              -c.mac.identity=null -c.mac.notarize=false
+          fi
 
       - name: Verify signature + entitlements + notarization
+        if: ${{ steps.apple_cert.outputs.signed == 'true' }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,26 +163,11 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Install Apple Certificate
+        id: apple_cert
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-        run: |
-          KEYCHAIN_PATH=$RUNNER_TEMP/electron-signing.keychain-db
-          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
-
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-
-          echo "$APPLE_CERTIFICATE" | base64 --decode > "$RUNNER_TEMP/certificate.p12"
-          security import "$RUNNER_TEMP/certificate.p12" \
-            -P "$APPLE_CERTIFICATE_PASSWORD" \
-            -A -t cert -f pkcs12 \
-            -k "$KEYCHAIN_PATH"
-
-          security list-keychain -d user -s "$KEYCHAIN_PATH"
-          security set-key-partition-list -S apple-tool:,apple:,codesign: \
-            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+        run: bash packages/electron/scripts/install-apple-certificate.sh
 
       - name: Build Electron app
         working-directory: packages/electron
@@ -193,6 +178,7 @@ jobs:
           # rebuild-native.mjs reads this to target the right arch when
           # cross-building (runner is arm64; x64 matrix needs the hint).
           ELECTRON_BUILDER_ARCH: ${{ matrix.arch }}
+          MAC_SIGNED: ${{ steps.apple_cert.outputs.signed }}
         run: |
           bun run build:web-assets
           bun run bundle:main
@@ -201,9 +187,17 @@ jobs:
           # target Electron ABI before packaging, otherwise node-pty/bun-pty
           # crash on require inside the packaged app.
           bun run rebuild:native
-          bunx electron-builder --mac --${{ matrix.arch }} --publish=never
+          if [ "$MAC_SIGNED" = "true" ]; then
+            bunx electron-builder --mac --${{ matrix.arch }} --publish=never
+          else
+            unset APPLE_ID APPLE_APP_SPECIFIC_PASSWORD APPLE_TEAM_ID
+            export CSC_IDENTITY_AUTO_DISCOVERY=false
+            bunx electron-builder --mac --${{ matrix.arch }} --publish=never \
+              -c.mac.identity=null -c.mac.notarize=false
+          fi
 
       - name: Verify signature + entitlements + notarization
+        if: ${{ steps.apple_cert.outputs.signed == 'true' }}
         run: |
           set -euo pipefail
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,6 +117,12 @@ To cut a version:
 
 The draft GitHub Release is published after macOS, Windows, and Linux desktop jobs succeed.
 
+macOS signing uses `APPLE_CERTIFICATE` (base64-encoded Developer ID `.p12`) and `APPLE_CERTIFICATE_PASSWORD`. If those secrets are missing or not a readable PKCS#12, CI builds **unsigned** macOS artifacts and skips notarization instead of failing. Gatekeeper will warn until a valid Developer ID is stored:
+
+```bash
+base64 -i DeveloperID.p12 | pbcopy
+```
+
 ## Before Submitting
 
 ```bash

--- a/packages/electron/README.md
+++ b/packages/electron/README.md
@@ -27,6 +27,8 @@ Packaging builds web assets, bundles the Electron main process, rebuilds native 
 
 GitHub Releases for this package are produced by `.github/workflows/release.yml`. Desktop is the default published artifact; npm and mobile jobs stay disabled unless a workflow dispatch explicitly enables them. See `CONTRIBUTING.md` for the version/tag steps.
 
+macOS notarized builds need `APPLE_CERTIFICATE` as base64 of a Developer ID Application `.p12`. Missing or unreadable certificates produce unsigned `.dmg`/`.zip` files instead of failing the job.
+
 ## Platform rules
 
 - Keep native windows, menus, updater, deep-link, SSH, and IPC behavior in this package.

--- a/packages/electron/scripts/install-apple-certificate.sh
+++ b/packages/electron/scripts/install-apple-certificate.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Import a Developer ID PKCS#12 into a temporary keychain for electron-builder.
+# Never prints certificate material or passwords.
+#
+# Expects APPLE_CERTIFICATE as whitespace-stripped base64 of a .p12 file, and
+# APPLE_CERTIFICATE_PASSWORD as that archive's password.
+#
+# Writes signed=true|false to GITHUB_OUTPUT. Missing or unreadable certificates
+# produce signed=false so the caller can build unsigned macOS artifacts.
+
+set -euo pipefail
+
+OUTPUT_PATH="${GITHUB_OUTPUT:-}"
+CERT_PATH="${RUNNER_TEMP:-/tmp}/certificate.p12"
+KEYCHAIN_PATH="${RUNNER_TEMP:-/tmp}/electron-signing.keychain-db"
+
+write_signed() {
+  if [[ -n "$OUTPUT_PATH" ]]; then
+    echo "signed=$1" >> "$OUTPUT_PATH"
+  fi
+}
+
+fail_unsigned() {
+  echo "$1"
+  echo "macOS artifacts will be unsigned. To sign and notarize, store a Developer ID Application PKCS#12 as APPLE_CERTIFICATE using:"
+  echo "  base64 -i DeveloperID.p12 | pbcopy"
+  rm -f "$CERT_PATH"
+  write_signed false
+  exit 0
+}
+
+compact="$(printf '%s' "${APPLE_CERTIFICATE:-}" | tr -d '[:space:]')"
+
+if [[ -z "$compact" ]]; then
+  fail_unsigned "APPLE_CERTIFICATE is empty."
+fi
+
+if [[ "$compact" == -----BEGIN* ]]; then
+  fail_unsigned "APPLE_CERTIFICATE looks like PEM, not a base64-encoded .p12."
+fi
+
+if ! printf '%s' "$compact" | base64 --decode > "$CERT_PATH"; then
+  fail_unsigned "APPLE_CERTIFICATE is not valid base64."
+fi
+
+if [[ ! -s "$CERT_PATH" ]]; then
+  fail_unsigned "APPLE_CERTIFICATE decoded to an empty file."
+fi
+
+if ! openssl pkcs12 -in "$CERT_PATH" -nokeys -passin "pass:${APPLE_CERTIFICATE_PASSWORD:-}" -out /dev/null; then
+  fail_unsigned "APPLE_CERTIFICATE is not a readable PKCS#12 (wrong encoding or password)."
+fi
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "PKCS#12 is readable; skipping keychain import off macOS."
+  write_signed true
+  exit 0
+fi
+
+KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
+
+security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+if ! security import "$CERT_PATH" \
+  -P "${APPLE_CERTIFICATE_PASSWORD:-}" \
+  -A -t cert -f pkcs12 \
+  -k "$KEYCHAIN_PATH"
+then
+  fail_unsigned "security could not import APPLE_CERTIFICATE into the signing keychain."
+fi
+
+security list-keychain -d user -s "$KEYCHAIN_PATH"
+security set-key-partition-list -S apple-tool:,apple:,codesign: \
+  -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+rm -f "$CERT_PATH"
+echo "Imported Apple signing certificate."
+write_signed true


### PR DESCRIPTION
## Intent

Unblock the 0.1.0 Electron release. macOS jobs failed with `SecKeychainItemImport: Unable to decode the provided data` because `APPLE_CERTIFICATE` is missing or not a valid base64 PKCS#12.

## Non-goals

- Creating or rotating Apple Developer certificates
- Changing Windows/Linux packaging

## Affected surfaces

- Release, desktop-smoke, and macOS DMG workflows
- `packages/electron/scripts/install-apple-certificate.sh`

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| desktop-shell | Electron packaging/signing | Unsigned fallback is explicit; notarization skipped when unsigned |
| change-discipline | Workflow/script contract | Smallest complete change; secrets are never logged |

## Validation

| Check | Result |
|---|---|
| Empty cert → `signed=false` | Pass |
| Generated PKCS#12 → `signed=true` (Linux skips keychain) | Pass |
| Invalid base64 → `signed=false` | Pass |
| Live macOS GitHub runner import | Not verified until this PR's Release re-run |

## Visual evidence

No UI change.

## Risks and failure behavior

Unsigned macOS builds will show Gatekeeper warnings. A later release can notarize once a Developer ID `.p12` is stored as base64 in `APPLE_CERTIFICATE`.


Made with [Cursor](https://cursor.com)