### PR TITLE
Release 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-08-17
+
 - Desktop and web packaged icons now use the PiChamber hexagon-and-pi mark instead of the inherited OpenChamber cube.
 - Packaged Electron no longer blocks filesystem fetches from `pichamber-ui://app` (CORS now allows the workspace directory header), and the Pi session daemon is spawned as Node so Windows desktop no longer sticks on Loading with `/api/pi/*` 400s.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pichamber-monorepo",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "PiChamber monorepo workspace for web, ui, and desktop runtimes",
   "private": true,
   "type": "module",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pichamber/electron",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "Electron desktop runtime for PiChamber",
   "author": "PiChamber",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pichamber/ui",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "main": "src/main.tsx",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pichamber/web",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "type": "module",
   "main": "./server/index.js",


### PR DESCRIPTION
## Intent

Cut desktop release **v0.1.1** so installers ship the PiChamber mark and the packaged Windows app can load providers instead of staying on Loading.

## Non-goals

- Publishing npm or mobile artifacts.
- Regenerating macOS 26 `Assets.car`.

## Affected surfaces

- Workspace versions: root, `packages/ui`, `packages/web`, `packages/electron` → `0.1.1`.
- `CHANGELOG.md` section `[0.1.1]`.
- GitHub Release workflow after tag `v0.1.1`.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `CONTRIBUTING.md` desktop releases | Version bump, changelog heading, tag | `bun run version:bump 0.1.1`; changelog section present; tag after merge |
| `.github/PULL_REQUEST_TEMPLATE.md` | Release PR evidence | Lists included fixes and validation |

## Validation

| Check | Result |
|---|---|
| Changelog heading `## [0.1.1] - 2026-08-17` | Present (required by release workflow) |
| Version files | root/ui/web/electron are `0.1.1` |
| Focused Windows/CORS tests | Already on main from #28 |
| Brand icons | Already on main from #27 |
| Release workflow / packaged Windows run | Runs after `v0.1.1` is pushed |

## Visual evidence

Installer/dock icons use the PiChamber hexagon-and-pi mark. Windows packaged UI should progress past Loading once the daemon starts as Node.

## Risks and failure behavior

- Release job fails if changelog heading is missing; it is present.
- macOS `Assets.car` still old until regenerated on a Mac; `icon.icns` is updated.
- If Windows still fails in the wild, `/api/pi/*` now returns 503 for daemon startup timeout instead of 400.

Made with [Cursor](https://cursor.com)