### PR TITLE
Release 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-08-18
+
+This release makes everyday PiChamber use feel calmer and more predictable: the
+composer takes up less space, model choices are easier to understand, and
+returning to an older chat keeps using the model that chat was built with.
+
+- The composer now uses a cleaner stacked layout with the model and thinking
+  controls kept together, while removing the unused desktop focus-mode control.
+- Thinking is now presented as a larger, discrete slider with clear minimum and
+  maximum labels. The available levels follow the selected Pi model.
+- New-session thinking defaults can be saved per model, so different providers
+  can keep their own preferred level.
+- Reopening an existing chat restores its most recently used model and thinking
+  level instead of inheriting whichever model was selected most recently
+  elsewhere. You can still change either choice manually.
+- Model pickers now use the configured-provider catalog and can hide models
+  that should not appear in everyday selection lists.
+- Project settings use the shared model picker, with a more consistent layout
+  for choosing a project's default model.
+- Session and project navigation is quieter and more compact, with cleaner
+  sidebar spacing, simpler session rows, and a unified Git/Changes rail.
+- Live conversations stream more smoothly, with less duplicate text while
+  responses arrive and better preservation of the active chat during switches.
+- Incomplete project actions no longer trigger premature validation errors while
+  they are still being filled in.
+
 ## [0.1.2] - 2026-08-17
 
 Desktop 0.1.2 is a Windows-focused reliability cut. Packaged Electron should get past Loading, show models, and talk to the Pi session daemon on native Windows.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pichamber-monorepo",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "PiChamber monorepo workspace for web, ui, and desktop runtimes",
   "private": true,
   "type": "module",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pichamber/electron",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "description": "Electron desktop runtime for PiChamber",
   "author": "PiChamber",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pichamber/ui",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "type": "module",
   "main": "src/main.tsx",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pichamber/web",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": false,
   "type": "module",
   "main": "./server/index.js",


### PR DESCRIPTION
## Intent

Prepare PiChamber 0.1.3 with a more focused composer, Pi-native thinking controls, and session-aware model restoration. This release makes model selection easier to understand and prevents an older chat from accidentally inheriting the model last used elsewhere.

## Non-goals

- No changes to Pi provider authentication or the underlying model catalog.
- No npm or mobile artifact publication; the public release path remains Electron desktop.
- No tag is created by this PR; the `v0.1.3` tag should be created after this branch is merged to `main`.

## Affected surfaces

- `packages/ui`: composer layout and thinking slider, model pickers, session hydration/restoration, sidebar and project-settings polish.
- `packages/web`: Pi thinking-level support, per-model defaults, daemon/session projections, and model/settings boundaries.
- `packages/electron`: version alignment for the 0.1.3 desktop release.
- `CHANGELOG.md`: user-facing release notes for the changes merged since 0.1.2.
- Workspace versions: root, `packages/ui`, `packages/web`, and `packages/electron` are now `0.1.3`.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `CONTRIBUTING.md` desktop releases | This PR prepares the version bump and changelog before the release tag. | All shipped workspace versions are aligned at 0.1.3; the changelog has a dated `[0.1.3]` section; npm/mobile publication remains off. |
| `pichamber-change-discipline` | The release changes package metadata and user-facing release documentation. | The diff is limited to the changelog and version bump; no dependencies or runtime behavior are changed in this PR. |
| `packages/ui/src/lib/pi/DOCUMENTATION.md`, `packages/ui/src/sync/DOCUMENTATION.md`, `packages/ui/src/components/chat/composer/DOCUMENTATION.md`, `packages/web/server/lib/pi/session-daemon/DOCUMENTATION.md` | These documents describe the behavior summarized in the release notes. | They were updated with the feature changes in the preceding merged PR and are included in the release baseline. |

## Validation

| Check | Result |
|---|---|
| `bun run release:prepare` | Passed: all non-mobile workspace builds, workspace type-check, and lint completed successfully. |
| `bun run docs:validate` | Passed: 7 pages and 7 sidebar links validated. |
| `git diff --check` | Passed with no whitespace errors. |
| `bun run --cwd packages/web test -- server/lib/pi/session-daemon/session-daemon.test.js` | Passed before this release-only change: 26 tests, 0 failures. |
| Focused UI Pi tests | Passed before this release-only change: 47 tests, 0 failures. |
| Packaged desktop smoke test | Not run on this Linux WSL2 host; release artifacts should be verified by the release workflow. |

## Visual evidence

No new visual behavior is introduced by this release-only version/changelog commit. The user-visible changes described here were validated in the preceding feature PR; fresh packaged screenshots were not captured for the version-only diff.

## Risks and failure behavior

- This PR only changes version metadata and release notes, so it does not alter runtime failure or persistence behavior.
- The release tag should be created only after merge so the release workflow builds from `main` at the final 0.1.3 commit.
- Electron, Windows, macOS, and Linux packaged behavior remains to be verified by the release workflow on their respective runners.


Made with [Cursor](https://cursor.com)