### PR TITLE
Simplify the add-folder dialog around path and a single CTA

### DIFF
--- a/packages/ui/src/components/session/DirectoryExplorerDialog.tsx
+++ b/packages/ui/src/components/session/DirectoryExplorerDialog.tsx
@@ -22,12 +22,28 @@ import { runtimeFetch } from '@/lib/runtime-fetch';
 import { useDeviceInfo } from '@/lib/device';
 import { MobileOverlayPanel } from '@/components/ui/MobileOverlayPanel';
 import { Icon } from "@/components/icon/Icon";
-import { getFilesystemHome, listLocalDirectory } from '@/lib/fsApi';
+import { getFilesystemHome, listLocalDirectory, pickLocalDirectory } from '@/lib/fsApi';
+import { canRequestNativeDirectoryAccess, requestDirectoryAccess } from '@/lib/desktop';
 
 import {
   isFilesystemError,
   type FilesystemErrorReason,
 } from '@/lib/api/files-errors';
+import {
+  absolutePathToDisplayPath,
+  appendBrowsePathSegment,
+  canNavigateUp,
+  displayPathToAbsolutePath,
+  ensureBrowseDirectoryPath,
+  getBrowseCurrentFolderName,
+  getBrowseDirectoryPath,
+  getBrowseLeafPathSegment,
+  getBrowseParentPath,
+  hasTrailingPathSeparator,
+  normalizeDirectoryPath,
+  normalizeSeparators,
+  trimTrailingSeparators,
+} from './directoryExplorerPaths';
 
 interface DirectoryExplorerDialogProps {
   open: boolean;
@@ -40,73 +56,8 @@ type BrowseEntry = {
 };
 
 type BrowseRow =
-  | { type: 'up'; value: 'browse:up'; name: string; path: string | null; disabled?: false }
-  | { type: 'directory'; value: string; name: string; path: string; disabled: boolean };
-
-const isRootPath = (value: string): boolean => value === '/';
-
-const normalizeSeparators = (value: string): string => value.replace(/\\/g, '/');
-
-const trimTrailingSeparators = (value: string): string => {
-  if (!value || isRootPath(value)) return value;
-  let result = value;
-  while (result.length > 1 && result.endsWith('/')) {
-    result = result.slice(0, -1);
-  }
-  return result;
-};
-
-const hasTrailingPathSeparator = (value: string): boolean => value.endsWith('/');
-
-const ensureBrowseDirectoryPath = (value: string): string => {
-  const trimmed = value.trim();
-  if (!trimmed || hasTrailingPathSeparator(trimmed)) return trimmed;
-  return `${trimmed}/`;
-};
-
-const getLastPathSeparatorIndex = (value: string): number => value.lastIndexOf('/');
-
-const getBrowseDirectoryPath = (value: string): string => {
-  if (hasTrailingPathSeparator(value)) return value;
-  const lastSeparator = getLastPathSeparatorIndex(value);
-  if (lastSeparator < 0) return value;
-  return value.slice(0, lastSeparator + 1);
-};
-
-const getBrowseLeafPathSegment = (value: string): string => {
-  const lastSeparator = getLastPathSeparatorIndex(value);
-  return value.slice(lastSeparator + 1);
-};
-
-const getBrowseParentPath = (value: string): string | null => {
-  const trimmed = trimTrailingSeparators(value.trim());
-  if (!trimmed || trimmed === '~' || trimmed === '~/' || trimmed === '/') return null;
-  const lastSeparator = getLastPathSeparatorIndex(trimmed);
-  if (lastSeparator < 0) return null;
-  if (trimmed.startsWith('~/') && lastSeparator <= 1) return '~/';
-  if (lastSeparator === 0) return '/';
-  return `${trimmed.slice(0, lastSeparator)}/`;
-};
-
-const canNavigateUp = (value: string): boolean => hasTrailingPathSeparator(value) && getBrowseParentPath(value) !== null;
-
-const appendBrowsePathSegment = (currentPath: string, segment: string): string => (
-  `${getBrowseDirectoryPath(currentPath)}${segment}/`
-);
-
-const normalizeDirectoryPath = (path: string | null | undefined): string | null => {
-  if (!path) return null;
-  const normalized = trimTrailingSeparators(normalizeSeparators(path.trim()));
-  if (!normalized) return null;
-  return normalized.toLowerCase();
-};
-
-const displayPathToAbsolutePath = (value: string, homeDirectory: string): string => {
-  const trimmed = value.trim();
-  if (trimmed === '~') return homeDirectory;
-  if (trimmed.startsWith('~/')) return `${homeDirectory}${trimmed.slice(1)}`;
-  return trimmed;
-};
+  | { type: 'parent'; value: 'browse:up'; name: string; path: string; alreadyAdded: boolean }
+  | { type: 'directory'; value: string; name: string; path: string; alreadyAdded: boolean };
 
 const isPrimaryModifierPressed = (event: React.KeyboardEvent<HTMLInputElement>): boolean => {
   const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform);
@@ -141,10 +92,9 @@ export const DirectoryExplorerDialog: React.FC<DirectoryExplorerDialogProps> = (
   const loadGitIdentityProfiles = useGitIdentitiesStore((s) => s.loadProfiles);
   const loadGlobalGitIdentity = useGitIdentitiesStore((s) => s.loadGlobalIdentity);
   const loadDefaultGitIdentityId = useGitIdentitiesStore((s) => s.loadDefaultGitIdentityId);
-  const { canRequestAccess, requestAccess, startAccessing } = useFileSystemAccess();
+  const { canRequestAccess, startAccessing } = useFileSystemAccess();
   const { isMobile } = useDeviceInfo();
   const inputRef = React.useRef<HTMLInputElement>(null);
-  const addButtonRef = React.useRef<HTMLButtonElement>(null);
   const rowRefs = React.useRef(new Map<string, HTMLButtonElement>());
   const [dialogHomeDirectory, setDialogHomeDirectory] = React.useState('');
   const [query, setQuery] = React.useState('~/');
@@ -155,12 +105,13 @@ export const DirectoryExplorerDialog: React.FC<DirectoryExplorerDialogProps> = (
   const [browseReloadKey, setBrowseReloadKey] = React.useState(0);
   const [highlightedIndex, setHighlightedIndex] = React.useState(0);
   const [isConfirming, setIsConfirming] = React.useState(false);
-  const [isOpeningFinder, setIsOpeningFinder] = React.useState(false);
-  const [addButtonWidth, setAddButtonWidth] = React.useState(0);
+  const [isPickingLocation, setIsPickingLocation] = React.useState(false);
   const [isCloneMode, setIsCloneMode] = React.useState(false);
   const [cloneRemoteUrl, setCloneRemoteUrl] = React.useState('');
   const [selectedGitIdentityId, setSelectedGitIdentityId] = React.useState<string | null>(null);
   const [showHidden, setShowHidden] = React.useState(false);
+  const [folderEnterFrom, setFolderEnterFrom] = React.useState<'left' | 'right'>('right');
+  const previousBrowsePathRef = React.useRef('~/');
 
   const explorerRootDirectory = dialogHomeDirectory || homeDirectory;
 
@@ -176,11 +127,13 @@ export const DirectoryExplorerDialog: React.FC<DirectoryExplorerDialogProps> = (
     setEntries([]);
     setHighlightedIndex(0);
     setIsConfirming(false);
-    setIsOpeningFinder(false);
+    setIsPickingLocation(false);
     setIsCloneMode(false);
     setCloneRemoteUrl('');
     setSelectedGitIdentityId(null);
     setShowHidden(false);
+    previousBrowsePathRef.current = '~/';
+    setFolderEnterFrom('right');
     requestAnimationFrame(() => focusPathInput(inputRef.current));
 
     let cancelled = false;
@@ -243,6 +196,13 @@ export const DirectoryExplorerDialog: React.FC<DirectoryExplorerDialogProps> = (
   );
 
   React.useEffect(() => {
+    const previous = previousBrowsePathRef.current;
+    if (previous === browseDirectoryDisplayPath) return;
+    setFolderEnterFrom(browseDirectoryDisplayPath.length >= previous.length ? 'right' : 'left');
+    previousBrowsePathRef.current = browseDirectoryDisplayPath;
+  }, [browseDirectoryDisplayPath]);
+
+  React.useEffect(() => {
     if (!open || !browseDirectoryAbsolutePath) {
       setEntries([]);
       setBrowseErrorReason(null);
@@ -292,10 +252,20 @@ export const DirectoryExplorerDialog: React.FC<DirectoryExplorerDialogProps> = (
     ));
   }, [browseFilterQuery, entries, showHidden]);
 
+  const currentFolderName = React.useMemo(() => getBrowseCurrentFolderName(query), [query]);
+  const parentPath = React.useMemo(() => getBrowseParentPath(query), [query]);
+
   const rows = React.useMemo<BrowseRow[]>(() => {
     const nextRows: BrowseRow[] = [];
-    if (canNavigateUp(query)) {
-      nextRows.push({ type: 'up', value: 'browse:up', name: '..', path: getBrowseParentPath(query) });
+    const currentNormalized = normalizeDirectoryPath(browseDirectoryAbsolutePath);
+    if (canNavigateUp(query) && currentFolderName && parentPath) {
+      nextRows.push({
+        type: 'parent',
+        value: 'browse:up',
+        name: currentFolderName,
+        path: parentPath,
+        alreadyAdded: Boolean(currentNormalized && addedProjectPaths.has(currentNormalized)),
+      });
     }
     for (const entry of filteredEntries) {
       const normalized = normalizeDirectoryPath(entry.path);
@@ -304,11 +274,11 @@ export const DirectoryExplorerDialog: React.FC<DirectoryExplorerDialogProps> = (
         value: `browse:${entry.path}`,
         name: entry.name,
         path: entry.path,
-        disabled: Boolean(normalized && addedProjectPaths.has(normalized)),
+        alreadyAdded: Boolean(normalized && addedProjectPaths.has(normalized)),
       });
     }
     return nextRows;
-  }, [addedProjectPaths, filteredEntries, query]);
+  }, [addedProjectPaths, browseDirectoryAbsolutePath, currentFolderName, filteredEntries, parentPath, query]);
 
   React.useEffect(() => {
     setHighlightedIndex(0);
@@ -333,18 +303,16 @@ export const DirectoryExplorerDialog: React.FC<DirectoryExplorerDialogProps> = (
       || (!hasTrailingPathSeparator(query) && browseFilterQuery.trim().length > 0 && exactEntry === null)
     )
   );
-  const canAddProject = !isConfirming
-    && !isOpeningFinder
+  const canAddFolder = !isConfirming
+    && !isPickingLocation
     && !isAlreadyAdded
     && browseErrorReason !== 'os-permission'
     && browseErrorReason !== 'invalid-response'
     && browseErrorReason !== 'unknown'
     && Boolean(targetPath);
-  const canSubmitClone = canAddProject && cloneRemoteUrl.trim().length > 0;
+  const canSubmitClone = canAddFolder && cloneRemoteUrl.trim().length > 0;
   const highlightedRow = rows[highlightedIndex] ?? null;
-  const hasHighlightedBrowseItem = Boolean(
-    highlightedRow && (highlightedRow.type === 'up' || (highlightedRow.type === 'directory' && !highlightedRow.disabled))
-  );
+  const hasHighlightedBrowseItem = Boolean(highlightedRow);
   const submitModifierLabel = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform)
     ? '⌘'
     : 'Ctrl';
@@ -358,26 +326,14 @@ export const DirectoryExplorerDialog: React.FC<DirectoryExplorerDialogProps> = (
       ? "Adding..."
     : shouldCreateTarget
       ? "Create & add"
-      : "Add project";
-
-  React.useLayoutEffect(() => {
-    const button = addButtonRef.current;
-    if (!button) return;
-
-    const updateWidth = () => setAddButtonWidth(Math.ceil(button.getBoundingClientRect().width));
-    updateWidth();
-
-    if (typeof ResizeObserver === 'undefined') return;
-    const observer = new ResizeObserver(updateWidth);
-    observer.observe(button);
-    return () => observer.disconnect();
-  }, [submitActionLabel]);
+      : "Add folder";
+  const canSubmit = isCloneMode ? canSubmitClone : canAddFolder;
 
   React.useLayoutEffect(() => {
     const input = inputRef.current;
     if (!input) return;
     input.scrollLeft = input.scrollWidth;
-  }, [addButtonWidth, query]);
+  }, [query]);
 
   React.useLayoutEffect(() => {
     if (!open) return;
@@ -400,20 +356,6 @@ export const DirectoryExplorerDialog: React.FC<DirectoryExplorerDialogProps> = (
     openNewSessionDraft({ selectedProjectId: projectId, directoryOverride: projectPath });
     handleClose();
   }, [handleClose, isMobile, openNewSessionDraft, setActiveMainTab, setSessionSwitcherOpen]);
-
-  const handleQuickAdd = React.useCallback((event: React.MouseEvent, path: string) => {
-    event.stopPropagation();
-    const normalized = normalizeDirectoryPath(path);
-    if (normalized && addedProjectPaths.has(normalized)) return;
-    const project = addProject(path);
-    if (!project) {
-      toast.error("Failed to add project", {
-        description: "Please select a valid directory path.",
-      });
-      return;
-    }
-    openProjectDraft(project.id, project.path);
-  }, [addProject, addedProjectPaths, openProjectDraft]);
 
   const finalizeSelection = React.useCallback(async (target: string) => {
     if (!target || isConfirming) return;
@@ -457,7 +399,7 @@ export const DirectoryExplorerDialog: React.FC<DirectoryExplorerDialogProps> = (
       }
       const project = addProject(selectedTarget);
       if (!project) {
-        toast.error("Failed to add project", {
+        toast.error("Failed to add folder", {
           description: "Please select a valid directory path.",
         });
         return;
@@ -482,45 +424,63 @@ export const DirectoryExplorerDialog: React.FC<DirectoryExplorerDialogProps> = (
 
   const executeRow = React.useCallback((row: BrowseRow | null) => {
     if (!row) return;
-    if (row.type === 'up') {
-      if (row.path) browseToDisplayPath(row.path);
+    if (row.type === 'parent') {
+      browseToDisplayPath(row.path);
       return;
     }
-    if (row.disabled) return;
     browseToEntry(row);
   }, [browseToDisplayPath, browseToEntry]);
 
-  const handleOpenInFinder = React.useCallback(async () => {
-    if (!canRequestAccess || isOpeningFinder) return;
-    setIsOpeningFinder(true);
+  const applyPickedLocation = React.useCallback(async (pickedPath: string) => {
+    const accessResult = await startAccessing(pickedPath);
+    if (!accessResult.success) {
+      toast.error("Failed to open directory", {
+        description: accessResult.error || "Desktop could not grant file access.",
+      });
+      return false;
+    }
+    const displayPath = explorerRootDirectory
+      ? absolutePathToDisplayPath(pickedPath, explorerRootDirectory)
+      : ensureBrowseDirectoryPath(normalizeSeparators(pickedPath));
+    browseToDisplayPath(displayPath);
+    return true;
+  }, [browseToDisplayPath, explorerRootDirectory, startAccessing]);
+
+  const handleBrowseLocation = React.useCallback(async () => {
+    if (isPickingLocation) return;
+    setIsPickingLocation(true);
     try {
-      const result = await requestAccess(targetPath);
-      if (!result.success || !result.path) {
-        if (result.error && result.error !== 'Directory selection cancelled') {
-          toast.error("Failed to select directory", {
-            description: result.error,
-          });
+      if (canRequestNativeDirectoryAccess()) {
+        const result = await requestDirectoryAccess(targetPath);
+        if (!result.success || !result.path) {
+          if (result.error && result.error !== 'Directory selection cancelled') {
+            toast.error("Failed to select directory", {
+              description: result.error,
+            });
+          }
+          return;
         }
+        await applyPickedLocation(result.path);
         return;
       }
 
-      const accessResult = await startAccessing(result.path);
-      if (!accessResult.success) {
-        toast.error("Failed to open directory", {
-          description: accessResult.error || "Desktop could not grant file access.",
+      const picked = await pickLocalDirectory(targetPath);
+      if (picked.status === 'cancelled') return;
+      if (picked.status !== 'picked') {
+        toast.error("Couldn't open a folder picker", {
+          description: picked.error,
         });
         return;
       }
-
-      await finalizeSelection(result.path);
+      await applyPickedLocation(picked.path);
     } catch (error) {
       toast.error("Failed to select directory", {
         description: error instanceof Error ? error.message : "Unknown error occurred.",
       });
     } finally {
-      setIsOpeningFinder(false);
+      setIsPickingLocation(false);
     }
-  }, [canRequestAccess, finalizeSelection, isOpeningFinder, requestAccess, startAccessing, targetPath]);
+  }, [applyPickedLocation, isPickingLocation, targetPath]);
 
   const handleKeyDown = React.useCallback((event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'ArrowDown') {
@@ -562,68 +522,100 @@ export const DirectoryExplorerDialog: React.FC<DirectoryExplorerDialogProps> = (
   );
 
   const inputSection = (
-    <div className="px-2.5 py-1.5">
-      {isCloneMode ? (
-        <div className="mb-1.5 flex items-center gap-1.5">
+    <div className="py-1.5">
+      <div className="flex items-center gap-1.5">
+        <div className="relative min-w-0 flex-1">
+          <Icon name="folder-3" className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground/80" />
           <Input
-            value={cloneRemoteUrl}
-            onChange={(event) => setCloneRemoteUrl(event.target.value)}
-            placeholder={"Repository URL (HTTPS or SSH)"}
-            className="min-w-0 flex-1 border-border/60 bg-[var(--surface-elevated)] font-mono typography-ui-label shadow-none"
+            ref={inputRef}
+            value={query}
+            onChange={(event) => setQuery(normalizeSeparators(event.target.value))}
+            onKeyDown={handleKeyDown}
+            placeholder={"Enter a folder path..."}
+            className="border-transparent bg-transparent pl-9 font-mono typography-ui-label shadow-none focus-visible:ring-0"
             spellCheck={false}
             autoComplete="off"
             autoCorrect="off"
             autoCapitalize="off"
           />
-          <IdentityDropdown
-            activeProfile={selectedGitIdentity}
-            identities={availableGitIdentities}
-            onSelect={(profile) => setSelectedGitIdentityId(profile.id)}
-            isApplying={isConfirming}
-            iconOnly
-          />
         </div>
-      ) : null}
-      <div className="relative">
-        <Icon name="folder-add" className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground/80" />
-        <Input
-          ref={inputRef}
-          value={query}
-          onChange={(event) => setQuery(normalizeSeparators(event.target.value))}
-          onKeyDown={handleKeyDown}
-          placeholder={"Enter path or select from tree..."}
-          className="border-transparent bg-transparent pl-9 font-mono typography-ui-label shadow-none focus-visible:ring-0"
-          style={!isMobile && addButtonWidth > 0 ? { paddingRight: `${addButtonWidth + 24}px` } : undefined}
-          spellCheck={false}
-          autoComplete="off"
-          autoCorrect="off"
-          autoCapitalize="off"
-        />
-        {!isMobile ? (
-          <Button
-            ref={addButtonRef}
-            variant="outline"
-            size="xs"
-            tabIndex={-1}
-            className="absolute right-1.5 top-1/2 h-7 -translate-y-1/2 gap-1 px-2 typography-meta"
-            disabled={isCloneMode ? !canSubmitClone : !canAddProject}
-            onMouseDown={(event) => event.preventDefault()}
-            onClick={() => void finalizeSelection(targetPath)}
-            title={submitActionLabel}
-          >
-            {submitActionLabel}
-          </Button>
-        ) : null}
+        <Button
+          variant="outline"
+          size="xs"
+          className="h-8 shrink-0 gap-1 px-2"
+          disabled={isConfirming || isPickingLocation}
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={() => void handleBrowseLocation()}
+          title={"Browse location"}
+          aria-label={"Browse location"}
+        >
+          <Icon name="folder-open" className="h-3.5 w-3.5" />
+          {isPickingLocation ? "Opening..." : "Browse"}
+        </Button>
       </div>
     </div>
   );
 
+  const hasParentRow = rows.some((row) => row.type === 'parent');
+
   const resultsSection = (
     <div className="relative min-h-0 flex-1 overflow-hidden rounded-xl border border-border/60 bg-[var(--surface-elevated)] shadow-sm">
       <div className="max-h-[min(28rem,58vh)] overflow-y-auto p-2">
-        <div className="px-2 pb-1 pt-0.5 typography-meta font-medium uppercase tracking-wide text-muted-foreground/80">
-          {"Directories"}
+        <div className="flex items-center justify-between gap-2 px-2 pb-1 pt-0.5">
+          <div className="typography-meta font-medium uppercase tracking-wide text-muted-foreground/80">
+            {"Directories"}
+          </div>
+          <Button
+            variant="ghost"
+            size="xs"
+            className="h-6 shrink-0 gap-1 text-muted-foreground"
+            aria-pressed={isCloneMode}
+            disabled={isConfirming || isPickingLocation}
+            onClick={() => setIsCloneMode((value) => !value)}
+          >
+            <Icon name="git-repository" className="h-3.5 w-3.5" />
+            {"Clone"}
+          </Button>
         </div>
+        {isCloneMode ? (
+          <div className="mb-2 space-y-1.5 px-2 pb-1">
+            <p className="typography-meta text-muted-foreground">
+              {"Clone into the folder path above."}
+            </p>
+            <div className="flex items-center gap-1.5">
+              <Input
+                value={cloneRemoteUrl}
+                onChange={(event) => setCloneRemoteUrl(event.target.value)}
+                placeholder={"Repository URL (HTTPS or SSH)"}
+                className="min-w-0 flex-1 font-mono typography-ui-label"
+                spellCheck={false}
+                autoComplete="off"
+                autoCorrect="off"
+                autoCapitalize="off"
+              />
+              <IdentityDropdown
+                activeProfile={selectedGitIdentity}
+                identities={availableGitIdentities}
+                onSelect={(profile) => setSelectedGitIdentityId(profile.id)}
+                isApplying={isConfirming}
+                iconOnly
+              />
+            </div>
+          </div>
+        ) : null}
+        {isAlreadyAdded ? (
+          <p className="px-2 pb-2 typography-meta text-muted-foreground">
+            {"This folder is already added. Open a subfolder to add that instead."}
+          </p>
+        ) : null}
+        <div
+          key={browseDirectoryDisplayPath}
+          className={cn(
+            'mt-3',
+            'animate-in fade-in-0 duration-200 motion-reduce:animate-none',
+            folderEnterFrom === 'left' ? 'slide-in-from-left-2' : 'slide-in-from-right-2'
+          )}
+        >
         {isLoading ? (
           <div className="py-10 text-center typography-ui-label text-muted-foreground">
             {"Loading directories..."}
@@ -637,7 +629,7 @@ export const DirectoryExplorerDialog: React.FC<DirectoryExplorerDialogProps> = (
             </div>
             <div className="flex items-center gap-2">
               {browseErrorReason === 'os-permission' && canRequestAccess ? (
-                <Button size="xs" onClick={() => void handleOpenInFinder()} disabled={isOpeningFinder}>
+                <Button size="xs" onClick={() => void handleBrowseLocation()} disabled={isPickingLocation}>
                   {"Grant access"}
                 </Button>
               ) : null}
@@ -654,58 +646,63 @@ export const DirectoryExplorerDialog: React.FC<DirectoryExplorerDialogProps> = (
           <div className="space-y-0.5">
             {rows.map((row, index) => {
               const isActive = index === highlightedIndex;
+              const isChildRow = row.type === 'directory' && hasParentRow;
               return (
-                <div key={row.value} className="flex w-full items-center gap-1">
-                  <button
-                    ref={(node) => {
-                      if (node) {
-                        rowRefs.current.set(row.value, node);
-                      } else {
-                        rowRefs.current.delete(row.value);
-                      }
-                    }}
-                    type="button"
-                    disabled={row.type === 'directory' && row.disabled}
-                    onMouseEnter={() => setHighlightedIndex(index)}
-                    onMouseDown={(event) => event.preventDefault()}
-                    onClick={() => executeRow(row)}
-                    className={cn(
-                      'flex min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-lg px-2 py-1.5 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50',
-                      isActive && 'bg-interactive-selection text-interactive-selection-foreground',
-                      !isActive && 'hover:bg-interactive-hover/50',
-                      row.type === 'directory' && row.disabled && 'cursor-not-allowed opacity-45 hover:bg-transparent'
-                    )}
-                  >
-                    {row.type === 'up' ? (
-                      <Icon name="arrow-left-s" className="h-4 w-4 flex-shrink-0 text-muted-foreground/80" />
+                <button
+                  key={row.value}
+                  ref={(node) => {
+                    if (node) {
+                      rowRefs.current.set(row.value, node);
+                    } else {
+                      rowRefs.current.delete(row.value);
+                    }
+                  }}
+                  type="button"
+                  aria-label={
+                    row.type === 'parent'
+                      ? (row.alreadyAdded ? `Go back from ${row.name}, already added` : `Go back from ${row.name}`)
+                      : (row.alreadyAdded ? `Open ${row.name}, already added` : `Open ${row.name}`)
+                  }
+                  onMouseEnter={() => setHighlightedIndex(index)}
+                  onMouseDown={(event) => event.preventDefault()}
+                  onClick={() => executeRow(row)}
+                  className={cn(
+                    'flex w-full cursor-pointer items-center gap-2 rounded-lg px-2 py-1.5 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50',
+                    isActive && 'bg-interactive-selection text-interactive-selection-foreground',
+                    !isActive && 'hover:bg-interactive-hover/50'
+                  )}
+                >
+                  <span className={cn('flex min-w-0 flex-1 items-center gap-2', isChildRow && 'pl-4')}>
+                    {row.type === 'parent' ? (
+                      <Icon name="folder-open" className="h-4 w-4 flex-shrink-0 text-muted-foreground/80" />
                     ) : (
                       <Icon name="folder-6" className="h-4 w-4 flex-shrink-0 text-muted-foreground/80" />
                     )}
-                    <span className="flex min-w-0 flex-1 items-center gap-1.5">
-                      <span className="truncate typography-ui-label text-foreground">{row.name}</span>
-                    </span>
-                    {row.type === 'directory' && row.disabled ? (
-                      <span className="rounded-full border border-border/60 px-2 py-0.5 typography-meta text-muted-foreground">
-                        {"Added"}
-                      </span>
-                    ) : null}
-                  </button>
-                  {row.type === 'directory' && !row.disabled ? (
-                    <button
-                      type="button"
-                      onMouseDown={(event) => event.preventDefault()}
-                      onClick={(event) => handleQuickAdd(event, row.path)}
-                      className="flex-shrink-0 rounded-full p-1 text-muted-foreground transition-colors hover:bg-interactive-hover/60 hover:text-foreground"
-                      title={"Add"}
+                    <span className="truncate typography-ui-label text-foreground">{row.name}</span>
+                  </span>
+                  {row.alreadyAdded ? (
+                    <span
+                      className={cn(
+                        'inline-flex shrink-0 items-center rounded-md px-1.5 py-0.5 typography-meta font-medium',
+                        isActive
+                          ? 'bg-interactive-selection-foreground/15 text-interactive-selection-foreground'
+                          : 'bg-[var(--surface-muted)] text-foreground'
+                      )}
                     >
-                      <Icon name="add" className="h-3.5 w-3.5" />
-                    </button>
+                      {"Added"}
+                    </span>
                   ) : null}
-                </div>
+                  {row.type === 'parent' ? (
+                    <Icon name="arrow-up-s" className="h-4 w-4 flex-shrink-0 text-muted-foreground/80" aria-hidden="true" />
+                  ) : (
+                    <Icon name="arrow-right-s" className="h-4 w-4 flex-shrink-0 text-muted-foreground/80" aria-hidden="true" />
+                  )}
+                </button>
               );
             })}
           </div>
         )}
+        </div>
       </div>
     </div>
   );
@@ -726,33 +723,32 @@ export const DirectoryExplorerDialog: React.FC<DirectoryExplorerDialogProps> = (
       </span>
       <span className="inline-flex items-center gap-1">
         <Icon name="corner-down-left" className="h-3.5 w-3.5" />
-        {"Select"}
+        {"Open folder"}
       </span>
       <span className="inline-flex items-center gap-1">
         <span>{submitModifierLabel}</span>
         <Icon name="corner-down-left" className="h-3.5 w-3.5" />
-        {"Add"}
+        {"Add folder"}
       </span>
     </div>
+  );
+
+  const addFolderButton = (
+    <Button
+      size={isMobile ? 'xs' : 'default'}
+      onClick={() => void finalizeSelection(targetPath)}
+      disabled={!canSubmit}
+      className={cn(isMobile && 'w-full flex-1')}
+    >
+      {submitActionLabel}
+    </Button>
   );
 
   const renderFooter = () => (
     <>
       {!isMobile ? footerHints : null}
       <div className={cn('flex w-full flex-row justify-end gap-2 sm:w-auto', isMobile && 'justify-stretch')}>
-        {canRequestAccess ? (
-          <Button variant="ghost" size="xs" onClick={handleOpenInFinder} disabled={isConfirming || isOpeningFinder || isCloneMode}>
-            {isOpeningFinder ? "Opening..." : "Open in Finder"}
-          </Button>
-        ) : null}
-        <Button variant="ghost" size="xs" onClick={() => setIsCloneMode((value) => !value)} disabled={isConfirming || isOpeningFinder} className={cn(isMobile && 'flex-1')}>
-          {isCloneMode ? "Add local project" : "Clone repository"}
-        </Button>
-        {isMobile ? (
-          <Button size="xs" onClick={() => void finalizeSelection(targetPath)} disabled={isCloneMode ? !canSubmitClone : !canAddProject} className="flex-1">
-            {submitActionLabel}
-          </Button>
-        ) : null}
+        {addFolderButton}
       </div>
     </>
   );
@@ -762,7 +758,7 @@ export const DirectoryExplorerDialog: React.FC<DirectoryExplorerDialogProps> = (
       <MobileOverlayPanel
         open={open}
         onClose={handleClose}
-        title={"Add project directory"}
+        title={"Add folder"}
         // Height only — the width stays on MobileOverlayPanel's shared max-w-lg
         // so this sheet matches every other mobile overlay on wide screens.
         className="h-[88dvh] max-h-[720px]"
@@ -786,13 +782,13 @@ export const DirectoryExplorerDialog: React.FC<DirectoryExplorerDialogProps> = (
         <DialogHeader className="px-5 pb-2 pt-5">
           <div className="flex items-start justify-between gap-4">
             <div>
-              <DialogTitle>{"Add project directory"}</DialogTitle>
-              <DialogDescription className="mt-2">{"Choose a folder to add as a project."}</DialogDescription>
+              <DialogTitle>{"Add folder"}</DialogTitle>
+              <DialogDescription className="mt-2">{"Choose a folder from the path above, then add it."}</DialogDescription>
             </div>
             {showHiddenToggle}
           </div>
         </DialogHeader>
-        <div className="min-h-0 flex-1 px-2 pb-0">{content}</div>
+        <div className="min-h-0 flex-1 px-5 pb-0">{content}</div>
         <DialogFooter className="flex w-full flex-col gap-3 px-5 py-3 sm:flex-row sm:items-center sm:justify-between">
           {renderFooter()}
         </DialogFooter>

--- a/packages/ui/src/components/session/directoryExplorerPaths.test.ts
+++ b/packages/ui/src/components/session/directoryExplorerPaths.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  absolutePathToDisplayPath,
+  appendBrowsePathSegment,
+  canNavigateUp,
+  displayPathToAbsolutePath,
+  getBrowseCurrentFolderName,
+  getBrowseParentPath,
+  normalizeDirectoryPath,
+} from './directoryExplorerPaths';
+
+describe('directoryExplorerPaths', () => {
+  test('treats home as the top of the browse tree', () => {
+    expect(getBrowseParentPath('~/')).toBeNull();
+    expect(canNavigateUp('~/')).toBe(false);
+    expect(getBrowseCurrentFolderName('~/')).toBeNull();
+  });
+
+  test('names the current folder and returns its parent path', () => {
+    expect(getBrowseParentPath('~/Projects/')).toBe('~/');
+    expect(canNavigateUp('~/Projects/')).toBe(true);
+    expect(getBrowseCurrentFolderName('~/Projects/')).toBe('Projects');
+    expect(getBrowseParentPath('~/Projects/app/')).toBe('~/Projects/');
+    expect(getBrowseCurrentFolderName('~/Projects/app/')).toBe('app');
+  });
+
+  test('does not treat a typed leaf as a navigable folder', () => {
+    expect(canNavigateUp('~/Projects')).toBe(false);
+    expect(getBrowseCurrentFolderName('~/Projects')).toBeNull();
+  });
+
+  test('appends browse segments onto the current directory', () => {
+    expect(appendBrowsePathSegment('~/Projects/', 'app')).toBe('~/Projects/app/');
+    expect(appendBrowsePathSegment('~/Projects/app', 'src')).toBe('~/Projects/src/');
+  });
+
+  test('round-trips home-relative display paths', () => {
+    const home = '/Users/ryder';
+    expect(displayPathToAbsolutePath('~/Projects/', home)).toBe('/Users/ryder/Projects/');
+    expect(absolutePathToDisplayPath('/Users/ryder', home)).toBe('~/');
+    expect(absolutePathToDisplayPath('/Users/ryder/Projects', home)).toBe('~/Projects/');
+    expect(absolutePathToDisplayPath('/opt/src', home)).toBe('/opt/src/');
+  });
+
+  test('normalizes directory identity without trailing separators', () => {
+    expect(normalizeDirectoryPath('/Users/Ryder/Projects/')).toBe('/users/ryder/projects');
+    expect(normalizeDirectoryPath('C:\\Users\\Ryder\\Projects')).toBe('c:/users/ryder/projects');
+  });
+});

--- a/packages/ui/src/components/session/directoryExplorerPaths.ts
+++ b/packages/ui/src/components/session/directoryExplorerPaths.ts
@@ -1,0 +1,91 @@
+const isRootPath = (value: string): boolean => value === '/';
+
+export const normalizeSeparators = (value: string): string => value.replace(/\\/g, '/');
+
+export const trimTrailingSeparators = (value: string): string => {
+  if (!value || isRootPath(value)) return value;
+  let result = value;
+  while (result.length > 1 && result.endsWith('/')) {
+    result = result.slice(0, -1);
+  }
+  return result;
+};
+
+export const hasTrailingPathSeparator = (value: string): boolean => value.endsWith('/');
+
+export const ensureBrowseDirectoryPath = (value: string): string => {
+  const trimmed = value.trim();
+  if (!trimmed || hasTrailingPathSeparator(trimmed)) return trimmed;
+  return `${trimmed}/`;
+};
+
+const getLastPathSeparatorIndex = (value: string): number => value.lastIndexOf('/');
+
+export const getBrowseDirectoryPath = (value: string): string => {
+  if (hasTrailingPathSeparator(value)) return value;
+  const lastSeparator = getLastPathSeparatorIndex(value);
+  if (lastSeparator < 0) return value;
+  return value.slice(0, lastSeparator + 1);
+};
+
+export const getBrowseLeafPathSegment = (value: string): string => {
+  const lastSeparator = getLastPathSeparatorIndex(value);
+  return value.slice(lastSeparator + 1);
+};
+
+export const getBrowseParentPath = (value: string): string | null => {
+  const trimmed = trimTrailingSeparators(value.trim());
+  if (!trimmed || trimmed === '~' || trimmed === '~/' || trimmed === '/') return null;
+  const lastSeparator = getLastPathSeparatorIndex(trimmed);
+  if (lastSeparator < 0) return null;
+  if (trimmed.startsWith('~/') && lastSeparator <= 1) return '~/';
+  if (lastSeparator === 0) return '/';
+  return `${trimmed.slice(0, lastSeparator)}/`;
+};
+
+export const canNavigateUp = (value: string): boolean => (
+  hasTrailingPathSeparator(value) && getBrowseParentPath(value) !== null
+);
+
+export const getBrowseCurrentFolderName = (value: string): string | null => {
+  if (!canNavigateUp(value)) return null;
+  const trimmed = trimTrailingSeparators(value.trim());
+  const name = getBrowseLeafPathSegment(trimmed);
+  return name || trimmed;
+};
+
+export const appendBrowsePathSegment = (currentPath: string, segment: string): string => (
+  `${getBrowseDirectoryPath(currentPath)}${segment}/`
+);
+
+export const normalizeDirectoryPath = (path: string | null | undefined): string | null => {
+  if (!path) return null;
+  const normalized = trimTrailingSeparators(normalizeSeparators(path.trim()));
+  if (!normalized) return null;
+  return normalized.toLowerCase();
+};
+
+export const displayPathToAbsolutePath = (value: string, homeDirectory: string): string => {
+  const trimmed = value.trim();
+  if (trimmed === '~') return homeDirectory;
+  if (trimmed.startsWith('~/')) return `${homeDirectory}${trimmed.slice(1)}`;
+  return trimmed;
+};
+
+export const absolutePathToDisplayPath = (absolute: string, homeDirectory: string): string => {
+  const normalizedAbsolute = trimTrailingSeparators(normalizeSeparators(absolute.trim()));
+  const normalizedHome = trimTrailingSeparators(normalizeSeparators(homeDirectory.trim()));
+  if (!normalizedAbsolute) return '';
+  if (!normalizedHome) return ensureBrowseDirectoryPath(normalizedAbsolute);
+
+  if (normalizedAbsolute.toLowerCase() === normalizedHome.toLowerCase()) {
+    return '~/';
+  }
+
+  const homePrefix = `${normalizedHome}/`;
+  if (normalizedAbsolute.toLowerCase().startsWith(homePrefix.toLowerCase())) {
+    return `~/${normalizedAbsolute.slice(normalizedHome.length + 1)}/`;
+  }
+
+  return ensureBrowseDirectoryPath(normalizedAbsolute);
+};

--- a/packages/ui/src/lib/fsApi.ts
+++ b/packages/ui/src/lib/fsApi.ts
@@ -79,3 +79,48 @@ export async function searchFiles(
   const data = (await response.json()) as { files?: ProjectFileSearchHit[] };
   return Array.isArray(data.files) ? data.files : [];
 }
+
+export type DirectoryPickResult =
+  | { status: 'picked'; path: string }
+  | { status: 'cancelled' }
+  | { status: 'unavailable'; error: string }
+  | { status: 'failed'; error: string };
+
+export async function pickLocalDirectory(defaultPath = ''): Promise<DirectoryPickResult> {
+  try {
+    const response = await runtimeFetch('/api/fs/pick-directory', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify({ path: defaultPath || undefined }),
+    });
+    const data = (await response.json().catch(() => null)) as {
+      path?: unknown;
+      cancelled?: unknown;
+      error?: unknown;
+    } | null;
+    if (data?.cancelled === true) {
+      return { status: 'cancelled' };
+    }
+    if (response.status === 501) {
+      return {
+        status: 'unavailable',
+        error: typeof data?.error === 'string' ? data.error : 'Folder picker is not available.',
+      };
+    }
+    if (!response.ok) {
+      return {
+        status: 'failed',
+        error: typeof data?.error === 'string' ? data.error : 'Failed to select directory.',
+      };
+    }
+    if (typeof data?.path === 'string' && data.path.trim()) {
+      return { status: 'picked', path: data.path.trim() };
+    }
+    return { status: 'failed', error: 'Failed to select directory.' };
+  } catch (error) {
+    return {
+      status: 'failed',
+      error: error instanceof Error ? error.message : 'Failed to select directory.',
+    };
+  }
+}

--- a/packages/web/server/lib/fs/pick-directory.js
+++ b/packages/web/server/lib/fs/pick-directory.js
@@ -1,0 +1,236 @@
+const isMissingBinaryError = (error) => (
+  Boolean(error && typeof error === 'object' && error.code === 'ENOENT')
+);
+
+const lastNonEmptyLine = (value) => {
+  const lines = String(value || '')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  return lines[lines.length - 1] || '';
+};
+
+const escapeAppleScriptString = (value) => value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+
+const zenityFilename = (defaultPath) => {
+  if (!defaultPath) return [];
+  return ['--filename', defaultPath.endsWith('/') ? defaultPath : `${defaultPath}/`];
+};
+
+const looksLikeWindowsPath = (value) => (
+  /^[A-Za-z]:[\\/]/.test(value) || value.startsWith('\\\\')
+);
+
+const detectWsl = () => Boolean(
+  process.env.WSL_DISTRO_NAME
+  || process.env.WSL_INTEROP
+);
+
+const encodePowerShellCommand = (script) => Buffer.from(script, 'utf16le').toString('base64');
+
+const WINDOWS_FOLDER_PICKER_SCRIPT = `
+Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+
+public static class PiChamberFolderPicker {
+  [ComImport]
+  [Guid("DC1C5A9C-E88A-4DDE-A5A1-60F82A20AEF7")]
+  private class FileOpenDialog { }
+
+  [ComImport]
+  [Guid("42f85136-db7e-439c-85f1-e4075d135fc8")]
+  [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+  private interface IFileOpenDialog {
+    [PreserveSig] int Show(IntPtr parent);
+    void SetFileTypes(uint cFileTypes, IntPtr rgFilterSpec);
+    void SetFileTypeIndex(uint iFileType);
+    void GetFileTypeIndex(out uint piFileType);
+    void Advise(IntPtr pfde, out uint pdwCookie);
+    void Unadvise(uint dwCookie);
+    void SetOptions(uint fos);
+    void GetOptions(out uint pfos);
+    void SetDefaultFolder(IShellItem psi);
+    void SetFolder(IShellItem psi);
+    void GetFolder(out IShellItem ppsi);
+    void GetCurrentSelection(out IShellItem ppsi);
+    void SetFileName([MarshalAs(UnmanagedType.LPWStr)] string pszName);
+    void GetFileName([MarshalAs(UnmanagedType.LPWStr)] out string pszName);
+    void SetTitle([MarshalAs(UnmanagedType.LPWStr)] string pszTitle);
+    void GetTitle([MarshalAs(UnmanagedType.LPWStr)] out string pszTitle);
+    void SetOkButtonLabel([MarshalAs(UnmanagedType.LPWStr)] string pszLabel);
+    void SetFileNameLabel([MarshalAs(UnmanagedType.LPWStr)] string pszLabel);
+    void GetResult(out IShellItem ppsi);
+    void AddPlace(IShellItem psi, int fdap);
+    void SetDefaultExtension([MarshalAs(UnmanagedType.LPWStr)] string pszDefaultExtension);
+    void Close(int hr);
+    void SetClientGuid(ref Guid guid);
+    void ClearClientData();
+    void SetFilter(IntPtr pFilter);
+    void GetResults(out IntPtr ppenum);
+    void GetSelectedItems(out IntPtr ppsai);
+  }
+
+  [ComImport]
+  [Guid("43826D1E-E718-42EE-BC55-A1E261C37BFE")]
+  [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+  private interface IShellItem {
+    void BindToHandler(IntPtr pbc, ref Guid bhid, ref Guid riid, out IntPtr ppv);
+    void GetParent(out IShellItem ppsi);
+    void GetDisplayName(uint sigdnName, [MarshalAs(UnmanagedType.LPWStr)] out string ppszName);
+    void GetAttributes(uint sfgaoMask, out uint psfgaoAttribs);
+    void Compare(IShellItem psi, uint hint, out int piOrder);
+  }
+
+  [DllImport("shell32.dll", CharSet = CharSet.Unicode, PreserveSig = false)]
+  private static extern void SHCreateItemFromParsingName(
+    [MarshalAs(UnmanagedType.LPWStr)] string pszPath,
+    IntPtr pbc,
+    [MarshalAs(UnmanagedType.LPStruct)] Guid riid,
+    out IShellItem ppv
+  );
+
+  private const uint FOS_PICKFOLDERS = 0x00000020;
+  private const uint FOS_FORCEFILESYSTEM = 0x00000040;
+  private const uint FOS_NOCHANGEDIR = 0x00000008;
+  private const uint SIGDN_FILESYSPATH = 0x80058000;
+
+  public static string Pick(string title, string initialPath) {
+    var dialog = (IFileOpenDialog)new FileOpenDialog();
+    dialog.SetOptions(FOS_PICKFOLDERS | FOS_FORCEFILESYSTEM | FOS_NOCHANGEDIR);
+    if (!string.IsNullOrEmpty(title)) {
+      dialog.SetTitle(title);
+    }
+    if (!string.IsNullOrEmpty(initialPath)) {
+      try {
+        IShellItem folder;
+        SHCreateItemFromParsingName(initialPath, IntPtr.Zero, typeof(IShellItem).GUID, out folder);
+        dialog.SetFolder(folder);
+      } catch {
+      }
+    }
+    int hr = dialog.Show(IntPtr.Zero);
+    if (hr != 0) {
+      return null;
+    }
+    IShellItem result;
+    dialog.GetResult(out result);
+    string path;
+    result.GetDisplayName(SIGDN_FILESYSPATH, out path);
+    return path;
+  }
+}
+"@
+
+$path = [PiChamberFolderPicker]::Pick('Select folder', $env:PICHAMBER_FOLDER_PICKER_START)
+if ([string]::IsNullOrWhiteSpace($path)) { exit 1 }
+Write-Output $path
+`.trim();
+
+export const buildWindowsFolderPickerCommand = (defaultPath = '') => ({
+  command: 'powershell.exe',
+  args: ['-NoProfile', '-STA', '-NonInteractive', '-EncodedCommand', encodePowerShellCommand(WINDOWS_FOLDER_PICKER_SCRIPT)],
+  env: {
+    PICHAMBER_FOLDER_PICKER_START: defaultPath || '',
+  },
+});
+
+export const buildDirectoryPickerCommands = (platform, defaultPath = '', options = {}) => {
+  const isWsl = options.isWsl ?? detectWsl();
+  const windowsPicker = buildWindowsFolderPickerCommand(defaultPath);
+
+  if (platform === 'darwin') {
+    const script = defaultPath
+      ? `POSIX path of (choose folder default location POSIX file "${escapeAppleScriptString(defaultPath)}")`
+      : 'POSIX path of (choose folder)';
+    return [{ command: 'osascript', args: ['-e', script] }];
+  }
+
+  if (platform === 'win32') {
+    return [windowsPicker];
+  }
+
+  const linuxCommands = [
+    { command: 'zenity', args: ['--file-selection', '--directory', ...zenityFilename(defaultPath)] },
+    { command: 'kdialog', args: ['--getexistingdirectory', defaultPath || '.'] },
+  ];
+
+  if (isWsl) {
+    return [windowsPicker, ...linuxCommands];
+  }
+
+  return [...linuxCommands, windowsPicker];
+};
+
+export const runDirectoryPickerCommand = (spawn, command, args, options = {}) => new Promise((resolve) => {
+  let child;
+  try {
+    child = spawn(command, args, {
+      windowsHide: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: options.env ? { ...process.env, ...options.env } : undefined,
+    });
+  } catch (error) {
+    resolve(isMissingBinaryError(error) ? { missing: true } : { error: error instanceof Error ? error.message : String(error) });
+    return;
+  }
+
+  let stdout = '';
+  let settled = false;
+  const finish = (result) => {
+    if (settled) return;
+    settled = true;
+    resolve(result);
+  };
+
+  child.stdout?.on('data', (chunk) => {
+    stdout += chunk.toString();
+  });
+  child.once('error', (error) => {
+    finish(isMissingBinaryError(error)
+      ? { missing: true }
+      : { error: error instanceof Error ? error.message : String(error) });
+  });
+  child.once('close', (code) => {
+    const pickedPath = lastNonEmptyLine(stdout);
+    if (code === 0 && pickedPath) {
+      finish({ path: pickedPath });
+      return;
+    }
+    finish({ cancelled: true });
+  });
+});
+
+const toHostPath = async (spawn, platform, pickedPath, runCommand) => {
+  if (platform !== 'linux' || !looksLikeWindowsPath(pickedPath)) {
+    return pickedPath;
+  }
+  const converted = await runCommand(spawn, 'wslpath', ['-u', pickedPath]);
+  return converted?.path || pickedPath;
+};
+
+export const pickHostDirectory = async ({
+  platform,
+  spawn,
+  defaultPath = '',
+  isWsl = detectWsl(),
+  runCommand = runDirectoryPickerCommand,
+} = {}) => {
+  let startPath = defaultPath;
+  if (isWsl && defaultPath && !looksLikeWindowsPath(defaultPath)) {
+    const converted = await runCommand(spawn, 'wslpath', ['-w', defaultPath]);
+    if (converted?.path) startPath = converted.path;
+  }
+  const commands = buildDirectoryPickerCommands(platform, startPath, { isWsl });
+  for (const candidate of commands) {
+    const result = await runCommand(spawn, candidate.command, candidate.args, { env: candidate.env });
+    if (result?.missing) continue;
+    if (result?.path) {
+      const hostPath = await toHostPath(spawn, platform, result.path, runCommand);
+      return { status: 'ok', path: hostPath };
+    }
+    if (result?.cancelled) return { status: 'cancelled' };
+    if (result?.error) return { status: 'error', error: result.error };
+  }
+  return { status: 'unavailable' };
+};

--- a/packages/web/server/lib/fs/pick-directory.test.js
+++ b/packages/web/server/lib/fs/pick-directory.test.js
@@ -1,0 +1,134 @@
+import { EventEmitter } from 'events';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  buildDirectoryPickerCommands,
+  pickHostDirectory,
+  runDirectoryPickerCommand,
+} from './pick-directory.js';
+
+const createChild = () => {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  return child;
+};
+
+describe('buildDirectoryPickerCommands', () => {
+  it('uses osascript on macOS', () => {
+    const commands = buildDirectoryPickerCommands('darwin', '/Users/ryder/Projects');
+    expect(commands).toEqual([
+      {
+        command: 'osascript',
+        args: ['-e', 'POSIX path of (choose folder default location POSIX file "/Users/ryder/Projects")'],
+      },
+    ]);
+  });
+
+  it('tries zenity, kdialog, then Windows PowerShell on Linux', () => {
+    const commands = buildDirectoryPickerCommands('linux', '/home/ryder', { isWsl: false });
+    expect(commands.map((entry) => entry.command)).toEqual(['zenity', 'kdialog', 'powershell.exe']);
+    expect(commands[0].args).toEqual(['--file-selection', '--directory', '--filename', '/home/ryder/']);
+    expect(commands[2].args).toContain('-EncodedCommand');
+    expect(commands[2].args.join(' ')).not.toContain('FolderBrowserDialog');
+  });
+
+  it('prefers the modern Windows folder picker on WSL', () => {
+    const commands = buildDirectoryPickerCommands('linux', '/home/ryder', { isWsl: true });
+    expect(commands.map((entry) => entry.command)).toEqual(['powershell.exe', 'zenity', 'kdialog']);
+    expect(commands[0].env.PICHAMBER_FOLDER_PICKER_START).toBe('/home/ryder');
+  });
+
+  it('uses the modern Windows folder picker on Windows', () => {
+    const commands = buildDirectoryPickerCommands('win32', 'C:\\Users\\ryder');
+    expect(commands).toHaveLength(1);
+    expect(commands[0].command).toBe('powershell.exe');
+    expect(commands[0].args).toContain('-EncodedCommand');
+    expect(commands[0].env.PICHAMBER_FOLDER_PICKER_START).toBe('C:\\Users\\ryder');
+  });
+});
+
+describe('runDirectoryPickerCommand', () => {
+  it('returns the picked path on success', async () => {
+    const child = createChild();
+    const spawn = vi.fn(() => child);
+    const pending = runDirectoryPickerCommand(spawn, 'zenity', ['--file-selection', '--directory']);
+    child.stdout.emit('data', '/home/ryder/src\n');
+    child.emit('close', 0);
+    await expect(pending).resolves.toEqual({ path: '/home/ryder/src' });
+  });
+
+  it('treats a missing binary as skippable', async () => {
+    const child = createChild();
+    const spawn = vi.fn(() => child);
+    const pending = runDirectoryPickerCommand(spawn, 'zenity', []);
+    child.emit('error', Object.assign(new Error('not found'), { code: 'ENOENT' }));
+    await expect(pending).resolves.toEqual({ missing: true });
+  });
+
+  it('treats a non-zero exit as cancelled', async () => {
+    const child = createChild();
+    const spawn = vi.fn(() => child);
+    const pending = runDirectoryPickerCommand(spawn, 'zenity', []);
+    child.emit('close', 1);
+    await expect(pending).resolves.toEqual({ cancelled: true });
+  });
+});
+
+describe('pickHostDirectory', () => {
+  it('skips missing pickers and returns the first successful path', async () => {
+    const runCommand = vi.fn()
+      .mockResolvedValueOnce({ missing: true })
+      .mockResolvedValueOnce({ path: '/picked' });
+
+    await expect(pickHostDirectory({
+      platform: 'linux',
+      spawn: vi.fn(),
+      defaultPath: '/home/ryder',
+      isWsl: false,
+      runCommand,
+    })).resolves.toEqual({ status: 'ok', path: '/picked' });
+
+    expect(runCommand).toHaveBeenCalledTimes(2);
+  });
+
+  it('converts a Windows path to a WSL path after picking', async () => {
+    const runCommand = vi.fn()
+      .mockResolvedValueOnce({ path: 'C:\\Users\\ryder\\src' })
+      .mockResolvedValueOnce({ path: '/mnt/c/Users/ryder/src' });
+
+    await expect(pickHostDirectory({
+      platform: 'linux',
+      spawn: vi.fn(),
+      isWsl: true,
+      runCommand,
+    })).resolves.toEqual({ status: 'ok', path: '/mnt/c/Users/ryder/src' });
+
+    expect(runCommand).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      'wslpath',
+      ['-u', 'C:\\Users\\ryder\\src'],
+    );
+  });
+
+  it('returns cancelled without trying later pickers', async () => {
+    const runCommand = vi.fn().mockResolvedValueOnce({ cancelled: true });
+    await expect(pickHostDirectory({
+      platform: 'linux',
+      spawn: vi.fn(),
+      isWsl: false,
+      runCommand,
+    })).resolves.toEqual({ status: 'cancelled' });
+    expect(runCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns unavailable when no picker binary exists', async () => {
+    const runCommand = vi.fn().mockResolvedValue({ missing: true });
+    await expect(pickHostDirectory({
+      platform: 'linux',
+      spawn: vi.fn(),
+      isWsl: false,
+      runCommand,
+    })).resolves.toEqual({ status: 'unavailable' });
+  });
+});

--- a/packages/web/server/lib/fs/routes.js
+++ b/packages/web/server/lib/fs/routes.js
@@ -3,6 +3,7 @@ import nodeFsPromises from 'node:fs/promises';
 import nodePath from 'node:path';
 import { resolvePiChamberDataDir } from '../pichamber-data-dir.js';
 import { createFsSearchRuntime } from './search.js';
+import { pickHostDirectory } from './pick-directory.js';
 
 const EXEC_JOB_TTL_MS = 30 * 60 * 1000;
 const OUTSIDE_FILE_GRANT_TTL_MS = 10 * 60 * 1000;
@@ -401,6 +402,7 @@ export const registerFsRoutes = (app, dependencies) => {
     buildAugmentedPath,
     resolveGitBinaryForSpawn,
     pichamberUserConfigRoot,
+    pickDirectory = pickHostDirectory,
   } = dependencies;
   const realpathCache = createRealpathCache({
     realpath: fsPromises.realpath.bind(fsPromises),
@@ -1217,6 +1219,42 @@ export const registerFsRoutes = (app, dependencies) => {
       }
       console.error('Failed to reveal path:', error);
       return res.status(500).json({ error: (error && error.message) || 'Failed to reveal path' });
+    }
+  });
+
+  app.post('/api/fs/pick-directory', async (req, res) => {
+    const requestedPath = typeof req.body?.path === 'string' ? req.body.path.trim() : '';
+    try {
+      const picked = await pickDirectory({
+        platform,
+        spawn,
+        defaultPath: requestedPath,
+      });
+      if (picked?.status === 'cancelled') {
+        return res.json({ cancelled: true });
+      }
+      if (picked?.status === 'unavailable') {
+        return res.status(501).json({ error: 'Folder picker is not available on this host.' });
+      }
+      if (picked?.status !== 'ok' || typeof picked.path !== 'string' || !picked.path.trim()) {
+        return res.status(500).json({ error: picked?.error || 'Failed to pick directory' });
+      }
+      const resolved = path.resolve(picked.path.trim());
+      const stats = await fsPromises.stat(resolved);
+      if (!stats.isDirectory()) {
+        return res.status(400).json({ error: 'Selected path is not a directory' });
+      }
+      return res.json({ path: resolved });
+    } catch (error) {
+      const err = error;
+      if (err && typeof err === 'object' && err.code === 'ENOENT') {
+        return res.status(404).json({ error: 'Path not found' });
+      }
+      if (isOsPermissionError(err)) {
+        return sendOsPermissionDenied(res, 'Access to path denied');
+      }
+      console.error('Failed to pick directory:', error);
+      return res.status(500).json({ error: (error && error.message) || 'Failed to pick directory' });
     }
   });
 

--- a/packages/web/server/lib/fs/routes.test.js
+++ b/packages/web/server/lib/fs/routes.test.js
@@ -857,3 +857,64 @@ describe('/api/fs/home', () => {
     });
   });
 });
+
+describe('/api/fs/pick-directory', () => {
+  const registerPick = ({ pickDirectory, fsPromises }) => {
+    const { app, getRoute } = createRouteRegistry();
+    registerFsRoutes(app, {
+      os: { homedir: () => '/home/user' },
+      path: path.posix,
+      fsPromises: {
+        realpath: async (targetPath) => targetPath,
+        stat: async () => ({ isDirectory: () => true }),
+        ...fsPromises,
+      },
+      spawn: vi.fn(),
+      crypto: { randomUUID: () => 'job-0' },
+      normalizeDirectoryPath: (p) => p,
+      resolveProjectDirectory: async () => ({ directory: '/repo' }),
+      buildAugmentedPath: () => '/usr/bin',
+      resolveGitBinaryForSpawn: () => 'git',
+      pichamberUserConfigRoot: '/home/user/.config',
+      pickDirectory,
+    });
+    return getRoute('POST', '/api/fs/pick-directory');
+  };
+
+  const callPick = async (handler, body) => {
+    const res = createMockResponse();
+    await handler({ body }, res);
+    return res;
+  };
+
+  it('returns the resolved directory path', async () => {
+    const handler = registerPick({
+      pickDirectory: vi.fn(async () => ({ status: 'ok', path: '/home/user/src' })),
+      fsPromises: {
+        stat: vi.fn(async () => ({ isDirectory: () => true })),
+      },
+    });
+    const res = await callPick(handler, { path: '/home/user' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ path: '/home/user/src' });
+  });
+
+  it('returns cancelled without treating it as an empty success path', async () => {
+    const handler = registerPick({
+      pickDirectory: vi.fn(async () => ({ status: 'cancelled' })),
+    });
+    const res = await callPick(handler, { path: '/home/user' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ cancelled: true });
+  });
+
+  it('returns 501 when no host picker is available', async () => {
+    const handler = registerPick({
+      pickDirectory: vi.fn(async () => ({ status: 'unavailable' })),
+    });
+    const res = await callPick(handler, {});
+    expect(res.statusCode).toBe(501);
+    expect(res.body).toEqual({ error: 'Folder picker is not available on this host.' });
+  });
+});
+


### PR DESCRIPTION
## Intent

Make adding a folder easier to understand: the dialog is driven by the path field, Browse picks a location without adding it, and **Add folder** is the only primary action. Clone sits in the directory list header. Already-added folders stay openable so a nested folder can still be added.

## Non-goals

Sidebar add-project labels, project persistence, and Electron IPC dialog plumbing are unchanged except that Browse prefers the modern Windows folder picker instead of the old tree dialog.

## Affected surfaces

- `packages/ui`: `DirectoryExplorerDialog` and path helpers; `pickLocalDirectory` in `fsApi`.
- `packages/web`: `POST /api/fs/pick-directory` host picker used by the web UI (Electron still uses the native shell dialog first).
- Web, desktop (via shared UI), hosted/Capacitor mobile (same dialog). VS Code does not own this dialog.
- No persisted project-store shape change; duplicate add is still exact-path only.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md / runtime boundaries | Shared UI plus a new PiChamber FS route | Domain picker lives in `packages/web/server/lib/fs`; UI consumes `runtimeFetch` / `fsApi` instead of inventing a runtime URL. |
| `pichamber-change-discipline` | Source, tests, and a new HTTP route | Smallest complete flow; duplicate add still blocked; picker cancel vs missing binary vs failure are distinct. |
| `ui-api-decoupling` | New `/api/fs/pick-directory` and desktop vs web pickers | Desktop uses existing native dialog; web uses the explicit PiChamber route; 501 is not treated as empty success. |
| `theme-system` | Buttons, icons, hover, folder-open animation | Shared `Button`/`Icon`; hover on full rows; list enter animates only opacity/transform; `motion-reduce:animate-none`. |
| `locale-ui-patterns` | Dialog copy, aria labels, CTA text | Direct inline strings; icon-only browse has `aria-label`; already-added rows stay labeled as openable. |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/components/session/directoryExplorerPaths.test.ts` | Pass (6 tests) |
| `bun run --cwd packages/web test -- server/lib/fs/pick-directory.test.js` | Pass (11 tests) |
| `bun run --cwd packages/web test -- server/lib/fs/pick-directory.test.js server/lib/fs/routes.test.js` | Pass (42 tests, including pick-directory route cases) |
| `bun run --cwd packages/ui type-check` / `lint` / `bun run dead-code` | Not run: this worktree did not have the local TypeScript/ESLint install those scripts expect |

Manual: not run in this worktree (dialog open, native/WSL browse, nested add). Static checks do not prove picker UX on desktop vs WSL.

## Visual evidence

User-visible add-folder dialog: path + Browse, clone in the list header, indented parent/child rows, up/`>` affordances, filled Added chip, enter animation. Screenshots were not captured in this session.

## Risks and failure behavior

- Browse on web/WSL opens a host OS picker. Cancel returns `{ cancelled: true }` and does not change the path. Missing picker returns 501 and a toast; it does not clear the current path.
- A failed pick leaves the existing path and directory list in place.
- Already-added folders are not re-added (`finalizeSelection` no-ops on exact path match). Child folders remain addable.
- Windows picks from WSL are converted with `wslpath`; if conversion fails the Windows path is kept and listing may fail until the user chooses another location.
- Remote/hosted servers may show a picker on the host, not the client (same class of issue as `/api/fs/reveal`).

Made with [Cursor](https://cursor.com)