### PR TITLE
Prepare the 0.1.8 release

### DIFF
--- a/.agents/skills/desktop-shell/SKILL.md
+++ b/.agents/skills/desktop-shell/SKILL.md
@@ -11,7 +11,7 @@ Read `packages/electron/README.md` and nearby `packages/electron` code before ed
 
 ## Runtime Boundary
 
-- Electron boots `@pichamber/web` in the same Node process and loads the UI over loopback. Do not introduce a sidecar server process.
+- Electron boots `@pi-chamber/web` in the same Node process and loads the UI over loopback. Do not introduce a sidecar server process.
 - Keep OpenCode feature backends and shared domain logic in web/server or runtime APIs.
 - Keep Electron focused on inherently native behavior: windows, menus, dialogs, notifications, updater, deep links, runtime host switching, privileged IPC, SSH, and tunnel lifecycle.
 - Shared renderer-facing contracts belong in `packages/ui`; shared server behavior belongs in `packages/web`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
         default: false
         type: boolean
       publish_npm:
-        description: 'Also publish @pichamber/web to npm (off for desktop-only releases)'
+        description: 'Also publish @pi-chamber/web to npm (off for desktop-only releases)'
         required: false
         default: false
         type: boolean

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.8] - 2026-08-18
+
+This release publishes the PiChamber server/CLI to npm as `@pi-chamber/web`.
+
+- Install with `npm install -g @pi-chamber/web` or the existing curl installer. The command is still `pichamber`.
+- `pichamber update` and desktop SSH-managed installs use that package. npm `latest` is trusted only when the registry repository is RyderAsKing/PiChamber.
+- Desktop installers stay on GitHub Releases. npm publish is opt-in on the Release workflow (`publish_npm` plus the `NPM_TOKEN` secret).
+
 ## [0.1.7] - 2026-08-18
 
 This release lets phones reach a desktop on the same Wi-Fi, keeps streaming

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ bun run lint:ui
 | `bun run build:ui` | Build only `packages/ui` |
 | `bun run build:electron` | Run Electron package build script without full packaging |
 | `bun run electron:build` | Build packaged desktop app for the current OS |
-| `bun run pack:web` | Create a package archive for `@pichamber/web` |
+| `bun run pack:web` | Create a package archive for `@pi-chamber/web` |
 
 ## Platform Build Notes
 
@@ -106,7 +106,7 @@ The final AppImage verifier checks desktop identity and the architecture of Elec
 
 ## Desktop releases
 
-PiChamber's public GitHub Release path is **Electron desktop** (macOS, Windows, Linux AppImage) plus a signed **Android APK/AAB** on version tags. npm (`@pichamber/web`) stays opt-in. iOS TestFlight stays opt-in via the Mobile Release workflow.
+PiChamber's public GitHub Release path is **Electron desktop** (macOS, Windows, Linux AppImage) plus a signed **Android APK/AAB** on version tags. npm (`@pi-chamber/web`) stays opt-in via the **Release** workflow (`publish_npm`). Store a granular npm **Automation** token as the `NPM_TOKEN` Actions secret; it must be allowed to publish the `pi-chamber` org. iOS TestFlight stays opt-in via the Mobile Release workflow.
 
 To cut a version:
 

--- a/bun.lock
+++ b/bun.lock
@@ -94,9 +94,9 @@
     },
     "packages/electron": {
       "name": "@pichamber/electron",
-      "version": "0.1.6",
+      "version": "0.1.8",
       "dependencies": {
-        "@pichamber/web": "workspace:*",
+        "@pi-chamber/web": "workspace:*",
         "electron-context-menu": "^4.1.2",
         "electron-log": "^5.4.3",
         "electron-updater": "^6.8.3",
@@ -130,7 +130,7 @@
     },
     "packages/ui": {
       "name": "@pichamber/ui",
-      "version": "0.1.6",
+      "version": "0.1.8",
       "dependencies": {
         "@aparajita/capacitor-secure-storage": "^8.0.0",
         "@base-ui/react": "^1.4.0",
@@ -228,8 +228,8 @@
       },
     },
     "packages/web": {
-      "name": "@pichamber/web",
-      "version": "0.1.6",
+      "name": "@pi-chamber/web",
+      "version": "0.1.8",
       "bin": {
         "pichamber": "./bin/cli.js",
       },
@@ -1045,13 +1045,13 @@
 
     "@peculiar/x509": ["@peculiar/x509@1.14.3", "", { "dependencies": { "@peculiar/asn1-cms": "^2.6.0", "@peculiar/asn1-csr": "^2.6.0", "@peculiar/asn1-ecc": "^2.6.0", "@peculiar/asn1-pkcs9": "^2.6.0", "@peculiar/asn1-rsa": "^2.6.0", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.0", "pvtsutils": "^1.3.6", "reflect-metadata": "^0.2.2", "tslib": "^2.8.1", "tsyringe": "^4.10.0" } }, "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA=="],
 
+    "@pi-chamber/web": ["@pi-chamber/web@workspace:packages/web"],
+
     "@pichamber/electron": ["@pichamber/electron@workspace:packages/electron"],
 
     "@pichamber/mobile": ["@pichamber/mobile@workspace:packages/mobile"],
 
     "@pichamber/ui": ["@pichamber/ui@workspace:packages/ui"],
-
-    "@pichamber/web": ["@pichamber/web@workspace:packages/web"],
 
     "@pierre/diffs": ["@pierre/diffs@1.3.0-beta.6", "", { "dependencies": { "@pierre/theme": "1.1.0", "@pierre/theming": "0.0.2", "@shikijs/transformers": "^3.0.0 || ^4.0.0", "diff": "9.0.0", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0 || ^4.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-SGxpOvuPeAq2sIMYqCokt8pVJ9UAZ6P5/qR4RYlcEVGRXOfGszbNMbrHs+IfRKnk6AufPNqVkIQWTwLC77x85A=="],
 
@@ -1777,7 +1777,7 @@
 
     "dezalgo": ["dezalgo@1.0.4", "", { "dependencies": { "asap": "^2.0.0", "wrappy": "1" } }, "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig=="],
 
-    "diff": ["diff@9.0.0", "", {}, "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw=="],
+    "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
     "dijkstrajs": ["dijkstrajs@1.0.3", "", {}, "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA=="],
 
@@ -2493,7 +2493,7 @@
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
-    "minipass": ["minipass@5.0.0", "", {}, "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="],
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "minipass-collect": ["minipass-collect@1.0.2", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA=="],
 
@@ -3283,8 +3283,6 @@
 
     "@capacitor/cli/tar": ["tar@7.5.13", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng=="],
 
-    "@earendil-works/pi-agent-core/diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
-
     "@earendil-works/pi-agent-core/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@earendil-works/pi-agent-core/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
@@ -3292,8 +3290,6 @@
     "@earendil-works/pi-ai/openai": ["openai@6.26.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
 
     "@earendil-works/pi-coding-agent/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
-
-    "@earendil-works/pi-coding-agent/diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
     "@earendil-works/pi-coding-agent/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
@@ -3345,8 +3341,6 @@
 
     "@ionic/utils-terminal/slice-ansi": ["slice-ansi@4.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "astral-regex": "^2.0.0", "is-fullwidth-code-point": "^3.0.0" } }, "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ=="],
 
-    "@isaacs/fs-minipass/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
-
     "@malept/flatpak-bundler/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
 
     "@npmcli/agent/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
@@ -3355,9 +3349,11 @@
 
     "@npmcli/move-file/rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
 
+    "@pi-chamber/web/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
     "@pichamber/ui/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
-    "@pichamber/web/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+    "@pierre/diffs/diff": ["diff@9.0.0", "", {}, "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw=="],
 
     "@radix-ui/react-collection/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
@@ -3475,8 +3471,6 @@
 
     "glob/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
-    "glob/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
-
     "iconv-corefoundation/cli-truncate": ["cli-truncate@2.1.0", "", { "dependencies": { "slice-ansi": "^3.0.0", "string-width": "^4.2.0" } }, "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg=="],
 
     "iconv-corefoundation/node-addon-api": ["node-addon-api@1.7.2", "", {}, "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg=="],
@@ -3531,8 +3525,6 @@
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
-    "path-scurry/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
-
     "postject/commander": ["commander@9.5.0", "", {}, "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="],
 
     "prebuild-install/tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
@@ -3567,6 +3559,8 @@
 
     "ssri/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
+    "tar/minipass": ["minipass@5.0.0", "", {}, "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="],
+
     "temp/mkdirp": ["mkdirp@0.5.6", "", { "dependencies": { "minimist": "^1.2.6" }, "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw=="],
 
     "temp/rimraf": ["rimraf@2.6.3", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "./bin.js" } }, "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA=="],
@@ -3600,8 +3594,6 @@
     "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "@capacitor/cli/tar/chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
-
-    "@capacitor/cli/tar/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "@capacitor/cli/tar/minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
 
@@ -3643,8 +3635,6 @@
 
     "app-builder-lib/tar/chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
 
-    "app-builder-lib/tar/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
-
     "app-builder-lib/tar/minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
 
     "app-builder-lib/tar/yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
@@ -3683,8 +3673,6 @@
 
     "node-gyp/make-fetch-happen/cacache": ["cacache@19.0.1", "", { "dependencies": { "@npmcli/fs": "^4.0.0", "fs-minipass": "^3.0.0", "glob": "^10.2.2", "lru-cache": "^10.0.1", "minipass": "^7.0.3", "minipass-collect": "^2.0.1", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "p-map": "^7.0.2", "ssri": "^12.0.0", "tar": "^7.4.3", "unique-filename": "^4.0.0" } }, "sha512-hdsUxulXCi5STId78vRVYEtDAjq99ICAUktLTeTYsLoTE6Z8dS0c8pWNCxwdrk9YfJeobDZc2Y186hD/5ZQgFQ=="],
 
-    "node-gyp/make-fetch-happen/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
-
     "node-gyp/make-fetch-happen/minipass-fetch": ["minipass-fetch@4.0.1", "", { "dependencies": { "minipass": "^7.0.3", "minipass-sized": "^1.0.3", "minizlib": "^3.0.1" }, "optionalDependencies": { "encoding": "^0.1.13" } }, "sha512-j7U11C5HXigVuutxebFadoYBbd7VSdZWggSe64NVdvWNBqGAiXPL2QVCehjmw7lY1oF9gOllYbORh+hiNgfPgQ=="],
 
     "node-gyp/make-fetch-happen/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
@@ -3694,8 +3682,6 @@
     "node-gyp/nopt/abbrev": ["abbrev@3.0.1", "", {}, "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg=="],
 
     "node-gyp/tar/chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
-
-    "node-gyp/tar/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "node-gyp/tar/minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
 
@@ -3732,8 +3718,6 @@
     "workbox-build/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "workbox-build/glob/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
-
-    "workbox-build/glob/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "@earendil-works/pi-coding-agent/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pichamber-monorepo",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "PiChamber monorepo workspace for web, ui, and desktop runtimes",
   "private": true,
   "type": "module",

--- a/packages/docs/content/docs/install.mdx
+++ b/packages/docs/content/docs/install.mdx
@@ -15,4 +15,10 @@ PiChamber server requires Node.js 22 or newer.
 curl -fsSL https://raw.githubusercontent.com/RyderAsKing/PiChamber/main/scripts/install.sh | bash
 ```
 
+Or install the CLI package from npm:
+
+```sh
+npm install -g @pi-chamber/web
+```
+
 Run `pichamber serve` after installation. The server creates and owns its local Pi session daemon automatically.

--- a/packages/electron/README.md
+++ b/packages/electron/README.md
@@ -4,7 +4,7 @@ Electron is PiChamber's native desktop shell for macOS, Windows, and Linux.
 
 ## Runtime
 
-`main.mjs` starts `@pichamber/web/server/index.js` in the Electron main process. It never starts a server sidecar or manages an external coding-agent binary. Development loads the HMR UI; packaged builds load staged assets from `pichamber-ui://` while the in-process loopback server remains the authenticated API backend. Unpackaged `electron ./main.mjs` reports host Electron version `0.0`; main pins `package.json` (or `0.0.0-dev`) onto `app.setVersion` before constructing `electron-updater`.
+`main.mjs` starts `@pi-chamber/web/server/index.js` in the Electron main process. It never starts a server sidecar or manages an external coding-agent binary. Development loads the HMR UI; packaged builds load staged assets from `pichamber-ui://` while the in-process loopback server remains the authenticated API backend. Unpackaged `electron ./main.mjs` reports host Electron version `0.0`; main pins `package.json` (or `0.0.0-dev`) onto `app.setVersion` before constructing `electron-updater`.
 
 The preload bridge exposes only desktop-owned capabilities. Main-process handlers enforce every privileged action; remote pages do not receive local filesystem, shell, token, or host privileges.
 

--- a/packages/electron/main.mjs
+++ b/packages/electron/main.mjs
@@ -31,8 +31,8 @@ import {
   setLinuxAutostartEnabled,
 } from './linux-autostart.mjs';
 import { unsupportedAppSpecificOpenError, validateLocalPath } from './path-open-utils.mjs';
-import { mintOutsideFileGrant } from '@pichamber/web/server/lib/fs/routes.js';
-import { resolvePiChamberDataDir, resolvePiChamberDataPath } from '@pichamber/web/server/lib/pichamber-data-dir.js';
+import { mintOutsideFileGrant } from '@pi-chamber/web/server/lib/fs/routes.js';
+import { resolvePiChamberDataDir, resolvePiChamberDataPath } from '@pi-chamber/web/server/lib/pichamber-data-dir.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -1340,8 +1340,8 @@ const loadShellEnv = () => {
 };
 
 // Merge the user's login-shell env (PATH, etc.) into this process before we
-import { pathLooksUserConfigured, mergePathValues } from '@pichamber/web/server/lib/server/path-utils.js';
-import { clearAppImageArgv0FromProcessEnv } from '@pichamber/web/server/lib/inherited-env.js';
+import { pathLooksUserConfigured, mergePathValues } from '@pi-chamber/web/server/lib/server/path-utils.js';
+import { clearAppImageArgv0FromProcessEnv } from '@pi-chamber/web/server/lib/inherited-env.js';
 
 // import/start the server in-process. The server and its subprocesses inherit
 // process.env directly — there is no sidecar
@@ -1438,7 +1438,7 @@ const spawnLocalServer = async () => {
   process.env.NO_PROXY = process.env.NO_PROXY || 'localhost,127.0.0.1';
   process.env.no_proxy = process.env.no_proxy || 'localhost,127.0.0.1';
 
-  const { startWebUiServer } = await import('@pichamber/web/server/index.js');
+  const { startWebUiServer } = await import('@pi-chamber/web/server/index.js');
 
   const handle = await startWebUiServer({
     port: chosenPort,

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@pichamber/electron",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": true,
   "description": "Electron desktop runtime for PiChamber",
   "author": "PiChamber",
   "type": "module",
   "main": "./dist-bundle/main.mjs",
   "dependencies": {
-    "@pichamber/web": "workspace:*",
+    "@pi-chamber/web": "workspace:*",
     "electron-context-menu": "^4.1.2",
     "electron-log": "^5.4.3",
     "electron-updater": "^6.8.3"

--- a/packages/electron/scripts/bundle-main.mjs
+++ b/packages/electron/scripts/bundle-main.mjs
@@ -1,14 +1,14 @@
 /**
  * Bundle main.mjs into a single file. Small electron-* helper deps are
  * inlined; everything else — including the in-process web server
- * (@pichamber/web) and native modules — stays external so it resolves
+ * (`@pi-chamber/web`) and native modules — stays external so it resolves
  * from node_modules at runtime inside the packaged app.
  *
  * Why external matters: packages/web/server pulls in bun-pty, which has
  * a top-level `import { dlopen } from "bun:ffi"`. If we inline it here,
  * Node's ESM loader sees `bun:ffi` at package load time and crashes with
  * ERR_UNSUPPORTED_ESM_URL_SCHEME before any runtime guard can skip it.
- * Leaving @pichamber/web external means the conditional
+ * Leaving @pi-chamber/web external means the conditional
  * `if (isBunRuntime) await import('bun-pty')` stays dynamic and is never
  * reached under Electron.
  */
@@ -26,8 +26,8 @@ const result = await Bun.build({
   format: 'esm',
   external: [
     'electron',
-    '@pichamber/web',
-    '@pichamber/web/*',
+    '@pi-chamber/web',
+    '@pi-chamber/web/*',
     'bun-pty',
     'node-pty',
   ],

--- a/packages/electron/ssh-manager.mjs
+++ b/packages/electron/ssh-manager.mjs
@@ -1005,14 +1005,14 @@ export class ElectronSshManager {
     const commands = [];
 
     if (preferred === 'bun') {
-      if (hasBun) commands.push(`bun add -g @pichamber/web@${version}`);
-      if (hasNpm) commands.push(`npm install -g @pichamber/web@${version}`);
+      if (hasBun) commands.push(`bun add -g @pi-chamber/web@${version}`);
+      if (hasNpm) commands.push(`npm install -g @pi-chamber/web@${version}`);
     } else if (preferred === 'npm') {
-      if (hasNpm) commands.push(`npm install -g @pichamber/web@${version}`);
-      if (hasBun) commands.push(`bun add -g @pichamber/web@${version}`);
+      if (hasNpm) commands.push(`npm install -g @pi-chamber/web@${version}`);
+      if (hasBun) commands.push(`bun add -g @pi-chamber/web@${version}`);
     } else {
-      if (hasBun) commands.push(`bun add -g @pichamber/web@${version}`);
-      if (hasNpm) commands.push(`npm install -g @pichamber/web@${version}`);
+      if (hasBun) commands.push(`bun add -g @pi-chamber/web@${version}`);
+      if (hasNpm) commands.push(`npm install -g @pi-chamber/web@${version}`);
     }
 
     if (commands.length === 0) {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pichamber/ui",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": true,
   "type": "module",
   "main": "src/main.tsx",

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -1,4 +1,4 @@
-# @pichamber/web
+# @pi-chamber/web
 
 PiChamber's web server and browser UI for the Pi coding-agent runtime.
 

--- a/packages/web/bin/cli.test.js
+++ b/packages/web/bin/cli.test.js
@@ -610,10 +610,10 @@ describe('cli entry detection', () => {
 
 describe('isPiChamberCmdline (and legacy isOpenchamberCmdline alias)', () => {
   it('accepts PiChamber package entrypoints (Unix + Windows paths)', () => {
-    expect(isPiChamberCmdline('node /usr/local/lib/node_modules/@pichamber/web/bin/cli.js serve')).toBe(true);
-    expect(isPiChamberCmdline('node /usr/local/lib/node_modules/@pichamber/web/server/index.js --port 9090')).toBe(true);
+    expect(isPiChamberCmdline('node /usr/local/lib/node_modules/@pi-chamber/web/bin/cli.js serve')).toBe(true);
+    expect(isPiChamberCmdline('node /usr/local/lib/node_modules/@pi-chamber/web/server/index.js --port 9090')).toBe(true);
     // Quoted Windows path with spaces in the install location.
-    expect(isPiChamberCmdline('"C:\\Program Files\\nodejs\\node.exe" "C:\\Users\\u\\AppData\\Roaming\\npm\\node_modules\\@pichamber\\web\\server\\index.js" --port 9090')).toBe(true);
+    expect(isPiChamberCmdline('"C:\\Program Files\\nodejs\\node.exe" "C:\\Users\\u\\AppData\\Roaming\\npm\\node_modules\\@pi-chamber\\web\\server\\index.js" --port 9090')).toBe(true);
     // Direct executable invocation on unix / windows must occupy argv[0].
     expect(isPiChamberCmdline('/usr/local/bin/pichamber serve --port 3000')).toBe(true);
     expect(isPiChamberCmdline('C:\\Users\\u\\AppData\\Roaming\\npm\\pichamber.cmd serve')).toBe(true);
@@ -646,7 +646,7 @@ describe('isPiChamberCmdline (and legacy isOpenchamberCmdline alias)', () => {
   });
 
   it('keeps the legacy alias compatible with current PiChamber callers', () => {
-    expect(isOpenchamberCmdline('node /usr/local/lib/node_modules/@pichamber/web/bin/cli.js serve')).toBe(true);
+    expect(isOpenchamberCmdline('node /usr/local/lib/node_modules/@pi-chamber/web/bin/cli.js serve')).toBe(true);
     expect(isOpenchamberCmdline('node /home/herjarsa/npm-global/bin/agentmemory')).toBe(false);
   });
 });

--- a/packages/web/bin/lib/cli-process.js
+++ b/packages/web/bin/lib/cli-process.js
@@ -132,7 +132,7 @@ function readProcessCmdline(pid) {
 // Identity recognition proceeds as follows:
 //   1. Accept a direct `pichamber` executable in argv[0].
 //   2. Accept a Node/Bun process only when its first script argument is a
-//      published `@pichamber/web` or source-checkout PiChamber entrypoint.
+//      published `@pi-chamber/web` or source-checkout PiChamber entrypoint.
 //
 // A product-name token in a later argument is not enough: a stale pid file
 // must never authorize stopping `/bin/sh -c "echo pichamber"` or
@@ -163,7 +163,7 @@ function isNodeOrBunExecutableToken(token) {
 
 function isPiChamberEntrypointToken(token) {
   const normalized = normalizeCommandToken(token);
-  return /(?:^|\/)@pichamber\/web\/(?:bin\/cli\.js|server\/index\.js)$/i.test(normalized)
+  return /(?:^|\/)@pi-chamber\/web\/(?:bin\/cli\.js|server\/index\.js)$/i.test(normalized)
     || /(?:^|\/)PiChamber\/packages\/web\/(?:bin\/cli\.js|server\/index\.js)$/i.test(normalized);
 }
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,8 +1,12 @@
 {
-  "name": "@pichamber/web",
-  "version": "0.1.7",
+  "name": "@pi-chamber/web",
+  "version": "0.1.8",
   "private": false,
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/RyderAsKing/PiChamber.git"
+  },
   "main": "./server/index.js",
   "types": "./server/index.d.ts",
   "bin": {

--- a/packages/web/server/lib/package-manager.js
+++ b/packages/web/server/lib/package-manager.js
@@ -9,9 +9,9 @@ import { resolvePiChamberDataDir, resolvePiChamberDataPath } from './pichamber-d
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const PACKAGE_NAME = '@pichamber/web';
+const PACKAGE_NAME = '@pi-chamber/web';
 const PACKAGE_PATH_SEGMENTS = PACKAGE_NAME.split('/');
-const NPM_REGISTRY_URL = `https://registry.npmjs.org/${PACKAGE_NAME}`;
+const NPM_REGISTRY_URL = `https://registry.npmjs.org/${encodeURIComponent(PACKAGE_NAME)}`;
 const OFFICIAL_GITHUB_REPO = 'ryderasking/pichamber';
 const CHANGELOG_URL = 'https://raw.githubusercontent.com/RyderAsKing/PiChamber/main/CHANGELOG.md';
 const GITHUB_RELEASES_URL = 'https://github.com/RyderAsKing/PiChamber/releases';
@@ -694,8 +694,8 @@ function isOfficialPiChamberRegistryPackage(data) {
 }
 
 /**
- * Fetch latest version from npm only when `@pichamber/web` is this project's package.
- * The scoped name is currently occupied by an unrelated 1.0.0; dist-tag alone is not enough.
+ * Fetch latest version from npm only when `@pi-chamber/web` is this project's package.
+ * Dist-tag alone is not enough if an unrelated package occupies the name.
  */
 async function getLatestVersion() {
   try {

--- a/packages/web/server/lib/package-manager.test.js
+++ b/packages/web/server/lib/package-manager.test.js
@@ -112,7 +112,7 @@ describe('checkForUpdates (no hosted API by default)', () => {
     });
   });
 
-  it('ignores npm latest when @pichamber/web is not the official PiChamber repository', async () => {
+  it('ignores npm latest when pichamber is not the official PiChamber repository', async () => {
     await withNoHostedApi(async () => {
       fetchMock.when('registry.npmjs.org', {
         ok: true,
@@ -348,10 +348,10 @@ describe('checkForUpdates (no hosted API by default)', () => {
 });
 
 describe('package-manager ownership detection', () => {
-  it('detects PiChamber-claimed paths only and rejects legacy pichamber package output', () => {
-    const containsPackage = (stdout) => stdout.includes('@pichamber/web');
-    expect(containsPackage('/home/u/.npm-global/lib/node_modules/@pichamber/web')).toBe(true);
-    expect(containsPackage('pichamber@1.0.0')).toBe(false);
+  it('detects PiChamber-claimed paths for the @pi-chamber/web package', () => {
+    const containsPackage = (stdout) => stdout.includes('@pi-chamber/web');
+    expect(containsPackage('/home/u/.npm-global/lib/node_modules/@pi-chamber/web')).toBe(true);
+    expect(containsPackage('@pi-chamber/web@0.1.7')).toBe(true);
   });
 });
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-PACKAGE_NAME="@pichamber/web"
+PACKAGE_NAME="@pi-chamber/web"
 BIN_NAME="pichamber"
 MIN_NODE_VERSION=22
 


### PR DESCRIPTION
## Intent

Ship 0.1.8 so the PiChamber server/CLI can be installed from npm as `@pi-chamber/web` (binary still `pichamber`). `@pichamber/web` is owned by someone else; this uses the `pi-chamber` org.

## Non-goals

No Homebrew/winget/apt packages. Desktop still ships from GitHub Releases. This PR does not create the `NPM_TOKEN` secret (it is already on the repo).

## Affected surfaces

- `@pi-chamber/web` (`packages/web`): published name, installer, `pichamber update`
- Electron: workspace dependency and in-process imports; SSH-managed remote install commands
- Docs/install script, Release workflow copy, CONTRIBUTING npm publish notes
- Versions: root, ui, web, electron bumped to 0.1.8 (mobile package version unchanged)

Web, hosted mobile, and Capacitor are unaffected except that they can install the same npm CLI.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `pichamber-change-discipline` | Package name, version, installer, and Electron workspace contract | Smallest rename to `@pi-chamber/web`; update consumers, tests, and owning docs |
| `desktop-shell` | Electron main imports and SSH remote install | In-process `startWebUiServer` still loads from the workspace package; no sidecar |
| `packages/web/README.md`, `packages/electron/README.md` | Owning package docs | Install and boot paths match the published name |
| Release changelog gate | Workflow requires `## [0.1.8]` in CHANGELOG.md | Section added for 2026-08-18 |

## Validation

| Check | Result |
|---|---|
| `bun run --cwd packages/web test -- bin/cli.test.js server/lib/package-manager.test.js` | 79 passed |
| `bun run --cwd packages/web type-check` | passed |
| `bun run --cwd packages/electron type-check` | `node --check` passed |
| `bun run docs:validate` | passed |
| Actual `npm publish` / Release workflow | not run in this commit; dispatched after the PR exists |

## Visual evidence

No rendered UI change. Install copy and the published package name are docs/CLI only.

## Risks and failure behavior

- If `NPM_TOKEN` cannot publish the `pi-chamber` org, the Release `publish-npm` job fails; GitHub desktop artifacts can still upload.
- `pichamber update` ignores npm `latest` unless the registry package repository is RyderAsKing/PiChamber, so a squatted name cannot drive upgrades.
- First-time global installs of `@pichamber/web` (wrong scope) stay broken; users must use `@pi-chamber/web`.
- Rollback: unpublish is not available after 72h; yank with a new version if needed.

## Test plan

- [ ] PR checks (type-check, lint, build, Electron unit tests) pass
- [ ] Release workflow on this branch with `version=0.1.8` and `publish_npm=true` publishes `@pi-chamber/web@0.1.8`
- [ ] `npm install -g @pi-chamber/web` then `pichamber --help` works
- [ ] Desktop artifacts appear on the v0.1.8 GitHub Release


Made with [Cursor](https://cursor.com)