### PR TITLE
fix(ui): remove auto Add folder popup on launch and instance switch

### DIFF
--- a/packages/ui/src/components/session/SessionDialogs.tsx
+++ b/packages/ui/src/components/session/SessionDialogs.tsx
@@ -16,11 +16,10 @@ import { DirectoryExplorerDialog } from './DirectoryExplorerDialog';
 import type { Session } from '@/lib/chat/types';
 import { useSessionUIStore } from '@/sync/session-ui-store';
 import * as sessionActions from '@/sync/session-actions';
-import { useDirectoryStore } from '@/stores/useDirectoryStore';
-import { useProjectsStore } from '@/stores/useProjectsStore';
 import { useUIStore } from '@/stores/useUIStore';
 import { useDeviceInfo } from '@/lib/device';
 import { sessionEvents } from '@/lib/sessionEvents';
+import { subscribeRuntimeEndpointWillChange } from '@/lib/runtime-switch';
 
 const renderToastDescription = (text?: string) =>
     text ? <span className="text-foreground/80 dark:text-foreground/70">{text}</span> : undefined;
@@ -32,7 +31,6 @@ type DeleteDialogState = {
 
 export const SessionDialogs: React.FC = () => {
     const [isDirectoryDialogOpen, setIsDirectoryDialogOpen] = React.useState(false);
-    const [hasShownInitialDirectoryPrompt, setHasShownInitialDirectoryPrompt] = React.useState(false);
     const [deleteDialog, setDeleteDialog] = React.useState<DeleteDialogState | null>(null);
     const [isProcessingDelete, setIsProcessingDelete] = React.useState(false);
 
@@ -40,23 +38,14 @@ export const SessionDialogs: React.FC = () => {
     const deleteSessions = useSessionUIStore((s) => s.deleteSessions);
     const showDeletionDialog = useUIStore((state) => state.showDeletionDialog);
     const setShowDeletionDialog = useUIStore((state) => state.setShowDeletionDialog);
-    const isHomeReady = useDirectoryStore((s) => s.isHomeReady);
-    const projects = useProjectsStore((s) => s.projects);
     const { isMobile, isTablet, hasTouchInput } = useDeviceInfo();
     const useMobileOverlay = isMobile || isTablet || hasTouchInput;
 
     React.useEffect(() => {
-        if (hasShownInitialDirectoryPrompt || !isHomeReady || projects.length > 0) {
-            return;
-        }
-
-        setHasShownInitialDirectoryPrompt(true);
-        setIsDirectoryDialogOpen(true);
-    }, [
-        hasShownInitialDirectoryPrompt,
-        isHomeReady,
-        projects.length,
-    ]);
+        return subscribeRuntimeEndpointWillChange(() => {
+            setIsDirectoryDialogOpen(false);
+        });
+    }, []);
 
     const openDeleteDialog = React.useCallback((payload: { sessions: Session[]; dateLabel?: string }) => {
         setDeleteDialog({


### PR DESCRIPTION
## Intent

Removes the automatic “Add folder” (`DirectoryExplorerDialog`) popup that fires on app open and on instance/runtime switch when `projects.length === 0`. Users reported the modal appearing every launch and every host switch, blocking the main UI. After this change the dialog only opens via explicit user action.

Behavior change:
- Before: `SessionDialogs` auto-opened when `isHomeReady && projects.length === 0` (once per mount), plus a race during `runtimeEndpointReset` where `projects` is briefly `[]` while `isHomeReady` flips `false→true` after switch.
- After: No auto-open on mount, on `isHomeReady` transition, or on runtime switch. Adding a folder remains available manually.

## Non-goals

- No change to `DirectoryExplorerDialog` validation, clone flow, or `mkdir` logic.
- No change to `useProjectsStore` / `useDirectoryStore` persistence or `runtimeEndpointReset` reset logic.
- No change to deletion-dialog flow in the same component.
- No new empty-state UI; existing sidebar/settings empty states are kept as-is.

## Affected surfaces

- **Package:** `packages/ui` — `src/components/session/SessionDialogs.tsx` (1 file)
- **Runtimes:** shared UI → web, desktop (Electron), hosted mobile, Capacitor mobile. Fix is in shared `SessionDialogs` mounted by `MainLayout` (web/desktop) and `MobileApp`.
- **User-visible:** auto-modal removed. Manual triggers preserved: `sessionEvents.requestDirectoryDialog()` from `SessionSidebar` (+ button), `CommandPalette` (“Add folder”), `ProjectsSidebar` (Settings → Projects +). Empty workspace now stays empty until user clicks Add.
- **Persisted/external contracts:** none. Removed state was local `useState(hasShownInitialDirectoryPrompt)` only — not persisted.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` Instruction Order + Runtime Boundaries | Change touches shared UI used by all runtimes; must respect shared/runtime contracts and `RuntimeAPIs` vs Pi API split | Verified `SessionDialogs` is shared UI, no `RuntimeAPIs` change, runtime-specific probe not needed |
| `AGENTS.md` Always-On Constraints + Correctness Invariants | Must not let fetch/persistence failure masquerade as empty state; must avoid heuristics | Auto-popup relied on `projects.length===0` heuristic before authoritative settings arrived — replaced with explicit manual action, so fetch race no longer treated as “needs onboarding” |
| `.agents/skills/pichamber-change-discipline/SKILL.md` (local impl) | Private component behavior in one package | Smallest change: 5 insertions / 16 deletions, preserved manual behavior, traced consumers |
| Sync/state invariants (implied) | Runtime switch clears caches then repopulates; dialog must not show stale cross-runtime path | Added `subscribeRuntimeEndpointWillChange(() => setIsDirectoryDialogOpen(false))` to drop open dialog before switch, matching other stores’ `resetForRuntimeSwitch` |
| Nearest docs: `packages/ui/DOCUMENTATION.md` (discovered) | UI package discipline | No ownership/contract doc change needed |

## Validation

| Check | Result |
|---|---|
| `bun run --cwd packages/ui type-check` (`tsc --noEmit`) | PASS |
| `bun run --cwd packages/ui lint` | PASS (0 errors, 1 pre-existing warning in `ComposerEditor.tsx:467` - missing `handlersRef` dep) |
| `bun run dead-code` | PASS — `SessionDialogs` not reported dead; expected duplicate-export warnings only |
| `bun test --cwd packages/ui` (full suite) | 1419 pass / 99 fail on branch. Stashed change and re-ran on `main`: 1411 pass / 99 fail — no new failures introduced; failing suites are pre-existing (`useUIStore`, `useConfigStore`, `PiService`, `Button`, etc. — not touching `SessionDialogs`) |
| Manual code trace | Confirmed no other `setIsDirectoryDialogOpen` caller besides auto-effect + `onDirectoryRequest`; grep clean after patch |
| Not verified (needs live hosts) | E2E: fresh profile cold start, manual Add via palette/sidebar, switch between two runtimes (LAN/relay) verifying no popup and manual dialog still works |

## Visual evidence

User-visible change is **removal** of an auto-modal. No new styling.

- Before: on fresh profile or immediately after `switchRuntimeEndpoint`, `DirectoryExplorerDialog` opened modally over the layout.
- After: app lands on normal layout/sidebar empty state; dialog only appears after explicit user trigger (Sidebar +, Command Palette > Add folder, Settings → Projects +). Manual open was verified by code path (`sessionEvents.requestDirectoryDialog → useEffect → setIsDirectoryDialogOpen(true)`) and is unchanged.

No screenshot/recording attached at PR creation — state change is absence of blocking modal. Can add before/after screen capture on request from a live desktop/web session.

## Risks and failure behavior

- **Risk: new users miss onboarding cue** — mitigated: empty sidebar still shows affordance; `ProjectsSidebar`/`ProjectsPage` show `+` CTA; docs can add inline hint as follow-up if needed.
- **Rollback:** revert commit `5f974a47` — restores auto-popup. No persisted migration to undo (local `useState` only).
- **Cleanup/failure:** if dialog was open during switch, `subscribeRuntimeEndpointWillChange` now closes it to avoid stale `dialogHomeDirectory`/`targetPath` (previous-runtime path leaking into new instance).
- **Cross-runtime:** change is shared → applies to web, desktop, mobile. No platform-specific native code.
- **Security/compatibility:** none — no new deps, no settings/core logic change.

Closes: add-folder auto-popup on open / instance switch.
