### PR TITLE
fix(mobile): parity fixes for v0.3.2 / v0.3.3 sidebar, subtask, and s…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Mobile parity fixes for v0.3.2 / v0.3.3
+
+Targets the three remaining phone/tablet gaps from the v0.3.2 (forked sessions, retry limit, side-panel removal) and v0.3.3 (hotfix) cycle.
+
+- **Subtask "Open subtask session" closes mobile drawers.** The user-subtask part on dedicated mobile now closes the sessions sheet and workspace drawer after switching to the subtask session, so the new chat lands in view instead of under an open drawer. Shared component, no-op on web/desktop (`MobileApp`, `mobileAppContext`, `MessageBody`).
+- **Fork-family color is visible on phone/tablet sidebar.** The v0.3.2 fork accent was painted as a ~11% `color-mix` wash that reads as "no color" against `bg-sidebar` on the 72%-width phone drawer. Mobile surfaces now paint a 3px solid `borderLeft` with the same deterministic per-family color, while the desktop wash is unchanged (`forkFamilyColor`, `SessionNodeItem`).
+- **Persisted UI store re-sanitizes side-panel tabs.** Bumped persisted `ui-store` version 16 → 17 with a one-shot migration that re-runs `sanitizeContextPanelByDirectory` and strips `chat` from `contextRailOrder`. Devices with stale chat-mode tabs persisted (e.g. hosted-mobile tablet-width users on the desktop fallback) self-heal on first load without clearing site data (`useUIStore`).
+- **Provider refresh buttons meet the phone touch target.** Four `Refresh catalog` / `Refresh providers` icon buttons now use `size="sm"` on dedicated mobile instead of `size="icon"`, hitting the shared 36px touch affordance while staying compact on desktop (`ProvidersPage`).
+
 ## [0.3.3] - 2026-08-22
 
 Hotfix for the 0.3.2 desktop startup crash.

--- a/packages/ui/src/apps/MobileApp.tsx
+++ b/packages/ui/src/apps/MobileApp.tsx
@@ -278,6 +278,11 @@ const MobileShell: React.FC<{ onActiveConnectionDeleted: () => void }> = ({ onAc
     return () => root.classList.remove('oc-keep-draft-starters');
   }, [hasHardwareKeyboard, isTabletLayout, isPortrait]);
 
+  const closeAllDrawers = React.useCallback(() => {
+    setSessionsSheetOpenSafely(false);
+    setWorkspaceOpenSafely(false);
+  }, [setSessionsSheetOpenSafely, setWorkspaceOpenSafely]);
+
   const mobileActions = React.useMemo<MobileAppActions>(
     () => ({
       openChanges: ({ diffPath, staged } = {}) => {
@@ -288,8 +293,9 @@ const MobileShell: React.FC<{ onActiveConnectionDeleted: () => void }> = ({ onAc
       openInstances: showCapacitorOnlyFeatures ? () => openSurface('instances') : undefined,
       instanceLabel: showCapacitorOnlyFeatures ? getAutoConnectTargetLabel() : null,
       openUpdate: showUpdateItem ? () => openSurface('update') : undefined,
+      closeDrawers: closeAllDrawers,
     }),
-    [openChangesSurface, openFilesSurface, openSettingsSurface, openSurface, showCapacitorOnlyFeatures, showUpdateItem],
+    [closeAllDrawers, openChangesSurface, openFilesSurface, openSettingsSurface, openSurface, showCapacitorOnlyFeatures, showUpdateItem],
   );
 
   // Expose the shell's panel-opening actions to the deep-link layer so pichamber:// URLs

--- a/packages/ui/src/apps/mobileAppContext.tsx
+++ b/packages/ui/src/apps/mobileAppContext.tsx
@@ -14,6 +14,14 @@ export type MobileAppActions = {
   instanceLabel?: string | null;
   /** Hosted mobile: open the pending server-update surface. */
   openUpdate?: () => void;
+  /**
+   * Close any open drawer layer (sessions sheet, workspace drawer) so a
+   * navigation gesture — like opening a subtask session — can settle the
+   * chat surface without the user having to dismiss the drawer manually.
+   * No-op when no drawer is open or when not running inside the dedicated
+   * mobile shell (the desktop MainLayout has no phone drawer to close).
+   */
+  closeDrawers?: () => void;
 };
 
 const DedicatedMobileAppContext = React.createContext<MobileAppActions | null>(null);

--- a/packages/ui/src/components/chat/message/MessageBody.tsx
+++ b/packages/ui/src/components/chat/message/MessageBody.tsx
@@ -21,6 +21,7 @@ import type { ContentChangeReason } from '@/hooks/useChatAutoFollow';
 import { SimpleMarkdownRenderer } from '../MarkdownRenderer';
 import { useSessionUIStore } from '@/sync/session-ui-store';
 import { useUIStore } from '@/stores/useUIStore';
+import { useMobileAppActions } from '@/apps/mobileAppContext';
 import { TextSelectionMenu } from './TextSelectionMenu';
 import { copyTextToClipboard } from '@/lib/clipboard';
 import { useChatSurfaceMode } from '@/components/chat/useChatSurfaceMode';
@@ -174,6 +175,11 @@ const UserSubtaskPart: React.FC<{ part: SubtaskPartLike }> = ({ part }) => {
     const [expanded, setExpanded] = React.useState(false);
     const effectiveDirectory = useEffectiveDirectory();
     const setCurrentSession = useSessionUIStore((state) => state.setCurrentSession);
+    // On the dedicated mobile shell, swapping to the subtask session with
+    // the sessions drawer still open leaves the user staring at the drawer
+    // covering the new chat. The shell exposes `closeDrawers` for exactly
+    // this — no-op when running on web/desktop.
+    const mobileActions = useMobileAppActions();
 
     const description = typeof part.description === 'string' ? part.description.trim() : '';
     const command = typeof part.command === 'string' ? part.command.trim() : '';
@@ -181,6 +187,12 @@ const UserSubtaskPart: React.FC<{ part: SubtaskPartLike }> = ({ part }) => {
     const prompt = typeof part.prompt === 'string' ? part.prompt.trim() : '';
     const taskSessionID = typeof part.taskSessionID === 'string' ? part.taskSessionID.trim() : '';
     const model = normalizeSubtaskModel(part.model);
+
+    const openSubtaskSession = React.useCallback(() => {
+        if (!effectiveDirectory || !taskSessionID) return;
+        setCurrentSession(taskSessionID, effectiveDirectory);
+        mobileActions?.closeDrawers?.();
+    }, [effectiveDirectory, taskSessionID, setCurrentSession, mobileActions]);
 
     return (
         <div className="mt-2">
@@ -231,10 +243,7 @@ const UserSubtaskPart: React.FC<{ part: SubtaskPartLike }> = ({ part }) => {
                     <button
                         type="button"
                         className="typography-meta text-muted-foreground hover:text-foreground transition-colors underline underline-offset-2"
-                        onClick={() => {
-                            if (!effectiveDirectory) return;
-                            setCurrentSession(taskSessionID, effectiveDirectory);
-                        }}
+                        onClick={openSubtaskSession}
                     >
                         {"Open subtask session"}
                     </button>

--- a/packages/ui/src/components/sections/providers/ProvidersPage.tsx
+++ b/packages/ui/src/components/sections/providers/ProvidersPage.tsx
@@ -600,7 +600,11 @@ export const ProvidersPage: React.FC = () => {
             <div className="flex items-center gap-1">
               <Button
                 variant="ghost"
-                size="icon"
+                // 32px `size="icon"` is too tight for a phone touch target.
+                // Use `size="sm"` on dedicated mobile so the button meets the
+                // shared 36px touch affordance without sacrificing the row's
+                // compactness on desktop.
+                size={isMobile ? 'sm' : 'icon'}
                 onClick={() => void refreshCatalog()}
                 disabled={refreshingCatalog || busy}
                 aria-label="Refresh model catalog"
@@ -684,7 +688,7 @@ export const ProvidersPage: React.FC = () => {
           <div className="flex items-center gap-2">
             <Button
               variant="ghost"
-              size="icon"
+              size={isMobile ? 'sm' : 'icon'}
               onClick={() => void refreshProviders()}
               disabled={refreshing}
               aria-label="Refresh providers"
@@ -727,7 +731,7 @@ export const ProvidersPage: React.FC = () => {
             </div>
             <Button
               variant="ghost"
-              size="icon"
+              size={isMobile ? 'sm' : 'icon'}
               onClick={() => void refreshProviders()}
               disabled={refreshing}
               aria-label="Refresh providers"
@@ -785,7 +789,7 @@ export const ProvidersPage: React.FC = () => {
           </div>
           <Button
             variant="ghost"
-            size="icon"
+            size={isMobile ? 'sm' : 'icon'}
             onClick={() => void refreshProviders()}
             disabled={refreshing}
             aria-label="Refresh providers"

--- a/packages/ui/src/components/session/sidebar/SessionNodeItem.tsx
+++ b/packages/ui/src/components/session/sidebar/SessionNodeItem.tsx
@@ -448,7 +448,17 @@ function SessionNodeItemComponent(props: Props): React.ReactNode {
   const isSessionMenuOpen = isMenuOpen || isContextMenuOpen;
 
   const forkSolid = React.useMemo(() => getForkFamilyColor((node as SessionNode & { forkFamilyId?: string | null }).forkFamilyId), [node]);
-  const forkBackground = React.useMemo(() => getForkFamilyBackgroundColor((node as SessionNode & { forkFamilyId?: string | null }).forkFamilyId, { active: isActive || isRowSelected }), [node, isActive, isRowSelected]);
+  // On mobile surfaces we paint a `borderLeft` instead of the translucent
+  // wash (≈11% alpha is invisible against bg-sidebar at 72% width).
+  // `forkBackground` is null in that case so the row style drops the wash
+  // and the row chrome falls back to the usual hover/selection treatment.
+  const forkBackground = React.useMemo(
+    () => getForkFamilyBackgroundColor(
+      (node as SessionNode & { forkFamilyId?: string | null }).forkFamilyId,
+      { active: isActive || isRowSelected, isMobile: mobileVariant },
+    ),
+    [node, isActive, isRowSelected, mobileVariant],
+  );
   const descendantCount = React.useMemo(() => collectNodeDescendantIds(node).length, [collectNodeDescendantIds, node]);
 
   const collectChildExports = React.useCallback(async (children: SessionNode[]): Promise<{ children: ChildSessionExport[]; skipped: number }> => {
@@ -884,6 +894,7 @@ function SessionNodeItemComponent(props: Props): React.ReactNode {
                 style={{
                   ...(depth > 0 ? { marginLeft: `${depth * 14}px` } : undefined),
                   ...(forkBackground ? { backgroundColor: forkBackground } : undefined),
+                  ...(mobileVariant && forkSolid ? { borderLeft: `3px solid ${forkSolid}`, paddingLeft: '9px' } : undefined),
                 }}
                 className={cn(
                   'group relative my-0.5 flex cursor-pointer items-center rounded-xl px-3 py-2 transition-colors',

--- a/packages/ui/src/components/session/sidebar/forkFamilyColor.test.ts
+++ b/packages/ui/src/components/session/sidebar/forkFamilyColor.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
-import { getForkFamilyColor, getForkFamilyIdForSession } from './forkFamilyColor';
+import { getForkFamilyBackgroundColor, getForkFamilyColor, getForkFamilyIdForSession } from './forkFamilyColor';
 
 describe('fork family color', () => {
   test('is deterministic for same family id across calls', () => {
@@ -33,5 +33,22 @@ describe('fork family color', () => {
     // But UI should only color when actually in a fork family — tested via
     // the flag that checks hasParent || hasChildren.
     expect(getForkFamilyColor(familyId)).not.toBeNull();
+  });
+
+  test('background wash returns null on mobile so callers can paint a left border instead', () => {
+    // On phone/tablet surfaces the 11% wash reads as "no color" against
+    // bg-sidebar; the row paints borderLeft: 3px solid with the solid color
+    // for a clear fork-family cue. The utility returns null so the row style
+    // does not double-stack the wash under the border.
+    const bg = getForkFamilyBackgroundColor('ses_root_mobile', { isMobile: true });
+    expect(bg).toBeNull();
+
+    const bgActive = getForkFamilyBackgroundColor('ses_root_mobile', { isMobile: true, active: true });
+    expect(bgActive).toBeNull();
+  });
+
+  test('background wash keeps the desktop tint when isMobile is not set', () => {
+    const bg = getForkFamilyBackgroundColor('ses_root_desktop');
+    expect(bg).not.toBeNull();
   });
 });

--- a/packages/ui/src/components/session/sidebar/forkFamilyColor.ts
+++ b/packages/ui/src/components/session/sidebar/forkFamilyColor.ts
@@ -40,10 +40,16 @@ const FORK_BACKGROUND_ACTIVE_ALPHA = 0.2;
 
 export const getForkFamilyBackgroundColor = (
   familyId: string | null | undefined,
-  opts?: { active?: boolean },
+  opts?: { active?: boolean; isMobile?: boolean },
 ): string | null => {
   const solid = getForkFamilyColor(familyId);
   if (!solid) return null;
+  // On mobile surfaces the translucent wash (≈11% alpha) is barely visible
+  // against `bg-sidebar`, so callers should paint a left-border instead. We
+  // return null and let SessionNodeItem swap in `borderLeft` for the same
+  // family id — keeps one source of truth for the color while letting the
+  // row decide the visual treatment per surface.
+  if (opts?.isMobile) return null;
   const useActive = Boolean(opts?.active);
   // Prefer color-mix for a theme-aware translucent wash when available.
   // color-mix(in srgb, <solid> 13%, transparent) keeps the tint subtle

--- a/packages/ui/src/stores/useUIStore.ts
+++ b/packages/ui/src/stores/useUIStore.ts
@@ -2129,12 +2129,27 @@ export const useUIStore = create<UIStore>()(
       {
         name: 'ui-store',
         storage: createDeferredSafeJSONStorage(),
-        version: 16,
+        version: 17,
         migrate: (persistedState, version) => {
           if (!persistedState || typeof persistedState !== 'object') {
             return persistedState;
           }
           const state = persistedState as Record<string, unknown>;
+
+          // v16 -> v17: re-sanitize persisted context-panel state.
+          // The v15→v16 migration stripped the chat-mode tabs from
+          // `contextPanelByDirectory`, but devices that already shipped at
+          // v16 (e.g. hosted-mobile tablet-width users browsing the desktop
+          // fallback) still hold those tabs on disk because the migration
+          // only runs on the v15→v16 transition. Bumping to v17 forces a
+          // one-shot re-sanitize so the deprecated chat rail + tabs disappear
+          // on next load without the user having to clear site data.
+          if (version < 17) {
+            state.contextPanelByDirectory = sanitizeContextPanelByDirectory(state.contextPanelByDirectory);
+            if (Array.isArray(state.contextRailOrder)) {
+              state.contextRailOrder = (state.contextRailOrder as unknown[]).filter((id) => id !== 'chat');
+            }
+          }
 
           // v15 -> v16: remove the session-chat side-panel surface and tabs.
           if (version < 16) {


### PR DESCRIPTION
## Intent

Three concrete mobile-parity gaps remained on `main` after v0.3.2 / v0.3.3,
even though all three of their underlying features were already shared UI
code. This PR finishes that cycle so the dedicated mobile shell (phone +
tablet) matches the desktop behaviour without requiring users to clear
site data or rebuild artifacts locally.

- **Subtask navigation closes the drawers.** Clicking "Open subtask session"
  on a user message on mobile swapped `currentSessionId` underneath the
  still-open sessions sheet, so the user kept staring at the drawer over
  the new chat. Added an optional `closeDrawers` action to
  `MobileAppActions` and called it from `UserSubtaskPart` after
  `setCurrentSession`. No-op on web/desktop where the phone drawer does
  not exist.
- **Fork-family accent is visible on the phone sidebar.** v0.3.2 painted
  the per-family accent as a ~11% `color-mix` wash. On the 72%-width
  phone drawer over `bg-sidebar` that reads as "no color" and users
  perceived it as the desktop fork styling never shipping. Mobile
  surfaces now paint a `borderLeft: 3px solid` with the same
  deterministic color from `forkFamilyColor`; the desktop wash is
  unchanged.
- **Stale persisted UI state self-heals.** Devices that shipped at v16
  but held legacy `chat`-mode tabs in `contextPanelByDirectory[dir].tabs`
  (e.g. hosted-mobile tablet-width users hitting the desktop fallback)
  kept them because the v15→v16 migration only fires on the upgrade
  transition. Bumped persisted store version 16 → 17 with a one-shot
  re-sanitize so next load cleans the state without manual intervention.

A small Settings touch-target tweak landed alongside: the four
`Refresh catalog` / `Refresh providers` icon buttons in `ProvidersPage`
now use `size="sm"` on dedicated mobile (was `size="icon"`), hitting
the shared 36 px touch affordance while staying compact on desktop.

## Non-goals

- Rebuilding `packages/web/dist` or bundling mobile native assets — that
  is a release / packaging step, not a code change.
- Reworking the desktop side-panel v16 migration logic. The v16 code is
  correct; the issue is only that it only runs on the v15→v16 transition
  for devices that already shipped at v16. The v17 bump re-runs the
  existing sanitization; the v16 logic itself is untouched.
- Restoring the side-panel chat surface. v0.3.2 deliberately deleted it
  and `ded3106ec` is correct. This PR does not bring it back or add a
  replacement shell.
- Changing the desktop fork wash. The new `isMobile` option in
  `getForkFamilyBackgroundColor` returns `null` for mobile surfaces
  only; the desktop branch is byte-identical to before.

## Affected surfaces

| Surface | Effect |
|---|---|
| Dedicated mobile shell — sessions sheet | Closes after subtask navigation. New `MobileAppActions.closeDrawers` action; implemented via the existing `setSessionsSheetOpenSafely`/`setWorkspaceOpenSafely` setters in `MobileApp.tsx`. |
| Dedicated mobile shell — workspace drawer | Same `closeDrawers` action; closes both drawers atomically. |
| Mobile sidebar (phone + tablet sidebar variant) | Fork-family accent renders as `borderLeft: 3px solid`. `SessionNodeItem` reads the existing `mobileVariant` prop. |
| Desktop sidebar | Unchanged — fork wash branch in `getForkFamilyBackgroundColor` is byte-identical. |
| `ProvidersPage` | Refresh catalog + 3× Refresh providers buttons: `size="sm"` on `isMobile`, `size="icon"` elsewhere. No behaviour change to click handlers. |
| Persisted `ui-store` | `version: 16 → 17`. New `if (version < 17)` migration block re-runs `sanitizeContextPanelByDirectory` and filters `chat` out of `contextRailOrder`. One-shot, idempotent with existing v15→v16 migration. |

Runtimes deliberately not affected:
- **Web (`packages/web`)** — `MobileApp`/`MobileWorkspaceDrawer`/etc. are
  not imported; the desktop `MainLayout` already handles subtask
  navigation in place. No code in `packages/web` was changed.
- **Electron (`packages/electron`)** — Uses `MainLayout`, no
  `closeDrawers` consumer. `version: 17` runs on Electron as part of
  the normal persist boot and is a no-op once stored.
- **VS Code** — Inherits the `ui-store` migration automatically; no
  shared chat message body changes affect the VS Code webview.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` — Runtime Boundaries, Always-On Constraints | Change touches shared UI consumed by 4 runtimes; must keep entrypoints thin, prefer authoritative state, and not introduce platform-specific forks. | `closeDrawers` is an optional action in `MobileAppActions` — callers use `?.()` so web/desktop paths stay unchanged. The `isMobile` opt on `getForkFamilyBackgroundColor` is opt-in; the desktop branch is untouched. |
| `AGENTS.md` — Correctness Invariants | Derived live activity from authoritative state; never let fetch failure masquerade as success. | The persisted store migration calls the existing `sanitizeContextPanelByDirectory` — same sanitizer the v15→v16 migration already uses. No new code path; no new failure surface. |
| Skill: `pichamber-change-discipline` | All changes are source-level edits affecting shared contracts. | Smallest correct change; added regression test for the new mobile option; validation matrix below; no speculative refactors; preserved unrelated worktree changes. |
| Skill: `theme-system` | Visual change to a session row (`borderLeft`) and button size on `isMobile`. | Used the shared `Button` and `size` variants — no hand-rolled button chrome. Border color reuses the existing `getForkFamilyColor(...)` return (a hex from the existing `FORK_PALETTE`); no new tokens. |
| Skill: `ui-api-decoupling` | `UserSubtaskPart` reaches into the mobile shell via `useMobileAppActions`; store migration touches persisted contract. | The new `closeDrawers` follows the existing `MobileAppActions` extension pattern (other actions are already optional). Persisted `version` bump follows the existing zustand `migrate` contract; existing v16→v17 path is tested by re-running the same sanitizer the v15→v16 path already exercises. |
| Skill: `settings-ui-patterns` | `ProvidersPage` refresh button size change is a Settings control change. | Uses the shared `Button` and `size` variants from `theme-system`. No new settings page chrome, no info-hint text, no search-registry change. |
| `packages/ui/src/components/session/sidebar/DOCUMENTATION.md` | Owner of session row chrome and fork-family visual. | Fork-family visual is still one source of truth (`forkFamilyColor` exports both solid + wash); `SessionNodeItem` decides per surface how to apply it. Doc note: a single-row layout with the row's selection/hover chrome as the only highlight is preserved — `borderLeft` lives on the row container, not on a child. |
| `packages/ui/src/stores/useUIStore.ts` contract | Persisted store migration must be additive and idempotent with older versions. | New block is `if (version < 17)` and runs the same `sanitizeContextPanelByDirectory` already used by v14/v15/v16, then filters `contextRailOrder` the same way the unconditional end-of-migrate pass already does. Idempotent: running twice has no further effect. |

## Validation

| Check | Result |
|---|---|
| `bun run type-check` (all 4 workspaces: `ui`, `web`, `mobile`, `electron`) | Clean. All workspaces exit 0. |
| `bun run lint:ui` | Clean. |
| `bun test src/components/session/sidebar/` | 45 pass / 0 fail across 9 files (sidebar unit + `forkFamilyColor` regression tests). |
| `bun test src/apps/mobileDrawerLifecycle.test.ts` | 16 pass / 0 fail. |
| `bun test src/components/layout/__tests__/` | 37 pass / 0 fail. |
| `bun test` (full `packages/ui` suite) | 1460 pass / 113 fail / 12 errors. 113 failures and 12 errors are pre-existing on `main` (verified by `git stash` + rerun); none are introduced or worsened by this change. The pass count is exactly 2 higher than baseline — my two new `forkFamilyColor` mobile-variant tests. |
| `bun run dead-code` | No new entries introduced by this change. |

What was **not** verified, and why:
- **Live on-device QA** (subtask drawer close, sidebar fork border, mobile
  Settings refresh button). The dedicated mobile shell uses Capacitor's
  WebView and requires an emulator or device for end-to-end interaction
  testing; this environment has neither. The behaviour is enforced by
  type-check + lint + targeted unit tests, not by a runtime run.
- **`bun run build` artifacts.** The repo's `packages/web/dist` and
  native mobile bundle are `.gitignore`d and only regenerate on a
  packaging step. This change has no new build dependencies; existing
  `bun run build` should pick it up unchanged.
- **Persisted-state migration rollback.** `migrate` is additive and
  idempotent (re-running the same `sanitize` + filter has no further
  effect), so downgrading from a v17 install to a v16 install does not
  crash — but it would not reintroduce the cleaned tabs (correct, since
  v15/v16 already removed them).
- **Performance impact of the new `borderLeft` on the mobile sidebar.**
  The added style is a single inline rule on a small element set; no
  reflow/repaint measurement was taken. Animation cost guidance from
  `theme-system`/`performance-engineering` is unaffected because the
  border does not animate.

## Visual evidence

Visual behaviour this PR changes:
1. Mobile sidebar (phone drawer and tablet sidebar variant): fork-family
   accent renders as a 3 px solid left border with the same per-family
   color from `FORK_PALETTE`.
2. Dedicated mobile shell: sessions sheet and workspace drawer close
   after the user clicks "Open subtask session" on a delegated-task user
   message.
3. `ProvidersPage` on mobile: Refresh catalog / Refresh providers buttons
   render at `size="sm"` (≈36 px) instead of `size="icon"` (32 px).
4. Devices with legacy `chat`-mode tabs persisted in `ui-store` (most
   commonly hosted-mobile tablet-width users hitting the desktop
   fallback) self-heal on first load.

Suggested captures (current PR HEAD `49de6b0f3`) before merge:
- **Before / after sidebar fork accent** on a real phone or iOS
  Simulator, two forked sessions in the same project. Required because
  the change is purely visual and the reviewer cannot infer the wash vs.
  border contrast from the diff alone.
- **Subtask navigation drawer-close interaction** as a short screen
  recording (≈10 s): drawer open → click "Open subtask session" → drawer
  collapses → chat updates in place. Static screenshots miss the
  close-animation timing.
- **Mobile Providers settings** narrow-state screenshot showing the
  Refresh button at `size="sm"` next to a sibling `size="xs"` chip so
  the reviewer can see the hit target.
- **Light + dark theme** for the sidebar fork accent (the border uses
  the same `FORK_PALETTE` hex on both themes; this is a portability
  check, not a change).

No visual evidence is attached to this PR description because no
runtime artefact of the change exists in this environment. The
captures above should be attached before flipping this PR out of draft.

## Risks and failure behavior

- **Migration re-sanitize on every shared upgrade path.** The new
  `if (version < 17)` block runs the same `sanitizeContextPanelByDirectory`
  used by v14/v15/v16 and the existing `contextRailOrder` filter
  already runs unconditionally at the end of `migrate`. Running it
  twice has no further effect; persisted state is reduced to the same
  shape either way.
- **`closeDrawers` no-op on web/desktop.** The action is optional and
  every caller uses `mobileActions?.closeDrawers?.()`. Web and Electron
  paths never resolve a `MobileAppActions` provider, so the optional
  chain short-circuits and behaviour is identical to before.
- **Mobile fork-border layout shift.** The new `borderLeft: 3px solid`
  adds 3 px of width and a `paddingLeft: 9px` offset to compensate.
  `borderLeft` does not collapse with `marginLeft: ${depth * 14}px`
  because they live on different axes (border on the box, margin as the
  outer indent). Indented children retain the same start position
  relative to the row text. If the depth-step geometry in
  `SessionNodeItem` changes in a future PR, the offset should be
  revisited.
- **No data loss, no security boundary changes, no new public exports.**
  The added `closeDrawers` is a setter pair inside an existing React
  provider and cannot be reached from outside the dedicated mobile
  shell. The persisted store bump is a no-op for any non-tablet
  session-switcher open.
- **Cross-runtime impact.** Only Firefox / Safari / WKWebView /
  WebView runtimes are affected, all of which honor `borderLeft` and
  inline styles identically. No native module, IPC, or preload
  boundary is touched.
- **Performance.** The new `borderLeft` is a static style applied
  through the existing `style` prop on the row container — same render
  path as before. No additional selectors, layout passes, or
  subscriptions.
