### PR TITLE
perf(ui): keep project list stable on worktree switch

### DIFF
--- a/packages/ui/src/stores/DOCUMENTATION.md
+++ b/packages/ui/src/stores/DOCUMENTATION.md
@@ -21,6 +21,9 @@ Caches and async work must be scoped to the active runtime. A failed authoritati
 
 `useProjectsStore.resetForRuntimeSwitch()` clears project paths until the new
 runtime's authenticated settings snapshot arrives; persisted paths from another
-host are not a valid bootstrap source.
+host are not a valid bootstrap source. `setActiveProjectIdOnly()` changes and
+persists only the active pointer. It preserves the `projects` array and project
+metadata references so session or worktree navigation does not wake every
+project-list consumer.
 
 When changing store shape, keep persisted state intentionally compatible or discard obsolete fields safely. Do not use persisted history to infer live Pi activity.

--- a/packages/ui/src/stores/useProjectsStore.test.ts
+++ b/packages/ui/src/stores/useProjectsStore.test.ts
@@ -4,6 +4,36 @@ import type { DesktopSettings } from "@/lib/desktop"
 import { useProjectsStore } from "./useProjectsStore"
 
 describe("useProjectsStore settings synchronization", () => {
+  test("changes only the active pointer for an id-only switch", () => {
+    const first = {
+      id: "project-a",
+      path: "/repo-a",
+      label: "Repo A",
+      lastOpenedAt: 100,
+    } as ProjectEntry
+    const second = {
+      id: "project-b",
+      path: "/repo-b",
+      label: "Repo B",
+      lastOpenedAt: 200,
+    } as ProjectEntry
+    const projects = [first, second]
+    useProjectsStore.setState({
+      projects,
+      activeProjectId: first.id,
+      manualProjectOrder: [first.id, second.id],
+    })
+
+    useProjectsStore.getState().setActiveProjectIdOnly(second.id)
+
+    const state = useProjectsStore.getState()
+    expect(state.activeProjectId).toBe(second.id)
+    expect(state.projects).toBe(projects)
+    expect(state.projects[0]).toBe(first)
+    expect(state.projects[1]).toBe(second)
+    expect(state.projects[1]?.lastOpenedAt).toBe(200)
+  })
+
   test("treats a successful empty project snapshot as authoritative", () => {
     const project = { id: "project-a", path: "/repo", label: "Repo" } as ProjectEntry
     useProjectsStore.setState({

--- a/packages/ui/src/stores/useProjectsStore.ts
+++ b/packages/ui/src/stores/useProjectsStore.ts
@@ -313,13 +313,7 @@ const readPersistedActiveProjectId = (): string | null => {
   return null;
 };
 
-const cacheProjects = (projects: ProjectEntry[], activeProjectId: string | null) => {
-  try {
-    safeStorage.setItem(getProjectsStorageKey(), JSON.stringify(projects));
-  } catch {
-    // ignored
-  }
-
+const cacheActiveProjectId = (activeProjectId: string | null) => {
   try {
     const activeProjectStorageKey = getActiveProjectStorageKey();
     if (activeProjectId) {
@@ -330,6 +324,20 @@ const cacheProjects = (projects: ProjectEntry[], activeProjectId: string | null)
   } catch {
     // ignored
   }
+};
+
+const cacheProjects = (projects: ProjectEntry[], activeProjectId: string | null) => {
+  try {
+    safeStorage.setItem(getProjectsStorageKey(), JSON.stringify(projects));
+  } catch {
+    // ignored
+  }
+  cacheActiveProjectId(activeProjectId);
+};
+
+const persistActiveProjectId = (activeProjectId: string) => {
+  cacheActiveProjectId(activeProjectId);
+  void updateDesktopSettings({ activeProjectId });
 };
 
 const persistProjects = (projects: ProjectEntry[], activeProjectId: string | null, manualOrder?: string[]) => {
@@ -457,21 +465,15 @@ export const useProjectsStore = create<ProjectsStore>()(
 
     setActiveProjectIdOnly: (id: string) => {
       const { projects, activeProjectId } = get();
-      if (activeProjectId === id) {
-        return;
-      }
-      const target = projects.find((project) => project.id === id);
-      if (!target) {
+      if (activeProjectId === id || !projects.some((project) => project.id === id)) {
         return;
       }
 
-      const now = Date.now();
-      const nextProjects = projects.map((project) =>
-        project.id === id ? { ...project, lastOpenedAt: now } : project
-      );
-
-      set({ projects: nextProjects, activeProjectId: id });
-      persistProjects(nextProjects, id, get().manualProjectOrder);
+      // Session/worktree navigation changes only the active pointer. Keeping
+      // the project list reference stable prevents every project-wide sidebar,
+      // Git, and catalog selector from rebuilding on each switch.
+      set({ activeProjectId: id });
+      persistActiveProjectId(id);
     },
 
     renameProject: (id: string, label: string) => {


### PR DESCRIPTION
## Intent

Switching between worktrees/projects was slow due to store fan-out. `setActiveProjectIdOnly()` recreated the entire `projects` array and bumped `lastOpenedAt` on every session/worktree switch, invalidating every `projects`-selecting consumer (sidebar, Git status, catalog ownership, `SessionOwnership` grouping) and forcing full rebuilds. This also serialized the full project list on each switch.

This branch keeps the `projects` array and project object references stable for the id-only path:
- `setActiveProjectIdOnly(id)` now updates **only** `activeProjectId` via `set({ activeProjectId: id })`
- Persists only the active pointer (`cacheActiveProjectId` / `persistActiveProjectId`) instead of `persistProjects` with the full list + `manualOrder`
- Preserves `lastOpenedAt` for this intentionally ID-only navigation (explicit `setActiveProject` retains the timestamp bump)

Synthetic benchmark at representative scale (15 projects, 75 worktrees, 14,561 sessions, 20 switches):
- Before: 20 ownership rebuilds, ~182.44 ms
- After: 0 ownership rebuilds, ~0.31 ms (O(1) pointer swap)

Primary fix is `dc719d16c`; the branch also carries prior perf work (KaTeX lazy-load, SessionSwitcher deferral, test isolation, etc.) that remains valid and is included in the diff vs `main`.

## Non-goals

- No change to `setActiveProject` semantics (still bumps `lastOpenedAt` and persists full list) — intentional explicit-switch path unchanged
- No change to project ordering, label/icon/color metadata, or `manualProjectOrder` handling for the id-only path
- No change to ownership/collision semantics (exact project root still wins over colliding worktree)
- No new dependencies, no migration of persisted `projects` shape

## Affected surfaces

- **Packages:** `packages/ui` (`stores/useProjectsStore.ts`, `stores/DOCUMENTATION.md`)
- **Runtimes:** web, desktop, mobile — shared UI store consumed everywhere; Electron and web both read `activeProjectId`/`projects` via `useProjectsStore`
- **Persisted contracts:** `safeStorage` keys `projects` / `activeProjectId` (namespaced by runtime) and `updateDesktopSettings` payload — now writes only `{ activeProjectId }` for id-only switches, compatible with existing readers (they already handle partial `DesktopSettings`)
- **User-visible states:** worktree/session switch in sidebar — no visual change, only latency reduction; project list, icons, and order unchanged

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` — keep changes minimal, read owning docs | Source change in stores | Modified only `useProjectsStore` + its test + owning `DOCUMENTATION.md`; left unrelated files untouched |
| `pichamber-change-discipline` — smallest complete change, validate at narrowest risk, classify risk | Persisted/external + cross-workspace contract (stored `projects`/`activeProjectId`, shared UI store) | Scoped to id-only path; preserved existing behavior for `setActiveProject`; updated docs; added regression test proving reference stability; ran package type-check/lint/build + focused tests |
| `sync-state-invariants` — runtime-scoped caches, authoritative settings | `resetForRuntimeSwitch` / `synchronizeFromSettings` touch persisted project paths | No change to runtime-scoping logic; active-pointer persistence remains runtime-namespaced via `getActiveProjectStorageKey()` |
| `performance-engineering` — hot path, large lists, reference stability | Sidebar/Git/catalog fan-out on every switch | Stabilized `projects` reference to avoid invalidating selectors; verified with synthetic ownership-rebuild benchmark |
| `packages/ui/src/stores/DOCUMENTATION.md` | Owning docs for store invariants | Updated to document `setActiveProjectIdOnly` only persists active pointer and keeps list references stable |

## Validation

| Check | Result |
|---|---|
| `bun run type-check` | pass — all workspaces (`ui`, `web`, `electron`, `mobile`) |
| `bun run lint` | pass — all workspaces |
| `bun run build` | pass — `@pi-chamber/web:build` built in 80.69s, PWA built |
| `bun test ./packages/ui/src/stores/useProjectsStore.test.ts` | 3/3 pass — including new `changes only the active pointer for an id-only switch` (reference equality on `projects[0]`, `projects[1]`, `projects` array, `lastOpenedAt` unchanged) |
| Synthetic benchmark (15/75/14561, 20 switches) | Before 182.44 ms / 20 rebuilds → After 0.31 ms / 0 rebuilds |
| `git diff --check` | pass — no whitespace errors |

Not verified: real browser profile trace of worktree switch (cold `listSessions`/`hydrate` path); manual multi-runtime switch. Type-check/lint are not claimed as runtime correctness.

## Visual evidence

No rendered UI change — fix is reference-stability / persistence scope. Sidebar project list, icons, order, and selection appearance are identical before/after; only switch latency changes. Synthetic before/after measurement provided above. No screenshot applicable; performance claim is backed by benchmark, not type-check.

## Risks and failure behavior

- **Rollback:** safe — id-only switch now writes only `activeProjectId`. Older readers that expect full `projects` on every write continue to read last persisted `projects` unchanged; full writes still occur on `setActiveProject`, `addProject`, etc.
- **Partial failure:** `cacheActiveProjectId` / `updateDesktopSettings` are best-effort (`try`/`void`); failure leaves in-memory `activeProjectId` correct, persisted pointer stale — next authoritative `synchronizeFromSettings` reconciles. No stranded optimistic state.
- **Compatibility:** persisted `lastOpenedAt` no longer touched on id-only path — no consumer relies on it being bumped on every switch; explicit path still bumps it. No migration needed.
- **Cross-runtime:** namespaced storage key `activeProjectId:<runtime>` preserves per-runtime isolation; `resetForRuntimeSwitch` unchanged.
- **Security/performance:** no secrets logged; reduces writes from O(n) project list serialization to O(1) pointer write.
