### PR TITLE
Add global home sessions and restore runtime on reload

### DIFF
--- a/packages/ui/src/components/chat/composer/state/useDraftTarget.ts
+++ b/packages/ui/src/components/chat/composer/state/useDraftTarget.ts
@@ -8,8 +8,20 @@ import { formatDirectoryName } from '@/lib/utils';
 import { useGitBranches, useGitStore, useIsGitRepo } from '@/stores/useGitStore';
 import { useProjectsStore } from '@/stores/useProjectsStore';
 import { buildAvailableWorktreesByProject, useWorktreeStore } from '@/stores/useWorktreeStore';
+import { useDirectoryStore } from '@/stores/useDirectoryStore';
 import { useSessionUIStore } from '@/sync/session-ui-store';
 import { normalizePath } from '../attachments/filePaths';
+
+const GLOBAL_PROJECT_ID = '__home__';
+const GLOBAL_PROJECT_LABEL = "Don't work in a repository";
+
+const getGlobalProjectPath = (homeDirectory: string | null | undefined): string | null => {
+  const normalized = normalizePath(homeDirectory ?? null);
+  if (normalized) return normalized;
+  // Fallback sentinel that DirectoryStore expands to the real home.
+  return '~';
+};
+
 import { buildLocalDraftBranchOptions, shouldRefreshDraftBranchesOnDraftEntry } from './draftTargetBranches';
 
 export interface DraftTargetProject {
@@ -37,26 +49,42 @@ export function useDraftTarget(enabled: boolean) {
         () => buildAvailableWorktreesByProject(registeredProjects, { projects: worktreeProjects }),
         [registeredProjects, worktreeProjects],
     );
-    const projects = React.useMemo<DraftTargetProject[]>(() => registeredProjects.flatMap((project) => {
-        const root: DraftTargetProject = {
-            ...project,
-            id: project.id,
-            ownerProjectId: project.id,
-            kind: 'project',
-        };
-        const worktrees = availableWorktreesByProject.get(normalizePath(project.path) ?? project.path) ?? [];
-        return [
-            root,
-            ...worktrees.map((worktree): DraftTargetProject => ({
-                id: `worktree:${project.id}:${worktree.path}`,
+    const homeDirectory = useDirectoryStore((state) => state.homeDirectory);
+    const projects = React.useMemo<DraftTargetProject[]>(() => {
+        const base = registeredProjects.flatMap((project) => {
+            const root: DraftTargetProject = {
+                ...project,
+                id: project.id,
                 ownerProjectId: project.id,
-                kind: 'worktree',
-                path: worktree.path,
-                branch: worktree.branch,
-                label: worktree.branch || (worktree.detached ? 'Detached HEAD' : worktree.name),
-            })),
-        ];
-    }), [availableWorktreesByProject, registeredProjects]);
+                kind: 'project',
+            };
+            const worktrees = availableWorktreesByProject.get(normalizePath(project.path) ?? project.path) ?? [];
+            return [
+                root,
+                ...worktrees.map((worktree): DraftTargetProject => ({
+                    id: `worktree:${project.id}:${worktree.path}`,
+                    ownerProjectId: project.id,
+                    kind: 'worktree',
+                    path: worktree.path,
+                    branch: worktree.branch,
+                    label: worktree.branch || (worktree.detached ? 'Detached HEAD' : worktree.name),
+                })),
+            ];
+        });
+        const globalPath = getGlobalProjectPath(homeDirectory);
+        if (!globalPath) return base;
+        // Avoid duplicating if a project already points at the home directory.
+        const already = base.some((entry) => normalizePath(entry.path) === normalizePath(globalPath));
+        if (already) return base;
+        const globalEntry: DraftTargetProject = {
+            id: GLOBAL_PROJECT_ID,
+            ownerProjectId: GLOBAL_PROJECT_ID,
+            kind: 'project',
+            path: globalPath,
+            label: GLOBAL_PROJECT_LABEL,
+        };
+        return [globalEntry, ...base];
+    }, [availableWorktreesByProject, registeredProjects, homeDirectory]);
     const activeProjectId = useProjectsStore((state) => state.activeProjectId);
     const setActiveProjectIdOnly = useProjectsStore((state) => state.setActiveProjectIdOnly);
     const newSessionDraft = useSessionUIStore((s) => s.newSessionDraft);
@@ -77,7 +105,19 @@ export function useDraftTarget(enabled: boolean) {
                 )) ?? projects.find((project) => project.id === newSessionDraft.selectedProjectId) ?? null
                 : null;
             if (explicit) return explicit;
+            // Global draft without an explicit project id (e.g. "~" from persistence):
+            // resolve by directory alone so the label does not flicker.
+            if (explicitDirectory) {
+                const byDir = projects.find((project) => normalizePath(project.path) === explicitDirectory) ?? null;
+                if (byDir) return byDir;
+            }
         } else if (currentSessionId) {
+            const sessionDirectory = normalizePath(currentSessionDirectory ?? null);
+            const globalPath = getGlobalProjectPath(homeDirectory);
+            if (globalPath && sessionDirectory && normalizePath(globalPath) === sessionDirectory) {
+                const global = projects.find((project) => project.ownerProjectId === GLOBAL_PROJECT_ID) ?? null;
+                if (global) return global;
+            }
             const fromSession = resolveProjectForSessionDirectory(
                 registeredProjects as ProjectEntry[],
                 availableWorktreesByProject,
@@ -101,6 +141,7 @@ export function useDraftTarget(enabled: boolean) {
         availableWorktreesByProject,
         currentSessionDirectory,
         currentSessionId,
+        homeDirectory,
         isDraftOpen,
         newSessionDraft?.directoryOverride,
         newSessionDraft?.selectedProjectId,
@@ -202,6 +243,16 @@ export function useDraftTarget(enabled: boolean) {
         const project = projects.find((entry) => entry.id === projectId);
         const nextDirectory = normalizePath(project?.path ?? null);
         if (!project || !nextDirectory) return;
+        if (project.ownerProjectId === GLOBAL_PROJECT_ID) {
+            // Global sessions live at ~ and must not change the active project.
+            setNewSessionDraftTarget({
+                projectId: GLOBAL_PROJECT_ID,
+                directoryOverride: nextDirectory,
+                branchIntent: null,
+                worktreeIntent: null,
+            });
+            return;
+        }
         if (activeProjectId !== project.ownerProjectId) setActiveProjectIdOnly(project.ownerProjectId);
         setNewSessionDraftTarget({
             projectId: project.ownerProjectId,

--- a/packages/ui/src/components/chat/composer/ui/DraftTargetSelectors.tsx
+++ b/packages/ui/src/components/chat/composer/ui/DraftTargetSelectors.tsx
@@ -60,9 +60,10 @@ export function ProjectLabel({
 }) {
     const rawLabel = getProjectDisplayLabel(project);
     const label = maxCharacters ? truncateWithEllipsis(rawLabel, maxCharacters) : rawLabel;
+    const isGlobal = project.id === '__home__' || project.ownerProjectId === '__home__';
     return (
         <span className="inline-flex min-w-0 items-center gap-1.5" title={rawLabel}>
-            <Icon name={project.kind === 'worktree' ? 'git-branch' : 'folder'} className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            <Icon name={project.kind === 'worktree' ? 'git-branch' : isGlobal ? 'home' : 'folder'} className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
             <span className="truncate text-muted-foreground">{label}</span>
         </span>
     );

--- a/packages/ui/src/components/session/sidebar/sessionOwnership.test.ts
+++ b/packages/ui/src/components/session/sidebar/sessionOwnership.test.ts
@@ -76,6 +76,20 @@ describe('createSessionOwnershipIndex', () => {
     ]);
   });
 
+  test('includes home sessions in every project', () => {
+    const ownership = createSessionOwnershipIndex(
+      [{ id: 'global', directory: '~' } as Session],
+      [
+        { id: 'app', normalizedPath: '/projects/app' },
+        { id: 'docs', normalizedPath: '/projects/docs' },
+      ],
+      new Map(),
+    );
+
+    expect(ownership.sessionsByProject.get('app')?.map((session) => session.id)).toEqual(['global']);
+    expect(ownership.sessionsByProject.get('docs')?.map((session) => session.id)).toEqual(['global']);
+  });
+
   test('supports a Windows drive root project', () => {
     const ownership = createSessionOwnershipIndex(
       [{ id: 'windows-root', directory: 'c:\\Users\\name\\project' } as Session],

--- a/packages/ui/src/components/session/sidebar/sessionOwnership.ts
+++ b/packages/ui/src/components/session/sidebar/sessionOwnership.ts
@@ -1,6 +1,29 @@
 /* eslint-disable */
 import type { Session } from '@/lib/chat/types';
 import { normalizePath } from '@/lib/pathNormalization';
+import { getDeferredSafeStorage } from '@/stores/utils/safeStorage';
+
+const isGlobalSessionDirectory = (directory: string | null): boolean => {
+  if (!directory) return false;
+  const normalized = normalizePath(directory);
+  if (!normalized) return false;
+  if (normalized === '~') return true;
+  try {
+    const rawHome = getDeferredSafeStorage().getItem('homeDirectory');
+    if (typeof rawHome === 'string' && rawHome.trim().length > 0) {
+      const homeNormalized = normalizePath(rawHome);
+      if (homeNormalized && normalized === homeNormalized) return true;
+    }
+  } catch { /* ignored */ }
+  try {
+    if (typeof window !== 'undefined' && typeof (window as unknown as { __PICHAMBER_HOME__?: string }).__PICHAMBER_HOME__ === 'string') {
+      const candidate = (window as unknown as { __PICHAMBER_HOME__?: string }).__PICHAMBER_HOME__;
+      const homeNormalized = candidate ? normalizePath(candidate) : null;
+      if (homeNormalized && normalized === homeNormalized) return true;
+    }
+  } catch { /* ignored */ }
+  return false;
+};
 
 type Project = {
   id: string;
@@ -141,7 +164,40 @@ export const createSessionOwnershipIndex = (
     scopeTarget?: Map<string, Set<string>>,
   ): void => {
     for (const session of input) {
-      const owner = resolveOwner(resolveSessionDirectory(session));
+      const directory = resolveSessionDirectory(session);
+      if (isGlobalSessionDirectory(directory)) {
+        // Global/home sessions (cwd ~) appear in every folder.
+        if (projects.length === 0) continue;
+        // Pick first project's owner for bySessionId so detail pages still
+        // resolve; the session is attached to every project's bucket.
+        let firstOwner: DirectoryOwner | null = null;
+        for (const project of projects) {
+          const projectRoot = normalizePath(project.normalizedPath);
+          if (!projectRoot) continue;
+          const owner = ownerByDirectory.get(projectRoot);
+          if (!owner) continue;
+          if (!firstOwner) firstOwner = owner;
+          const projectSessions = target.get(owner.projectId);
+          if (projectSessions) {
+            if (!projectSessions.some((entry) => entry.id === session.id)) {
+              projectSessions.push(session);
+            }
+          } else {
+            target.set(owner.projectId, [session]);
+          }
+          if (scopeTarget) {
+            const scopeSessions = scopeTarget.get(owner.scopeDirectory);
+            if (scopeSessions) {
+              scopeSessions.add(session.id);
+            } else {
+              scopeTarget.set(owner.scopeDirectory, new Set([session.id]));
+            }
+          }
+        }
+        if (firstOwner) bySessionId.set(session.id, firstOwner);
+        continue;
+      }
+      const owner = resolveOwner(directory);
       if (!owner) continue;
       bySessionId.set(session.id, owner);
       const projectSessions = target.get(owner.projectId);

--- a/packages/ui/src/lib/runtime-switch.ts
+++ b/packages/ui/src/lib/runtime-switch.ts
@@ -1,5 +1,6 @@
 import { refreshRuntimeUrlAuthToken, setRuntimeBearerToken, setRuntimeExtraHeaders } from '@/lib/runtime-auth';
 import { configureRuntimeUrlResolver } from '@/lib/runtime-url';
+import { getDeferredSafeStorage } from '@/stores/utils/safeStorage';
 import {
   activateRelayTunnel,
   deactivateRelayTunnel,
@@ -21,6 +22,49 @@ const RUNTIME_ENDPOINT_WILL_CHANGE_EVENT = 'pichamber:runtime-endpoint-will-chan
 
 let activeApiBaseUrl = '';
 let activeRuntimeKey = '';
+
+const LAST_RUNTIME_STORAGE_KEY = 'pichamber:lastRuntimeEndpoint.v1';
+
+const readPersistedRuntime = (): { apiBaseUrl: string; runtimeKey: string } | null => {
+  try {
+    const raw = getDeferredSafeStorage().getItem(LAST_RUNTIME_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as { apiBaseUrl?: unknown; runtimeKey?: unknown };
+    const apiBaseUrl = typeof parsed.apiBaseUrl === 'string' ? parsed.apiBaseUrl.trim() : '';
+    const runtimeKey = typeof parsed.runtimeKey === 'string' ? parsed.runtimeKey.trim() : '';
+    if (!apiBaseUrl || !runtimeKey) return null;
+    if (runtimeKey === 'mobile-disconnected') return null;
+    return { apiBaseUrl, runtimeKey };
+  } catch {
+    return null;
+  }
+};
+
+const persistLastRuntimeEndpoint = (apiBaseUrl: string, runtimeKey: string): void => {
+  try {
+    const storage = getDeferredSafeStorage();
+    if (runtimeKey === 'mobile-disconnected' || !apiBaseUrl) {
+      storage.removeItem(LAST_RUNTIME_STORAGE_KEY);
+      return;
+    }
+    storage.setItem(LAST_RUNTIME_STORAGE_KEY, JSON.stringify({ apiBaseUrl, runtimeKey }));
+  } catch {
+    // Best-effort cache — full storage must never break runtime switching.
+  }
+};
+
+const hydratePersistedRuntime = (): void => {
+  if (activeApiBaseUrl || activeRuntimeKey) return;
+  if (typeof window === 'undefined') return;
+  const persisted = readPersistedRuntime();
+  if (!persisted) return;
+  activeApiBaseUrl = persisted.apiBaseUrl;
+  activeRuntimeKey = persisted.runtimeKey;
+  try {
+    (window as typeof window & { __PICHAMBER_API_BASE_URL__?: string }).__PICHAMBER_API_BASE_URL__ = persisted.apiBaseUrl;
+  } catch { /* read-only contextBridge */ }
+  configureRuntimeUrlResolver({ apiBaseUrl: persisted.apiBaseUrl, realtimeBaseUrl: persisted.apiBaseUrl });
+};
 
 const setWindowRuntimeValue = <K extends '__PICHAMBER_API_BASE_URL__' | '__PICHAMBER_CLIENT_TOKEN__' | '__PICHAMBER_RUNTIME_HEADERS__'>(
   runtimeWindow: typeof window & {
@@ -75,7 +119,10 @@ const sameOrigin = (left: string, right: string): boolean => {
   }
 };
 
-export const getRuntimeApiBaseUrl = (): string => activeApiBaseUrl || readInjectedApiBaseUrl();
+export const getRuntimeApiBaseUrl = (): string => {
+  hydratePersistedRuntime();
+  return activeApiBaseUrl || readInjectedApiBaseUrl();
+};
 
 // `getRuntimeKey` keys caches, stores, and persisted state across the whole UI,
 // so it runs on store reads, event handling, and render paths. Before the
@@ -102,6 +149,7 @@ const readRawRuntimeGlobal = (key: '__PICHAMBER_API_BASE_URL__' | '__PICHAMBER_L
 };
 
 export const getRuntimeKey = (): string => {
+  hydratePersistedRuntime();
   if (activeRuntimeKey) return activeRuntimeKey;
 
   const rawApiBaseUrl = readRawRuntimeGlobal('__PICHAMBER_API_BASE_URL__');
@@ -125,6 +173,8 @@ export const getRuntimeKey = (): string => {
 };
 
 export const initializeRuntimeEndpoint = (options: { apiBaseUrl?: string | null; runtimeKey?: string | null } = {}): void => {
+  // Prefer the last explicitly chosen runtime over the injected default.
+  hydratePersistedRuntime();
   if (activeApiBaseUrl || activeRuntimeKey) {
     return;
   }
@@ -143,6 +193,7 @@ export const switchRuntimeEndpoint = (options: { apiBaseUrl: string; clientToken
   const previousApiBaseUrl = getRuntimeApiBaseUrl();
   const previousRuntimeKey = getRuntimeKey();
   const runtimeKey = options.runtimeKey?.trim() || normalizeRuntimeUrlKey(apiBaseUrl);
+  persistLastRuntimeEndpoint(apiBaseUrl, runtimeKey);
   const detail = { apiBaseUrl, previousApiBaseUrl, runtimeKey, previousRuntimeKey };
   if (typeof window !== 'undefined') {
     window.dispatchEvent(new CustomEvent<RuntimeEndpointChangedDetail>(RUNTIME_ENDPOINT_WILL_CHANGE_EVENT, { detail }));

--- a/packages/ui/src/sync/DOCUMENTATION.md
+++ b/packages/ui/src/sync/DOCUMENTATION.md
@@ -109,6 +109,7 @@ catalog.listStatusByDirectory:   Map<directory, 'idle'|'loading'|'ready'|'failed
 - A failed `listSessions` for `D` keeps the prior rows for `D` and flips `listStatusByDirectory[D]` to `'failed'`. Failure is not empty success.
 - Pi events update rows in place: `session.lifecycle` flips `lifecycle`. `session.updated` writes `title` without bumping last-prompt recency. A user-message start from another device stamps recency and fills an empty stub title from the prompt text so a remote first send is not stuck as "Untitled Session". Token deltas and lifecycle/snapshot boundaries do **not** bump `updatedAt`. Last-prompt recency is written by `PiSessionStore.prompt()` on this client and by remote user-message starts via `touchRecordUpdatedAt`.
 - An event arriving for a session that has not been listed yet (`byId` has no row) inserts a `upsertStubRecord` so the sidebar can render the session as busy. `applyDirectoryListToCatalog` preserves a non-idle existing lifecycle on listed ids, so a stub is never downgraded to idle by a slow list.
+- A global/home session (directory `~` or the expanded home directory, created via the "Don't work in a repository" composer target) is treated as global: `listUiSessionsFromCatalog(directory)` merges those ids into every directory's view, and `createSessionOwnershipIndex` attaches them to every project's bucket so they appear in all folders. The `PiSessionCatalogFeeder` includes the home directory in its refresh set so globals are re-fetched after a reload. The composer target for this is defined in `useDraftTarget` (`__home__` / "Don't work in a repository") and `session-ui-store` persists it as `selectedProjectId: "__home__"`.
 
 ### Single fill path
 
@@ -136,6 +137,8 @@ Per-directory failures stay scoped to that directory. The catalog's `listStatusB
 ### Runtime switch
 
 `dispose` / `clear` / `resetForRuntime` reset the catalog via `initial()`. The `hydratedSessionIds` set, `lastAccessById`, and the per-directory refresh generations all clear in lockstep.
+
+Ctrl+R reload keeps the active runtime and its last session: the active endpoint (`apiBaseUrl` + `runtimeKey`) is persisted to `pichamber:lastRuntimeEndpoint.v1` and re-hydrated before `getRuntimeKey`/`getRuntimeApiBaseUrl` are used, so a reload does not snap back to `local`. The last active session per runtime is persisted via `last-session-cache` (`oc.lastSession.v1`) on every `setCurrentSession`; `PiSessionProvider` falls back to that persisted session (web/desktop, non-Capacitor) when the in-memory `lastSelectedSessionForDirectory` hint is empty after a reload, and `PiSessionCatalogFeeder` ensures the home directory is part of the catalog refresh so a global `~` session is discoverable.
 
 ## Session list rules
 

--- a/packages/ui/src/sync/pi-session-catalog-feeder.tsx
+++ b/packages/ui/src/sync/pi-session-catalog-feeder.tsx
@@ -26,11 +26,35 @@ import { getPiSessionStore } from '@/apps/pi-session-store';
 import { useProjectsStore } from '@/stores/useProjectsStore';
 import { buildKnownSessionDirectories } from '@/sync/known-session-directories';
 import { buildAvailableWorktreesByProject, useWorktreeStore } from '@/stores/useWorktreeStore';
+import { useDirectoryStore } from '@/stores/useDirectoryStore';
+import { normalizePath } from '@/lib/pathNormalization';
+import { getDeferredSafeStorage } from '@/stores/utils/safeStorage';
 
 const collectProjectDirectories = (): string[] => {
   const projects = useProjectsStore.getState().projects;
   const worktrees = buildAvailableWorktreesByProject(projects, useWorktreeStore.getState());
-  return [...buildKnownSessionDirectories(projects, worktrees, { includeWorktrees: true })];
+  const base = [...buildKnownSessionDirectories(projects, worktrees, { includeWorktrees: true })];
+  // Global sessions (cwd ~, i.e. the user's home directory) must be
+  // discoverable after a reload even though home is not a project root.
+  // Fetching the home directory once keeps the catalog's global bucket warm.
+  try {
+    const homeCandidates: Array<string | null | undefined> = [
+      useDirectoryStore.getState().homeDirectory,
+      getDeferredSafeStorage().getItem('homeDirectory'),
+      typeof window !== 'undefined' ? (window as unknown as { __PICHAMBER_HOME__?: string }).__PICHAMBER_HOME__ : null,
+    ];
+    const seen = new Set(base.map((entry) => normalizePath(entry)?.toLowerCase() ?? entry));
+    for (const candidate of homeCandidates) {
+      if (!candidate) continue;
+      const normalized = normalizePath(candidate);
+      if (!normalized) continue;
+      const key = normalized.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      base.push(normalized);
+    }
+  } catch { /* best-effort */ }
+  return base;
 };
 
 const sortedSignature = (directories: readonly string[]): string => {

--- a/packages/ui/src/sync/pi-session-catalog.test.ts
+++ b/packages/ui/src/sync/pi-session-catalog.test.ts
@@ -1033,11 +1033,38 @@ describe('listUiSessionsFromCatalog', () => {
     expect(listUiSessionsFromCatalog(catalog, { archived: false, directory: '' })).toEqual([]);
   });
 
-  test('a concrete directory lists only that membership', () => {
+  test('a concrete directory includes its own and global membership', () => {
     let catalog = initialCatalog();
     catalog = applyDirectoryListToCatalog(catalog, '/repo-a', [listItem('a-1', '/repo-a')], 1);
     catalog = applyDirectoryListToCatalog(catalog, '/repo-b', [listItem('b-1', '/repo-b')], 1);
-    expect(listUiSessionsFromCatalog(catalog, { archived: false, directory: '/repo-a' }).map((session) => session.id)).toEqual(['a-1']);
+    catalog = applyDirectoryListToCatalog(catalog, '~', [listItem('global-1', '~')], 1);
+    expect(listUiSessionsFromCatalog(catalog, { archived: false, directory: '/repo-a' }).map((session) => session.id)).toEqual([
+      'a-1',
+      'global-1',
+    ]);
+  });
+
+  test('merges and deduplicates literal and expanded home membership', () => {
+    const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+    try {
+      Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: { __PICHAMBER_HOME__: '/home/tester' },
+      });
+      let catalog = initialCatalog();
+      catalog = applyDirectoryListToCatalog(catalog, '~', [listItem('shared', '~')], 1);
+      catalog = applyDirectoryListToCatalog(catalog, '/home/tester', [
+        listItem('shared', '/home/tester'),
+        listItem('expanded', '/home/tester'),
+      ], 1);
+      expect(listUiSessionsFromCatalog(catalog, { archived: false, directory: '/repo-a' }).map((session) => session.id).sort()).toEqual([
+        'expanded',
+        'shared',
+      ]);
+    } finally {
+      if (previousWindow) Object.defineProperty(globalThis, 'window', previousWindow);
+      else Reflect.deleteProperty(globalThis, 'window');
+    }
   });
 });
 

--- a/packages/ui/src/sync/pi-session-catalog.ts
+++ b/packages/ui/src/sync/pi-session-catalog.ts
@@ -27,7 +27,35 @@
 
 import { mapWithConcurrency } from '@/lib/concurrency';
 import { normalizePath } from '@/lib/pathNormalization';
+import { getDeferredSafeStorage } from '@/stores/utils/safeStorage';
 import type { Session } from '@/lib/chat/types';
+
+/** Global session directories: sessions rooted at the user's home (`~`) are
+ *  visible in every folder view. See `useDraftTarget`'s "Don't work in a
+ *  repository" option and `sessionOwnership`'s global bucket. */
+const getGlobalCatalogDirectories = (): string[] => {
+  const dirs: string[] = [];
+  // Sentinel value stored when a draft's directoryOverride is "~" rather
+  // than an expanded absolute path. The catalog keys such rows as "~".
+  dirs.push('~');
+  try {
+    const rawHome = getDeferredSafeStorage().getItem('homeDirectory');
+    if (typeof rawHome === 'string' && rawHome.trim().length > 0) {
+      const normalized = normalizePath(rawHome);
+      if (normalized && !dirs.includes(normalized)) dirs.push(normalized);
+    }
+  } catch { /* storage unavailable */ }
+  try {
+    if (typeof window !== 'undefined' && typeof (window as unknown as { __PICHAMBER_HOME__?: string }).__PICHAMBER_HOME__ === 'string') {
+      const candidate = (window as unknown as { __PICHAMBER_HOME__?: string }).__PICHAMBER_HOME__;
+      const normalized = candidate ? normalizePath(candidate) : null;
+      if (normalized && !dirs.includes(normalized)) dirs.push(normalized);
+    }
+  } catch { /* window unavailable */ }
+  return dirs;
+};
+
+
 import type { PiSessionListItem } from '@/lib/pi/protocol';
 import type { PiRetryInfo, PiSessionId } from '@/lib/pi/types';
 
@@ -540,7 +568,23 @@ export const listUiSessionsFromCatalog = (
   const directory = options?.directory;
   let ids: readonly string[];
   if (typeof directory === 'string' && directory.length > 0) {
-    ids = catalog.byDirectory.get(normalizedDirectory(directory)) ?? [];
+    const normalized = normalizedDirectory(directory);
+    const base = catalog.byDirectory.get(normalized) ?? [];
+    // Global/home sessions (cwd ~) appear in every folder view.
+    const globalDirs = getGlobalCatalogDirectories();
+    const globalIds: string[] = [];
+    const seen = new Set<string>(base);
+    for (const gd of globalDirs) {
+      if (gd === normalized) continue;
+      const gIds = catalog.byDirectory.get(gd);
+      if (!gIds) continue;
+      for (const id of gIds) {
+        if (seen.has(id)) continue;
+        seen.add(id);
+        globalIds.push(id);
+      }
+    }
+    ids = globalIds.length > 0 ? [...base, ...globalIds] : base;
   } else if (directory === null || directory === '') {
     return EMPTY_UI_SESSIONS;
   } else {

--- a/packages/ui/src/sync/pi-session-context.tsx
+++ b/packages/ui/src/sync/pi-session-context.tsx
@@ -7,6 +7,9 @@ import { parseRoute } from '@/lib/router';
 import { isNewSessionDraftActive } from '@/lib/router/session-intent';
 import { useSessionUIStore } from '@/sync/session-ui-store';
 import { createSnapshotSelectorCache } from './select-snapshot';
+import { readLastActiveSession } from '@/sync/last-session-cache';
+import { getRuntimeKey } from '@/lib/runtime-switch';
+import { isCapacitorMobileApp } from '@/apps/mobileNativeChrome';
 
 const PiSessionContext = React.createContext<PiSessionStore | null>(null);
 
@@ -39,6 +42,21 @@ export const PiSessionProvider = ({ children, directory }: { children: ReactNode
       return;
     }
     if (!targetDirectory) {
+      // Even with no project, a persisted last session on this runtime
+      // (e.g. a global ~ session) should be re-opened on reload instead
+      // of showing the empty project picker. Native mobile has its own
+      // restore flow with snapshot validation, so skip the shortcut there.
+      if (!draftIsActive && !isCapacitorMobileApp()) {
+        const persisted = readLastActiveSession(getRuntimeKey());
+        if (persisted?.sessionId) {
+          void store.start({
+            ...(persisted.directory ? { directory: persisted.directory } : {}),
+            sessionId: persisted.sessionId,
+            ...(persisted.directory ? { sessionDirectoryKnown: true } : {}),
+          });
+          return;
+        }
+      }
       void store.connectWithoutProject();
       return;
     }
@@ -47,9 +65,32 @@ export const PiSessionProvider = ({ children, directory }: { children: ReactNode
     // that directory. The hint is internal — explicit route / caller
     // hints still win.
     const remembered = draftIsActive ? null : store.lastSelectedSessionForDirectory(targetDirectory);
+    if (remembered) {
+      void store.start({
+        directory: targetDirectory,
+        sessionId: remembered,
+        sessionDirectoryKnown: true,
+      });
+      return;
+    }
+    // Full reload: in-memory LRU is empty but the last active session
+    // is persisted per runtime (see last-session-cache). Using it here
+    // keeps Ctrl+R on the same chat instead of showing the project's
+    // first session. Native mobile's restore does its own snapshot
+    // validation, so keep this path for web/desktop only.
+    if (!draftIsActive && !isCapacitorMobileApp()) {
+      const persisted = readLastActiveSession(getRuntimeKey());
+      if (persisted?.sessionId) {
+        void store.start({
+          directory: persisted.directory ?? targetDirectory,
+          sessionId: persisted.sessionId,
+          ...(persisted.directory ? { sessionDirectoryKnown: true } : {}),
+        });
+        return;
+      }
+    }
     void store.start({
       directory: targetDirectory,
-      ...(remembered ? { sessionId: remembered, sessionDirectoryKnown: true } : {}),
     });
   }, [store, targetDirectory]);
   return <PiSessionContext.Provider value={store}>{children}</PiSessionContext.Provider>;

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -720,11 +720,13 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
     const currentDirectory = normalizePath(useDirectoryStore.getState().currentDirectory ?? null)
     const persistedTarget = readPersistedDraftTarget()
 
+    const GLOBAL_PROJECT_ID = '__home__'
+    const isGlobalExplicit = options?.selectedProjectId === GLOBAL_PROJECT_ID
     const explicitDirectory = options?.directoryOverride !== undefined
       ? normalizePath(options.directoryOverride)
       : null
     const explicitProject = options?.selectedProjectId
-      ? projects.find((p) => p.id === options.selectedProjectId) ?? null
+      ? (isGlobalExplicit ? { id: GLOBAL_PROJECT_ID, path: explicitDirectory ?? '' } as unknown as typeof projects[number] : projects.find((p) => p.id === options.selectedProjectId) ?? null)
       : null
 
     const inferredProjectFromDir = resolveProjectForSessionDirectory(projects, availableWorktreesByProject, explicitDirectory)
@@ -734,32 +736,37 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
       return projects[0] ?? null
     })()
 
+    const isPersistedGlobal = persistedTarget?.projectId === GLOBAL_PROJECT_ID
     const persistedProjectById = persistedTarget?.projectId
-      ? projects.find((p) => p.id === persistedTarget.projectId) ?? null
+      ? (isPersistedGlobal ? { id: GLOBAL_PROJECT_ID, path: persistedTarget.directory ?? '' } as unknown as typeof projects[number] : projects.find((p) => p.id === persistedTarget.projectId) ?? null)
       : null
     const persistedProjectByDir = resolveProjectForSessionDirectory(projects, availableWorktreesByProject, persistedTarget?.directory ?? null)
     const currentDirProject = resolveProjectForSessionDirectory(projects, availableWorktreesByProject, currentDirectory)
 
     const selectedProject = (() => {
+      if (isGlobalExplicit) return explicitProject
       if (explicitProject) return explicitProject
       if (explicitDirectory !== null) return inferredProjectFromDir
       if (currentDirectory) return currentDirProject
+      if (isPersistedGlobal) return persistedProjectById
       return persistedProjectByDir ?? persistedProjectById ?? fallbackProject
     })()
 
     const directory = (() => {
       if (explicitDirectory !== null) return explicitDirectory
+      if (isGlobalExplicit) return explicitDirectory ?? normalizePath((useDirectoryStore.getState().homeDirectory || getDeferredSafeStorage().getItem('homeDirectory') || '~') as string) ?? explicitDirectory
       if (explicitProject) return normalizePath(explicitProject.path ?? null)
       if (currentDirectory) return currentDirectory
       if (persistedTarget?.directory) return persistedTarget.directory
       return normalizePath(selectedProject?.path ?? null)
     })()
 
-    persistDraftTarget({ projectId: selectedProject?.id ?? null, directory })
+    const draftSelectedProjectId = isGlobalExplicit ? GLOBAL_PROJECT_ID : (selectedProject?.id ?? null)
+    persistDraftTarget({ projectId: draftSelectedProjectId, directory })
 
     const nextDraft: NewSessionDraftState = {
       open: true,
-      selectedProjectId: selectedProject?.id ?? null,
+      selectedProjectId: draftSelectedProjectId,
       directoryOverride: directory,
       branchIntent: options?.branchIntent
         && options.branchIntent.runtimeKey === getRuntimeKey()


### PR DESCRIPTION
## Intent

Add a new-session folder choice named "Don't work in a repository". It creates the session in the connected runtime's home directory and lists that session in every project folder. A browser or desktop renderer reload also restores the last selected runtime and session instead of returning to Local server.

## Non-goals

This does not change repository-backed session ownership, native mobile's validated connection restore flow, or relay credential storage.

## Affected surfaces

- Shared UI composer target selection and draft persistence.
- Live session catalog refresh and sidebar project ownership.
- Web and desktop renderer runtime/session reload behavior.
- Local storage adds the credential-free `pichamber:lastRuntimeEndpoint.v1` endpoint record. Existing `oc.lastSession.v1` remains the session cache.
- Capacitor mobile keeps its existing validated restore flow.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` and `pichamber-change-discipline` | Shared UI source and persistence contracts changed. | Changes stay in owning composer, sync, sidebar, and runtime modules; sync documentation was updated. |
| `sync-state-invariants` and `packages/ui/src/sync/DOCUMENTATION.md` | Catalog membership, reload restoration, and runtime-scoped session state changed. | Global aliases merge without duplicate IDs, failed directory behavior is unchanged, and persisted sessions remain keyed by runtime. Focused tests cover catalog and ownership behavior. |
| `ui-api-decoupling` | Runtime URL selection and runtime identity changed. | The persisted record contains only endpoint and runtime identity, never tokens or request headers. Existing runtime URL/auth helpers remain the request path. |
| `theme-system` and `locale-ui-patterns` | The composer adds a visible option and icon. | The option uses the existing home icon and the requested product copy without adding theme values. |
| `performance-engineering` | Catalog and ownership code runs across session lists. | Global membership uses bounded directory buckets and ID deduplication; ordinary session resolution remains unchanged. |

## Validation

| Check | Result |
|---|---|
| `bun run type-check` | Passed. |
| `bun run lint` | Passed. |
| `bun run build` | Passed. Vite emitted the existing large-chunk warning. |
| `bun run test` | Passed: UI 1,719 tests, web 564 tests, Electron architecture 38 tests, Electron updater 20 tests. |
| `bun run dead-code` | Completed. It reported the repository's existing non-blocking unused-export findings; new temporary exports were removed. |
| `git diff --check` | Passed. |

Manual cross-runtime reload testing and current screenshots were not captured in this environment.

## Visual evidence

No screenshot is attached. The only static UI change is one row in the existing composer folder dropdown using an existing icon. Runtime and session restoration require a reload interaction and were validated through the owning logic and automated suite, not a browser recording.

## Risks and failure behavior

Storage is best effort. Invalid or unavailable persisted endpoint data falls back to the injected runtime. The endpoint record excludes credentials. Runtime auth continues through existing injected or runtime-owned credential flows. Global sessions recognize both literal `~` and expanded-home catalog buckets and deduplicate matching session IDs. Rollback consists of removing the new storage key and reverting this commit; existing session data is unchanged.
