### PR TITLE
Prepare v0.5.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-08-25
+
+Focused composer and reload reliability release.
+
+- **Repository-free sessions.** The new-session folder picker now offers "Don't work in a repository", creates the session in the connected runtime's home directory, and shows those home sessions in every project folder. Literal `~` and expanded-home catalog entries merge without duplicate rows.
+- **Reload restores context.** Reloading the web or desktop renderer preserves the selected runtime and its last active session instead of reverting to Local server. Runtime endpoint persistence remains credential-free, and Capacitor mobile keeps its existing validated restore flow.
+- **Safe worktree names.** Small-model utility inference now runs in an isolated Pi text-transformation session without coding-agent instructions, repository context, skills, extensions, templates, or tools. Worktree naming accepts only a complete lowercase ASCII hyphenated slug within 48 characters; conversational or malformed replies fall back to the deterministic task-derived name.
+
 ## [0.5.0] - 2026-08-24
 
 Pi extension release: existing extensions now run inside PiChamber's session daemon, their commands and standard UI prompts work across clients, and extensions can add native cards, panels, forms, and sandboxed app views to the workspace.

--- a/bun.lock
+++ b/bun.lock
@@ -93,7 +93,7 @@
     },
     "packages/electron": {
       "name": "@pichamber/electron",
-      "version": "0.3.3",
+      "version": "0.5.1",
       "dependencies": {
         "@pi-chamber/web": "workspace:*",
         "electron-context-menu": "^4.1.2",
@@ -129,7 +129,7 @@
     },
     "packages/ui": {
       "name": "@pichamber/ui",
-      "version": "0.3.3",
+      "version": "0.5.1",
       "dependencies": {
         "@aparajita/capacitor-secure-storage": "^8.0.0",
         "@base-ui/react": "^1.4.0",
@@ -227,7 +227,7 @@
     },
     "packages/web": {
       "name": "@pi-chamber/web",
-      "version": "0.3.3",
+      "version": "0.5.1",
       "bin": {
         "pichamber": "./bin/cli.js",
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pichamber-monorepo",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "PiChamber monorepo workspace for web, ui, and desktop runtimes",
   "private": true,
   "type": "module",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pichamber/electron",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "description": "Electron desktop runtime for PiChamber",
   "author": "PiChamber",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pichamber/ui",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "main": "src/main.tsx",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-chamber/web",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": false,
   "type": "module",
   "repository": {


### PR DESCRIPTION
## Intent

Prepare PiChamber v0.5.1 with the repository-free session, reload restoration, and safe isolated worktree-name generation fixes from PRs #56 and #57. Align release manifests and the workspace lockfile, and add the required changelog section.

## Non-goals

No additional product behavior changes are included in this release-preparation commit. `packages/mobile` keeps its independent version.

## Affected surfaces

- Root, UI, web, and Electron package versions move from 0.5.0 to 0.5.1.
- `bun.lock` workspace versions are synchronized to 0.5.1.
- `CHANGELOG.md` gains the v0.5.1 release notes.
- The release workflow will build desktop/mobile artifacts and publish the exact `@pi-chamber/web` tarball when dispatched with `publish_npm=true`.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md`, `CONTRIBUTING.md`, and `pichamber-change-discipline` | Version manifests, lockfile, and release contracts changed. | Used `bun run version:bump 0.5.1`, synchronized the lockfile, added dated release notes, and validated the release package locally. |
| `.github/workflows/release.yml` | Owns npm publication and checksum verification. | The workflow publishes the exact packed tarball, then compares its SHA-512 integrity and SHA-1 shasum with npm metadata and downloaded registry bytes before attaching it to the release. |

## Validation

| Check | Result |
|---|---|
| Release manifest/changelog validation | Passed for all four release manifests and `CHANGELOG.md`. |
| `bun run release:prepare` | Passed: production build, workspace type-check, and workspace lint. Vite emitted its existing large-chunk warning. |
| Local `npm pack` for `packages/web` | Produced `pi-chamber-web-0.5.1.tgz`, 7,660,272 bytes. SHA-512: `sha512-anNXv0pItRoH+qiFA6y3eHmG6OlkKtb57GaYqTLDJ77c9mmRn1VcGtojIbIqw2l8g1pmF61PtdZZQWMSFu2HMQ==`; SHA-1: `5722c512cea4a39179cf4c4b07bbaf18d7a0a76c`. The temporary tarball was removed. |
| `git diff --check` | Passed. |
| `bun run test` | UI, Electron, and the prior feature-head suite passed. In this release worktree, 11 existing session-daemon tests hit their fixed 1-second IPC timeout while 553 web tests passed. A second isolated run reproduced the timeout. No release code touches that daemon path; PR CI remains the clean-environment authority and must pass before merge. |

## Visual evidence

No rendered behavior changes in this version/changelog-only commit.

## Risks and failure behavior

The release workflow creates a draft first and publishes it only after required desktop jobs and asset inventory checks pass. npm publication verifies the exact tarball against registry integrity metadata and downloaded bytes. A failed checksum or artifact job leaves the GitHub release draft rather than publishing a partial release.
