### PR TITLE
fix(ui): show worktree-specific agent loading in sidebar spaces bar

### DIFF
--- a/packages/ui/src/components/session/SessionSidebar.tsx
+++ b/packages/ui/src/components/session/SessionSidebar.tsx
@@ -1123,6 +1123,26 @@ const SessionSidebarComponent: React.FC<SessionSidebarProps> = ({
     });
   }, [activeSessionIdSet, projectSections]);
 
+  // Per-directory active set: for each project, which group directories (root + worktrees)
+  // currently contain at least one busy session. This lets SidebarSpacesBar show the spinner
+  // on the primary worktree when expanded, or aggregated on the project row when collapsed.
+  const activeDirectoriesByProject = React.useMemo(() => {
+    const map = new Map<string, Set<string>>();
+    for (const section of projectSections) {
+      const dirs = new Set<string>();
+      for (const group of section.groups) {
+        if (group.isArchivedBucket) continue;
+        const hasActive = group.sessions.some((node) => activeSessionIdSet.has(node.session.id));
+        if (hasActive && group.directory) {
+          const normalized = normalizePath(group.directory)?.toLowerCase();
+          if (normalized) dirs.add(normalized);
+        }
+      }
+      if (dirs.size > 0) map.set(section.project.id, dirs);
+    }
+    return map as ReadonlyMap<string, ReadonlySet<string>>;
+  }, [activeSessionIdSet, projectSections]);
+
   const hasUnseenByProject = React.useCallback((projectId: string) => {
     const section = projectSections.find((s) => s.project.id === projectId);
     if (!section) return false;
@@ -1492,6 +1512,7 @@ const SessionSidebarComponent: React.FC<SessionSidebarProps> = ({
           totalSessionCount={totalSessionCount}
           getSessionCountForProject={(id) => sessionCountByProject.get(id) ?? 0}
           hasActiveSessionByProject={hasActiveSessionByProject}
+          activeDirectoriesByProject={activeDirectoriesByProject}
           hasUnseenByProject={hasUnseenByProject}
           homeDirectory={homeDirectory}
           mobileVariant={mobileVariant}

--- a/packages/ui/src/components/session/sidebar/SidebarSpacesBar.tsx
+++ b/packages/ui/src/components/session/sidebar/SidebarSpacesBar.tsx
@@ -26,7 +26,7 @@ import {
 } from '@/components/ui/context-menu';
 import { cn, formatDirectoryName } from '@/lib/utils';
 import { useProjectsStore } from '@/stores/useProjectsStore';
-import { formatProjectLabel, sidebarRowIconClass, sidebarRowLabelClass } from './utils';
+import { formatProjectLabel, normalizePath, sidebarRowIconClass, sidebarRowLabelClass } from './utils';
 
 export type SpaceProject = {
   id: string;
@@ -53,6 +53,8 @@ export interface SidebarSpacesBarProps {
   totalSessionCount?: number;
   getSessionCountForProject?: (projectId: string) => number;
   hasActiveSessionByProject?: (projectId: string) => boolean;
+  /** Per-project set of normalized-lowercased directories that have a busy session. */
+  activeDirectoriesByProject?: ReadonlyMap<string, ReadonlySet<string>>;
   hasUnseenByProject?: (projectId: string) => boolean;
   homeDirectory: string | null;
   className?: string;
@@ -211,6 +213,7 @@ export const SidebarSpacesBar: React.FC<SidebarSpacesBarProps> = ({
   onOpenProjectEditDialog,
   onRemoveProject,
   hasActiveSessionByProject,
+  activeDirectoriesByProject,
   homeDirectory,
   className,
   mobileVariant = false,
@@ -259,13 +262,24 @@ export const SidebarSpacesBar: React.FC<SidebarSpacesBarProps> = ({
               || formatDirectoryName(project.normalizedPath, homeDirectory)
               || project.normalizedPath,
             );
+            const activeSet = activeDirectoriesByProject?.get(project.id);
+            const normalizedRoot = normalizePath(project.normalizedPath)?.toLowerCase() ?? '';
+            const hasActiveInRoot = normalizedRoot ? (activeSet?.has(normalizedRoot) ?? false) : false;
+            const hasAnyActive = (activeSet?.size ?? 0) > 0;
+            // When the project is expanded, only show the primary spinner on the root
+            // if the busy session is actually in the primary worktree. When collapsed,
+            // the root row aggregates all worktrees so the user still sees activity.
+            const legacyHasActive = hasActiveSessionByProject?.(project.id) ?? false;
+            const hasActiveForProject = activeDirectoriesByProject
+              ? (isProjectExpanded ? hasActiveInRoot : hasAnyActive)
+              : legacyHasActive;
             return (
               <React.Fragment key={project.id}>
                 <SortableFolderRow
                   project={project}
                   label={label}
                   isSelected={isSelected}
-                  hasActive={hasActiveSessionByProject?.(project.id)}
+                  hasActive={hasActiveForProject}
                   hasWorktrees={worktrees.length > 0}
                   worktreeError={worktreeErrorsByProject.get(project.normalizedPath)}
                   isExpanded={isProjectExpanded}
@@ -277,6 +291,10 @@ export const SidebarSpacesBar: React.FC<SidebarSpacesBarProps> = ({
                 />
                 {isProjectExpanded ? worktrees.map((worktree: GitWorktree) => {
                   const worktreeSelected = selectedWorktreePath === worktree.path;
+                  const normalizedWorktree = normalizePath(worktree.path)?.toLowerCase() ?? '';
+                  const hasActiveInWorktree = normalizedWorktree ? (activeSet?.has(normalizedWorktree) ?? false) : false;
+                  // Fallback to legacy global check only if the new map is unavailable (backwards compat).
+                  const showWorktreeActive = activeDirectoriesByProject ? hasActiveInWorktree : false;
                   return (
                     <button
                       key={worktree.path}
@@ -286,10 +304,23 @@ export const SidebarSpacesBar: React.FC<SidebarSpacesBarProps> = ({
                       aria-pressed={worktreeSelected}
                       title={worktree.path}
                     >
-                      <Icon name="git-branch" className={cn(sidebarRowIconClass(mobileVariant), 'text-muted-foreground')} />
-                      <span className={sidebarRowLabelClass(mobileVariant)}>
-                        {worktree.branch || (worktree.detached ? 'Detached HEAD' : worktree.name)}
-                      </span>
+                      <div className="flex min-w-0 flex-1 items-center gap-1.5">
+                        <Icon name="git-branch" className={cn(sidebarRowIconClass(mobileVariant), 'text-muted-foreground')} />
+                        <span className={sidebarRowLabelClass(mobileVariant)}>
+                          {worktree.branch || (worktree.detached ? 'Detached HEAD' : worktree.name)}
+                        </span>
+                      </div>
+                      <div className="flex items-center gap-1 shrink-0 ml-1">
+                        {showWorktreeActive ? (
+                          <AgentThinkingLoader
+                            variant="inline"
+                            text={null}
+                            animationType="spinner"
+                            speedMs={80}
+                            className="text-primary text-xs shrink-0"
+                          />
+                        ) : null}
+                      </div>
                     </button>
                   );
                 }) : null}


### PR DESCRIPTION
## Intent

Fix sidebar worktree agent loading indicator. When a project has linked git worktrees, the busy/active spinner was previously shown only on the primary project row (aggregated), so worktree-specific activity was invisible when the project was expanded. This PR makes the spinner worktree-specific:

- Computes `activeDirectoriesByProject` in `SessionSidebar` — per-project set of normalized directories (primary + worktrees) that contain a busy session.
- In `SidebarSpacesBar`, when expanded show spinner only on the primary row if the busy session is in the primary worktree, and per-worktree spinner on each linked worktree row that is busy. When collapsed, the project row aggregates all worktrees so activity remains visible.

Single-project / no-worktree behavior unchanged.

## Non-goals

- No change to session ownership, grouping, or filtering logic beyond the activity indicator.
- No change to unseen/aggregate dot behavior; only busy spinner handling.
- No backend / daemon changes.

## Affected surfaces

- `packages/ui/src/components/session/SessionSidebar.tsx` — adds `activeDirectoriesByProject` memo derived from `projectSections` + `activeSessionIdSet`.
- `packages/ui/src/components/session/sidebar/SidebarSpacesBar.tsx` — consumes `activeDirectoriesByProject`, splits busy indicator between primary and worktree rows; adds `normalizePath` import, `AgentThinkingLoader` per-worktree.
- Runtimes: shared UI (web, desktop, hosted-mobile, Capacitor mobile) — purely presentational.
- User-visible: sidebar spaces bar project/worktree rows.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md — Runtime Boundaries / Always-On Constraints | Shared UI change must define behavior for all runtimes | Change is in `packages/ui` with no runtime-specific branching; `RuntimeAPIs` not touched |
| Sync/state invariants | Derives live activity from live channels | Uses `activeSessionIdSet` (live status index) and `projectSections` authoritative directory ownership; scoped per-project directories |
| Theme system | UI indicator reuse | Reuses `AgentThinkingLoader` and existing `text-primary` token |

Nearest docs: `packages/ui/src/sync/DOCUMENTATION.md` (live status), `packages/ui/src/components/session/sidebar/DOCUMENTATION.md` (project zones/worktrees).

## Validation

| Check | Result |
|---|---|
| `git rebase origin/main` | Pass — rebased `pichamber/fix-sidebar-worktree-agent-loading` onto `c0cdae31` (#59) cleanly |
| `git diff origin/main...HEAD --stat` | 2 files, 58 insertions(+), 6 deletions(-) — only intended sidebar files |
| `gh auth status` | Pass — logged in as RyderAsKing |
| `bun run type-check` / `bun run lint` | Not run pre-merge (requested immediate merge); CI will gate |

## Visual evidence

No screenshots — indicator change is state-driven (busy spinner per worktree). Manual verification needed on expanded vs collapsed project with busy session in linked worktree.

## Risks and failure behavior

- **Rollback**: Revert single commit `887ba9b4`; no persisted migration.
- **Failure**: If `activeDirectoriesByProject` missing (older caller), falls back to legacy `hasActiveSessionByProject` path.
- **Compatibility**: No API contract change; purely UI.
- **Cross-runtime**: No Electron/Capacitor-specific code.

