### PR TITLE
chore: prepare v0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-09-01
+
+Streaming reliability and faster session startup.
+
+- **Live turns survive reload.** Reopening a chat that is still running restores the working/tooling state from `getSession` (`isStreaming` / `lifecycle: 'busy'` plus in-flight tools) instead of showing a settled transcript until the next token.
+- **Event stream stays attached.** Transport switches reconnect from the last accepted sequence without treating a disconnect as an empty session. Missed replay windows force-hydrate from an authoritative snapshot.
+- **Remembered desktop host auth.** Reloading an existing Electron window reapplies the selected remote host URL and stored client token so a remembered password is not prompted again (`startup-url-selection`, `main.mjs`).
+- **Warm sidebar catalog.** Stable session-list metadata is cached per runtime and restored as idle rows before directory lists return. Failed folder refreshes keep cached rows; authoritative empty lists persist an empty tombstone. Busy/retry and hydrated transcripts are never restored from cache (`pi-session-catalog-cache`).
+- **Faster crowded folder lists.** `sessions.list` reads up to eight JSONL session files at a time in a directory. One unreadable or header-malformed file still fails that folder only.
+
 ## [0.6.0] - 2026-08-25
 
 Worktree-aware sidebar and no-folder session fixes.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pichamber-monorepo",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "PiChamber monorepo workspace for web, ui, and desktop runtimes",
   "private": true,
   "type": "module",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pichamber/electron",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "description": "Electron desktop runtime for PiChamber",
   "author": "PiChamber",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pichamber/ui",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "main": "src/main.tsx",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-chamber/web",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": false,
   "type": "module",
   "repository": {


### PR DESCRIPTION
## Intent

Cut the 0.7.0 minor release: bump workspace versions and move changelog notes out of Unreleased so the Release workflow can publish GitHub desktop artifacts and `@pi-chamber/web` on npm.

## Non-goals

- No additional product code. Feature work landed in #61.
- Does not bump `packages/mobile` (version:bump contract).

## Affected surfaces

- Root, `packages/ui`, `packages/web`, and `packages/electron` `package.json` versions (`0.6.0` → `0.7.0`).
- `CHANGELOG.md` section `## [0.7.0] - 2026-09-01`.
- Release consumers: GitHub Release, Electron updater manifests, npm `@pi-chamber/web`.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `CONTRIBUTING.md` Desktop releases | Required bump + changelog heading before tag/dispatch | `bun run version:bump 0.7.0`; changelog heading matches workflow extractor |
| `AGENTS.md` | No secrets in docs | Changelog describes behavior only |

## Validation

| Check | Result |
|---|---|
| `bun run version:bump 0.7.0` | updated four manifests to 0.7.0 |
| Changelog heading `## [0.7.0] - 2026-09-01` | present for release-notes extractor |
| Feature CI (#61) | pass |

## Visual evidence

Version and changelog only. No rendered UI change.

## Risks and failure behavior

- Release workflow fails if the changelog heading is missing; it is present.
- npm publishes only when the Release workflow is dispatched with `publish_npm=true` (tag pushes skip npm). That dispatch follows merge of this PR.
- Android APK still builds on the version tag created by the workflow; iOS stays opt-in.

Made with [Cursor](https://cursor.com)