### PR TITLE
fix(ui): remove PiChamber heading from Settings nav

### DIFF
--- a/packages/ui/src/components/views/SettingsView.tsx
+++ b/packages/ui/src/components/views/SettingsView.tsx
@@ -804,16 +804,20 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onClose, forceMobile
                 .map((group) => ({ group, pages: pagesByGroup.get(group) ?? [] }))
                 .filter((entry) => entry.pages.length > 0);
 
-              return visibleGroups.map(({ group, pages }, groupIndex) => (
+              return visibleGroups.map(({ group, pages }, groupIndex) => {
+                const groupLabel = group === 'projects' ? 'Workspace' : group === 'agent' ? 'Agent' : null;
+                return (
                 <div key={group} className="space-y-0.5">
+                  {groupLabel ? (
                   <div
                     className={cn(
                       'px-3 pb-1 typography-micro font-semibold uppercase tracking-wide text-muted-foreground sm:px-2 sm:pb-0.5',
                       groupIndex === 0 ? 'pt-1' : 'pt-4 sm:pt-3',
                     )}
                   >
-                    {group === 'general' ? 'PiChamber' : group === 'projects' ? 'Workspace' : 'Agent'}
+                    {groupLabel}
                   </div>
+                  ) : null}
                   {pages.map((page) => {
                     // On the mobile nav STAGE nothing is "current" — the user is
                     // choosing, and settingsSlug only remembers the last visited
@@ -851,7 +855,8 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onClose, forceMobile
                     );
                   })}
                 </div>
-              ));
+                );
+              });
             })()}
           </div>
         </div>


### PR DESCRIPTION
## Intent
Remove the redundant `PiChamber` subheading at the top of the Settings left nav. The general group contains General/Appearance/Chat/Dictation/Notifications/Sessions/Shortcuts/About — the fact that Settings is opened inside PiChamber already provides context, so a dedicated label is unnecessary. Users referred to it as "Spy Chamber" (phonetic misreading of PiChamber) and requested its removal.

Behavior change: Settings nav no longer renders a heading for the `general` group. `Workspace` and `Agent` headings are unchanged. Affects both desktop (`256px` sidebar) and mobile (`nav` stage) because `renderSettingsNav()` is shared.

## Non-goals
- Not moving or renaming any settings pages or their routes/slugs
- Not touching page content under General group (PiChamberPage, AboutSettings, etc.) — only the nav group label
- Not changing persisted settings, search index, or metadata in `packages/ui/src/lib/settings/metadata.ts` (group remains `general`)
- Not altering theming, icons, or search behavior beyond hiding one label

## Affected surfaces
- **Package:** `@pichamber/ui` — `packages/ui/src/components/views/SettingsView.tsx:804-860`
- **Runtimes:** web, desktop (Electron), hosted-mobile, Capacitor mobile — all consume shared `SettingsView` via `@pichamber/ui`
- **User-visible:** Settings navigation chrome (left sidebar on desktop, full-screen nav on mobile). No other surfaces.
- **Not affected:** persisted/desktop settings, Pi runtime session contracts, provider catalog, sync/relay.

## Repository guidance
| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md Instruction Order & Runtime Boundaries | Any source change must respect shared UI contracts | Kept change in `packages/ui` (shared UI) with no runtime-specific branching |
| pichamber-change-discipline | Modifying exported React component behavior | Classified as Local implementation; smallest complete change (1 file, 8 insertions/3 deletions); preserved observable behavior of pages/icons/search; no new deps |
| settings-ui-patterns + layout.md | Changing Settings nav hierarchy | Read `references/layout.md` — general = app-level settings. Removed heading rather than adding new hierarchy; kept container-query (`@xl/@3xl`) pane rules untouched |
| theme-system | Touching nav styling | Reused existing `cn`/typography-micro tokens, no hardcoded colors |
| locale-ui-patterns | Removing user-facing string | Removed `PiChamber` heading string; no dangling interpolation |

## Validation
| Check | Result |
|---|---|
| `bunx --package typescript@5.9.3 tsc --noEmit --skipLibCheck --allowJs --jsx react-jsx packages/ui/src/components/views/SettingsView.tsx` | PASS — no errors (isolated check, full monorepo `node_modules` not installed in worktree) |
| Manual code inspection | Confirmed `groupLabel` is `null` for `general`, rendered conditionally; `visibleGroups` ordering (`NAV_GROUP_ORDER = [general, projects, agent]`) unchanged |
| `git diff --stat` | 1 file, 8+/3- |
| Full `bun run type-check / lint / build` | NOT run in worktree (no `node_modules`); change is single conditional render with no type or import changes — risk low; CI will run full checks on PR |

## Visual evidence
User-visible change in Settings left nav. Before: first group heading showed `PI CHAMBER` (uppercase micro) above General. After: first heading removed; list starts directly with General. No screenshots attached in this automation — behavior verified by reading `renderSettingsNav()` and confirming conditional `{groupLabel ? <div>…</div> : null}`. Reviewer can verify locally with `bun run dev` → Settings. Light/dark unaffected (heading used `text-muted-foreground` token).

## Risks and failure behavior
- **Rollback:** Single commit revert restores heading.
- **Stale data / cleanup:** No persisted stateing — purely presentational.
- **Compatibility:** No route/slug/metadata change; search still finds pages via `metadata.ts` keywords.
- **Failure modes:** If `visibleGroups` filtering empties `general`, first visible group (`projects` or `agent`) still renders its heading with correct top padding (`pt-1` vs `pt-4`) because `groupIndex` logic preserved.
- **Security/performance:** None — no data handling, no new hooks, no layout thrash.
