### PR TITLE
fix(ui): show local OpenAI logo for openai-codex provider

### DIFF
--- a/packages/ui/src/hooks/useProviderLogo.ts
+++ b/packages/ui/src/hooks/useProviderLogo.ts
@@ -18,6 +18,9 @@ const PRELOADED_LOGO_SRCS = new Set<string>();
 
 const LOGO_ALIAS = new Map<string, string>([
     ['codex', 'openai'],
+    ['openai-codex', 'openai'],
+    ['openai_codex', 'openai'],
+    ['openai.codex', 'openai'],
     ['chatgpt', 'openai'],
     ['claude', 'anthropic'],
     ['gemini', 'google'],
@@ -45,7 +48,16 @@ const buildLogoCandidates = (providerId: string | null | undefined) => {
 
     const compact = normalized.replace(/[^a-z0-9_\-./:]/g, '');
     const primary = compact.split(/[/:]/)[0] || compact;
-    const candidates = [LOGO_ALIAS.get(compact), LOGO_ALIAS.get(primary), compact, primary]
+    const base = primary.split(/[-_\.]/)[0] || primary;
+    const candidates = [
+        LOGO_ALIAS.get(compact),
+        LOGO_ALIAS.get(primary),
+        LOGO_ALIAS.get(base),
+        normalized.includes('codex') ? 'openai' : undefined,
+        compact,
+        primary,
+        base,
+    ]
         .filter((value): value is string => Boolean(value && value.length > 0));
 
     return [...new Set(candidates)];

--- a/packages/ui/src/hooks/useProviderLogo.ts
+++ b/packages/ui/src/hooks/useProviderLogo.ts
@@ -48,7 +48,7 @@ const buildLogoCandidates = (providerId: string | null | undefined) => {
 
     const compact = normalized.replace(/[^a-z0-9_\-./:]/g, '');
     const primary = compact.split(/[/:]/)[0] || compact;
-    const base = primary.split(/[-_\.]/)[0] || primary;
+    const base = primary.split(/[-_.]/)[0] || primary;
     const candidates = [
         LOGO_ALIAS.get(compact),
         LOGO_ALIAS.get(primary),


### PR DESCRIPTION
## Intent

Fixes the model-picker “disk” (provider logo pill/section header) for **OpenAI Codex** not showing the local OpenAI logo. `useProviderLogo` only aliased exact `codex` → `openai`, while Pi exposes the provider as `openai-codex` (also `openai_codex`, `openai.codex`, `provider.openai-codex`, `models.openai-codex`, `openai-codex/<model>`). That produced candidates `["openai-codex"]` with no local `openai.svg` match and a broken remote fallback `https://models.dev/logos/openai-codex.svg`, so `<ProviderLogo>` rendered nothing.

## Non-goals

- No new logo assets, no changes to `ProviderLogo` props or `ModelPickerList` layout.
- No rework of remote fallback hosting or `models.dev` catalog; only candidate resolution.
- No changes to quota/billing or `openai-codex` model catalog behavior.

## Affected surfaces

- **Package:** `packages/ui` — `src/hooks/useProviderLogo.ts` (shared logo resolution), `src/components/ui/ProviderLogo.tsx` (consumer), `src/components/model-picker/ModelPickerList.tsx` and `src/components/chat/ModelControls.tsx` (model-picker UI).
- **Runtimes:** web, desktop (Electron), hosted-mobile, Capacitor mobile — shared UI contract via `useProviderLogo`/`ProviderLogo`; no runtime-specific branching.
- **User-visible:** Model picker provider sections, favorites/recent rows, and header/provider cards for `openai-codex` now show bundled `openai.svg` (local) with remote `openai.svg` fallback. Other providers unchanged (`github-copilot`, `zai-coding-plan`, etc. verified).
- **Persisted contracts:** none.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` — Always-On Constraints, Runtime Boundaries, Correctness Invariants | Change touches shared UI (`packages/ui`) consumed by all runtimes; must keep bridges thin and define intentional behavior per runtime. | Fix lives in the owning module `useProviderLogo`; no web/electron/mobile-specific forks. `runtimeFetch`/`RuntimeAPIs` untouched. |
| `AGENTS.md` — Documentation Discovery | Hook is sync/asset boundary adjacent; check nearest docs. | Read `packages/ui/src/sync/DOCUMENTATION.md` and `packages/ui/README` precedent before editing; no owning doc change needed (behavioral fix, not contract). |
| `.agents/skills/pichamber-change-discipline/SKILL.md` | Any source/export/build-config change. | Minimal, focused diff (1 file, 13 insertions); preserves unrelated worktree; no new deps; `bun run dead-code` not required (no exports changed). |
| `.agents/skills/theme-system/SKILL.md` | Provider logo is themed visual asset rendered with `dark:invert`. | No new colors/tokens; reuses existing `openai.svg` asset and `dark:invert` class; light/dark unaffected. |

## Validation

| Check | Result |
|---|---|
| `bun run --cwd packages/ui type-check` (`tsc --noEmit`) | pass (no output) |
| `bun run --cwd packages/ui test` (`bun test --isolate`) | 1743 pass, 0 fail |
| `bun -e` manual `buildLogoCandidates` probe for `openai-codex`, `openai_codex`, `openai.codex`, `codex`, `openai-codex/gpt-5`, `provider.openai-codex`, `custom-codex-provider`, `anthropic`, `github-copilot`, `zai-coding-plan` | all resolve to `["openai", …]` for codex variants (local hit), others unchanged |
| `bun run test:web` full suite | 1 pre-existing flaky failure in `server/lib/relay/host-client.test.js` (timeout) unrelated to UI change; 568/569 pass |
| Visual/relay/perf | Not exercised; claim limited to local fallback resolution, verified via unit logic and lack of network dependency. |

## Visual evidence

No user-visible change beyond fixing a missing image: `openai-codex` now renders the bundled `openai.svg` (same asset used for `openai`/`codex`/`chatgpt`) wherever `ProviderLogo providerId="openai-codex"` is used (picker sections, favorites, mobile panel, provider cards). No new asset or layout.

- Before: `buildLogoCandidates("openai-codex") === ["openai-codex"]` → `LOCAL_PROVIDER_LOGO_MAP` miss → remote `openai-codex.svg` 404 → `<ProviderLogo>` returns `null`.
- After: `buildLogoCandidates("openai-codex") === ["openai","openai-codex"]` (aliases + `base="openai"` + `codex` heuristic) → local `openai.svg` hit → `<img src="<bundled openai.svg>">` with eager/preload.

No additional screenshots because the change is a missing-asset fix reusing an existing asset; manual UI verification is a single logo presence check in the picker for any authenticated `openai-codex` provider.

## Risks and failure behavior

- **Rollback:** revert single file; risk is isolated logo miss for `openai-codex` only.
- **Compatibility:** aliases + `base` split (`primary.split(/[-_\.]/)`) + `codex` substring heuristic are additive and deduped; existing providers still resolve to their most-specific local logo first (`zai-coding-plan` → its own svg before `zai`, `github-copilot` before `github`). No credential or pairing exposure.
- **Performance:** candidate list grows from 2–4 to 3–7 entries, deduped via `Set`; negligible for picker hot path.
- **Cross-runtime:** change is runtime-agnostic (no `RuntimeAPIs`, no file/secret logging).
- **Failure:** if local `openai.svg` missing, fallback remote is now `https://models.dev/logos/openai.svg` (exists) instead of `openai-codex.svg` (404); `onError` still falls back local→remote→none.

