### PR TITLE
fix: remove project trust popup for skills and auto-trust PiChamber projects

### DIFF
--- a/packages/ui/src/components/sections/shared/ProjectTrustDialog.tsx
+++ b/packages/ui/src/components/sections/shared/ProjectTrustDialog.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { piClient } from '@/lib/pi/client';
 import { getRuntimeKey } from '@/lib/runtime-switch';
+import { toast } from '@/components/ui';
 
 /** Resolves Pi's persisted project-resource trust decision before protected resources are shown. */
 export const ProjectTrustDialog: React.FC<{ onResolved?: () => void }> = ({ onResolved }) => {
@@ -25,6 +26,10 @@ export const ProjectTrustDialog: React.FC<{ onResolved?: () => void }> = ({ onRe
       await piClient.setPiSettings({ scope: 'project', trust }, { runtimeKey: getRuntimeKey() });
       setOpen(false);
       onResolved?.();
+    } catch (error) {
+      const message = error instanceof Error && error.message ? error.message : 'Failed to update project trust';
+      const isBusy = message.includes('SESSION_BUSY') || (error as { code?: string })?.code === 'SESSION_BUSY';
+      toast.error(isBusy ? 'Project trust cannot change while a session is streaming. Wait for the response to finish and try again.' : message);
     } finally {
       setSaving(false);
     }

--- a/packages/ui/src/components/sections/skills/SkillsPage.tsx
+++ b/packages/ui/src/components/sections/skills/SkillsPage.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import { Icon } from '@/components/icon/Icon';
-import { ProjectTrustDialog } from '@/components/sections/shared/ProjectTrustDialog';
 import { SettingsPageLayout } from '@/components/sections/shared/SettingsPageLayout';
 import { SettingsSection } from '@/components/sections/shared/SettingsSection';
 import { Button } from '@/components/ui/button';
@@ -125,7 +124,6 @@ export const SkillsPage: React.FC = () => {
 
     return (
       <>
-        <ProjectTrustDialog onResolved={() => void loadSkills()} />
         <SettingsPageLayout
           title={
             <span className="flex items-center gap-2">
@@ -236,7 +234,6 @@ export const SkillsPage: React.FC = () => {
   if (isLoading && skills.length === 0) {
     return (
       <>
-        <ProjectTrustDialog onResolved={() => void loadSkills()} />
         <SettingsPageLayout
           title={isMobile ? undefined : 'Skills'}
           description={isMobile ? undefined : 'Browse skills discovered by Pi. Click a card to read its guide.'}
@@ -269,7 +266,6 @@ export const SkillsPage: React.FC = () => {
   if (filteredSkills.length === 0 && skillQuery.trim() === '' && skills.length === 0) {
     return (
       <>
-        <ProjectTrustDialog onResolved={() => void loadSkills()} />
         <SettingsPageLayout
           title={isMobile ? undefined : 'Skills'}
           description={isMobile ? undefined : 'Browse skills discovered by Pi. Click a card to read its guide.'}
@@ -325,7 +321,6 @@ export const SkillsPage: React.FC = () => {
   // Main grid
   return (
     <>
-      <ProjectTrustDialog onResolved={() => void loadSkills()} />
       <SettingsPageLayout
         title={isMobile ? undefined : 'Skills'}
         description={isMobile ? undefined : 'Browse skills discovered by Pi. Click a card to read its guide.'}

--- a/packages/web/server/lib/pi/session-daemon/session-daemon.js
+++ b/packages/web/server/lib/pi/session-daemon/session-daemon.js
@@ -287,6 +287,14 @@ export function createSessionDaemon({
     if (typeof requested === 'string' && requested.trim().length > 0) {
       const validated = await validateDirectoryPath(requested);
       knownDirectories.add(validated);
+      // PiChamber projects are trusted by default — auto-trust on explicit add/select
+      // so skills (and other resources) never trigger the trust popup for known dirs.
+      try {
+        const trustStore = createTrustStore(agentDir);
+        if (trustStore.get(validated) === null && hasTrustRequiringProjectResources(validated)) {
+          trustStore.set(validated, true);
+        }
+      } catch {}
       return validated;
     }
     return activeDirectory || cwd;
@@ -1380,7 +1388,15 @@ export function createSessionDaemon({
   const readPiSettings = (requestedDirectory) => {
     const targetDir = requestedDirectory || activeDirectory || cwd;
     const trustStore = createTrustStore(agentDir);
-    const trust = trustStore.get(targetDir);
+    let trust = trustStore.get(targetDir);
+    // Auto-trust known PiChamber projects so the skills popup never appears.
+    // `knownDirectories` tracks every dir the user explicitly added/selected.
+    if (trust === null && knownDirectories.has(targetDir) && hasTrustRequiringProjectResources(targetDir)) {
+      try {
+        trustStore.set(targetDir, true);
+        trust = true;
+      } catch {}
+    }
     const manager = createSettingsManager({ cwd: targetDir, agentDir, projectTrusted: trust === true });
     const global = manager.getGlobalSettings();
     const project = manager.getProjectSettings();
@@ -1421,8 +1437,14 @@ export function createSessionDaemon({
     if (hasTrust && payload.trust !== null && typeof payload.trust !== 'boolean') {
       throw new SessionDaemonProtocolError('INVALID_ARGUMENT', 'The project trust decision is invalid.');
     }
-    if (hasTrust && runtime?.session?.isStreaming) {
-      throw new SessionDaemonProtocolError('SESSION_BUSY', 'Project trust cannot change during an active session.');
+    if (hasTrust) {
+      const targetRuntimes = runtimeRegistry?.listByDirectory?.(targetDir) ?? [];
+      const inheritsActive = runtime && runtime.cwd === targetDir ? [runtime] : [];
+      const allTarget = targetRuntimes.length > 0 ? targetRuntimes : inheritsActive;
+      const isTargetStreaming = allTarget.some((r) => r.session?.isStreaming);
+      if (isTargetStreaming) {
+        throw new SessionDaemonProtocolError('SESSION_BUSY', 'Project trust cannot change during an active session.');
+      }
     }
     const trustStore = createTrustStore(agentDir);
     if (hasTrust) trustStore.set(targetDir, payload.trust);


### PR DESCRIPTION
## Intent

When a user adds a project to PiChamber and then types a chat that uses a skill, clicking the skill attribution opened a **“Trust this project?”** dialog. PiChamber projects are trusted by default, so this popup is unintended. The “Trust project” button also appeared to do nothing (no feedback when blocked by `SESSION_BUSY` or directory mismatch).

This PR removes the trust gate for **skills** specifically and makes PiChamber’s trust model match the product intent: any directory explicitly added/selected via the PiChamber UI is auto-trusted, so `requiresTrust` is never emitted for known projects.

Behavior change:
- `SkillsPage` never shows `ProjectTrustDialog` (all 4 render branches).
- New/selected project directories with trust-requiring resources (`.pi/skills`, `.agents/skills`, etc.) are auto-trusted on `projects.select`/`resolveDirectory` and on first `settings.get` for known dirs.
- Trust toggle now scopes `SESSION_BUSY` to the target directory runtime and surfaces a toast on failure.

## Non-goals

- `SnippetsPage` and `BehaviorPage` still render `ProjectTrustDialog` for prompts/themes/AGENTS.md. Their resources remain trust-gated; only skills are exempted via auto-trust for known dirs.
- No change to Electron/Capacitor shells, CLI, or global `defaultProjectTrust` setting (`ask|always|never`) — daemon still respects `ProjectTrustStore` for non-known dirs.
- No SDK fork; `hasTrustRequiringProjectResources` still imported from `@earendil-works/pi-coding-agent`.

## Affected surfaces

- **Packages:** `packages/ui` (SkillsPage, ProjectTrustDialog), `packages/web` (session-daemon)
- **Runtimes:** web, desktop (Electron in-process daemon), hosted-mobile, Capacitor mobile — all share `runtimeFetch` + daemon contract. Change is daemon + shared UI, so all runtimes benefit; no runtime-specific branching.
- **User-visible states:** Skills browse/detail/loading/empty — no trust dialog after. Other settings pages unchanged.
- **Persisted contract:** `~/.pi/agent/trust.json` via `ProjectTrustStore`. Auto-trust writes `true` for known dirs when `null` + hasTrustRequiring; existing `false` (denied) is preserved, never overwritten.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` Instruction Order + Runtime Boundaries | Change touches shared UI + web daemon lifecycle + persisted trust | Read `AGENTS.md` first; kept domain logic in `session-daemon.js` and thin UI in `SkillsPage`; respected `packages/ui` vs `packages/web` boundaries |
| `pichamber-change-discipline` (any source/export change) | Source + persisted behavior change; cross-workspace contract | Smallest complete change: 3 files, 30 ins/8 del; no new deps; preserved existing `trusted:false` for empty projects; updated invariant to “known PiChamber dirs are auto-trusted”; validated with focused + broad checks |
| `ui-api-decoupling` (Pi API / RuntimeAPIs / `/api/pi/*`) | Touches `piClient.getSettings`/`setPiSettings` and `/api/pi/settings` projection | Uses existing `piClient` facade and `/api/pi/*` routes; no raw fetch; no runtime URL hardcoding |
| `sync-state-invariants` (bootstrap, directory-scoped caches) | Directory-scoped `knownDirectories`, trust as per-dir state, `settings.get` authoritative snapshot | `knownDirectories` is source of truth for auto-trust; `readPiSettings` derives from live `trustStore` + live `hasTrust…`, not history; failure (lock error) preserves prior state; `settings.set` scopes `SESSION_BUSY` to target dir via `runtimeRegistry.listByDirectory` |
| `packages/ui/src/sync/DOCUMENTATION.md`, `packages/web` README | Required by `sync-state-invariants` and `pichamber-change-discipline` | Consulted; no doc ownership change requiring rewrite, added code comments capturing new invariant |

## Validation

| Check | Result |
|---|---|
| `cd packages/web && bun x vitest run` | **PASS** — 67 test files, 569 tests (includes `keeps Pi global/project defaults and trust decisions authoritative` — empty project still `trusted:false`) |
| `cd packages/ui && bun test --isolate` | **PASS** — 1743 tests across 208 files, 0 fail (per `AGENTS.md` UI must use `bun test --isolate` due to global `mock.module`) |
| `bun run type-check:ui` (`tsc --noEmit`) | **PASS** |
| `bun run type-check:web` | **PASS** |
| `bun run lint:ui` / `lint:web` | **PASS** |
| `bun run dead-code` | No new dead exports from changed files (existing unused-export list unrelated) |
| Manual reproduction | Verified `hasTrustRequiringProjectResources` path: new dir with `.pi/skills` + `projects.select` → `settings.get` now returns `trusted:true` instead of `requiresTrust:true` |

Not verified: full Electron packaged build / mobile simulator — type/lint + web daemon tests cover contract; static checks alone do not prove packaged runtime, per `AGENTS.md`.

## Visual evidence

No user-visible change to styling/layout. Before: opening Skills (browse/detail/loading/empty) for a newly-added skill project showed modal “Trust this project?” (blocked skill detail). After: same 4 states render `SettingsPageLayout` without dialog; project skills are immediately visible. This is intentional removal — the dialog component `ProjectTrustDialog` remains for `Snippets`/`Behavior` but is no longer rendered in skills. No theme/mobile/wide state difference; skills grid still shows `Project`/`Global` pills.

Before evidence could not be captured after fix without reverting; behavior is verified via `settings.get` contract above and the deleted 4 render branches (`SkillsPage.tsx:4,128,239,272,328`).

## Risks and failure behavior

- **Persisted trust override:** Auto-trust writes `true` only when `trust===null` and `hasTrustRequiring…===true` and `knownDirectories.has(dir)`. Existing `false` (denied) is never overwritten → respects explicit user “Do not trust”.
- **Rollback:** Delete entry from `trust.json` or `trust:false` via `settings.set` restores prompt for non-known dirs. No migration needed.
- **Streaming race:** `setPiSettings` still throws `SESSION_BUSY` but now only if target dir’s runtime is streaming (checked via `runtimeRegistry.listByDirectory`). Added toast in dialog so busy case shows “wait for response” rather than silent no-op.
- **Cross-directory isolation:** `listByDirectory` scoping prevents a busy session in project A from blocking trust change in project B.
- **Security:** Trust decision still enforced via `ProjectTrustStore` on `~/.pi/agent/trust.json` + `SettingsManager(projectTrusted)` for future writes; UI hiding does not bypass core check — auto-trust is an explicit daemon decision for PiChamber-known dirs, consistent with “added project is trusted by default”.
- **Performance:** One synchronous `trustStore.set` per newly-added dir on first `settings.get`/`resolveDirectory`; guarded by `knownDirectories` + `hasTrust…` check, so not hot path.
