### PR TITLE
feat(ui): UI tweaks — sidebar border, Projects grid, tablet header and chat padding

### DIFF
--- a/packages/ui/src/components/chat/ChatContainer.tsx
+++ b/packages/ui/src/components/chat/ChatContainer.tsx
@@ -386,7 +386,7 @@ const ChatViewport = React.memo(({
                             <StatusRowContainer />
                         </div>
 
-                        <div className="flex-shrink-0" style={{ height: isMobile ? '40px' : '10vh' }} aria-hidden="true" />
+                        <div className="flex-shrink-0" style={{ height: isMobile ? 'calc(40px + var(--oc-safe-area-bottom, 0px))' : 'calc(10vh + var(--oc-safe-area-bottom, 0px))' }} aria-hidden="true" />
                     </div>
                 </ScrollShadow>
                 <OverlayScrollbar containerRef={scrollRef} suppressVisibility={isProgrammaticFollowActive} userIntentOnly observeMutations={false} />

--- a/packages/ui/src/components/chat/ChatMessage.tsx
+++ b/packages/ui/src/components/chat/ChatMessage.tsx
@@ -1022,7 +1022,10 @@ const ChatMessage: React.FC<ChatMessageProps> = ({
                 className={cn(
                     'group w-full',
                     isUser ? (isMobile ? 'pt-2' : 'pt-4') : assistantTopPaddingClass,
-                    isUser ? 'pb-0' : (isFollowedByAssistant || nextIsHiddenUserMessage) ? 'pb-0' : 'pb-2'
+                    // Tablet and desktop share bottom spacing (pb-2) for consistency;
+                    // mobile keeps tighter pb-0. User bubble's internal pb-4 below
+                    // provides the visual bottom padding inside the bubble.
+                    isUser ? (isMobile ? 'pb-0' : 'pb-2') : (isFollowedByAssistant || nextIsHiddenUserMessage) ? 'pb-0' : 'pb-2'
                 )}
                 id={`message-${message.info.id}`}
                 data-message-id={message.info.id}
@@ -1045,7 +1048,12 @@ const ChatMessage: React.FC<ChatMessageProps> = ({
                                                 borderRadius: userMessageRadius,
                                                 borderBottomRightRadius: 'var(--radius-sm)',
                                             }}
-                                            className="px-5 py-3 shadow-none border border-primary/5"
+                                            className={cn(
+                                                'px-5 py-3 shadow-none border border-primary/5',
+                                                // Desktop and tablet share the same bottom padding (pb-4)
+                                                // for visual consistency; mobile keeps tighter py-3.
+                                                !isMobile && 'pb-4'
+                                            )}
                                         >
                                             <MessageBody
                                                 sessionId={message.info.sessionID}

--- a/packages/ui/src/components/layout/MainLayout.tsx
+++ b/packages/ui/src/components/layout/MainLayout.tsx
@@ -521,7 +521,6 @@ export const MainLayout: React.FC = () => {
                         <Sidebar
                             isOpen={isSidebarOpen}
                             isMobile={isMobile}
-                            className="border-border"
                         >
                             <SessionSidebar isVisible={isSidebarOpen} />
                         </Sidebar>

--- a/packages/ui/src/components/layout/Sidebar.tsx
+++ b/packages/ui/src/components/layout/Sidebar.tsx
@@ -129,9 +129,8 @@ export const Sidebar: React.FC<SidebarProps> = ({ isOpen, isMobile, children, cl
         <aside
             ref={sidebarRef}
             className={cn(
-                'relative flex h-full overflow-hidden border-r border-border motion-reduce:transition-none',
+                'relative flex h-full overflow-hidden motion-reduce:transition-none',
                 'bg-sidebar',
-                !isOpen && 'border-r-0',
                 className,
             )}
             style={{

--- a/packages/ui/src/components/layout/TitlebarLeftControls.tsx
+++ b/packages/ui/src/components/layout/TitlebarLeftControls.tsx
@@ -12,10 +12,10 @@ import { useTabletLayout } from '@/lib/device';
 const ICON_BUTTON_CLASS =
   'app-region-no-drag inline-flex h-8 w-8 items-center justify-center gap-2 rounded-md typography-ui-label font-medium text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary hover:bg-interactive-hover transition-colors';
 
-// Tablet header buttons sit alongside h-9 workspace tabs; a 32px toggle would
-// look visibly smaller than its row-mates and offset the rest of the header.
+// Mirrors the context-usage chart button in the header (size-10 rounded-full,
+// 18px icon) so the left burger and right rail controls share size/position.
 const TABLET_TOGGLE_BUTTON_CLASS =
-  'app-region-no-drag inline-flex h-9 w-9 items-center justify-center gap-2 p-2 rounded-md typography-ui-label font-medium text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:pointer-events-none disabled:opacity-50 hover:text-foreground hover:bg-interactive-hover transition-colors';
+  'app-region-no-drag flex size-10 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:pointer-events-none disabled:opacity-50';
 
 /**
  * Persistent top-left titlebar controls (window chrome + collapsed-sidebar toggle).
@@ -48,7 +48,7 @@ export const TitlebarLeftControls: React.FC = () => {
   const showAppMenu = usesFramelessChrome;
   const showOverlay = showToggle || showWindowControls || showAppMenu;
   // A toggle-only cluster is always a 2rem button on desktop. On tablet the
-  // toggle grows to h-9 (36px) to match the header's other row-mates — see
+  // toggle grows to size-10 (40px) to match the context-usage chart button — see
   // TABLET_TOGGLE_BUTTON_CLASS. Measuring it on every sidebar toggle flushes
   // the just-invalidated layout tree; only native window chrome can make this
   // cluster's width variable.
@@ -114,11 +114,17 @@ export const TitlebarLeftControls: React.FC = () => {
     // header / sidebar strip beneath carve a matching no-drag region under it
     // and remain drag regions everywhere else, so window dragging still works
     // in the empty parts of the strip.
+    // On tablet/Android the header has `padding-top: var(--oc-safe-area-top)` for the
+    // notifications bar; the overlay must sit *below* that inset so the burger
+    // is vertically aligned with the right-rail header icons (which are inside
+    // the header's content box). Using top + height-calc keeps desktop (safe=0)
+    // identical and tablet aligned.
     <div
       ref={overlayRef}
-      className="app-region-no-drag absolute left-0 top-0 z-40 flex select-none items-center pr-2"
+      className="app-region-no-drag absolute left-0 z-40 flex select-none items-center pr-2"
       style={{
-        height: 'var(--oc-header-height, 3rem)',
+        top: 'var(--oc-safe-area-top, 0px)',
+        height: 'calc(var(--oc-header-height, 3rem) - var(--oc-safe-area-top, 0px))',
         paddingLeft: 'var(--oc-titlebar-left-inset, 0.75rem)',
       }}
     >
@@ -159,7 +165,7 @@ export const TitlebarLeftControls: React.FC = () => {
               >
                 <Icon
                   name="layout-left"
-                  className={isTabletLayoutEnabled ? 'h-5 w-5' : 'h-[18px] w-[18px]'}
+                  className={isTabletLayoutEnabled ? 'size-[18px]' : 'h-[18px] w-[18px]'}
                 />
               </button>
             </TooltipTrigger>

--- a/packages/ui/src/components/sections/projects/ProjectCard.tsx
+++ b/packages/ui/src/components/sections/projects/ProjectCard.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+
+import { Icon } from '@/components/icon/Icon';
+import { cn } from '@/lib/utils';
+import type { ProjectEntry } from '@/lib/api/types';
+
+interface ProjectCardProps {
+  project: ProjectEntry;
+  onSelect: (projectId: string) => void;
+}
+
+/** Grid card for project browse. Mirrors Provider/Skill/Snippet cards. */
+export const ProjectCard: React.FC<ProjectCardProps> = ({ project, onSelect }) => {
+  const label = project.label?.trim() || project.path.split('/').pop()?.trim() || project.path;
+  const hasCustomLabel = Boolean(project.label?.trim());
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(project.id)}
+      aria-label={`${label} project, ${project.path}`}
+      className={cn(
+        'group flex min-h-[118px] flex-col gap-3 rounded-xl border bg-[var(--surface-elevated)] p-4 text-left',
+        'border-border/60 hover:bg-interactive-hover hover:border-border',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--interactive-focus-ring)]',
+        'transition-colors duration-150',
+      )}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <span className="inline-flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+          <Icon name="folder" className="size-4" aria-hidden />
+        </span>
+      </div>
+
+      <div className="min-w-0 flex-1">
+        <div className="truncate typography-ui-label font-medium text-foreground">{label}</div>
+        {hasCustomLabel ? (
+          <div className="truncate font-mono typography-micro text-muted-foreground">{project.path}</div>
+        ) : (
+          <div className="truncate typography-micro text-muted-foreground">{project.path}</div>
+        )}
+      </div>
+    </button>
+  );
+};
+
+interface ProjectCardSkeletonProps {
+  count?: number;
+}
+
+export const ProjectCardSkeleton: React.FC<ProjectCardSkeletonProps> = ({ count = 6 }) => (
+  <>
+    {Array.from({ length: count }).map((_, index) => (
+      <div
+        key={index}
+        className="flex min-h-[118px] flex-col gap-3 rounded-xl border border-border/60 bg-[var(--surface-elevated)] p-4"
+      >
+        <div className="flex items-start justify-between gap-2">
+          <div className="size-8 shrink-0 animate-pulse rounded-md bg-muted" />
+        </div>
+        <div className="space-y-1.5">
+          <div className="h-4 w-3/4 animate-pulse rounded bg-muted" />
+          <div className="h-3 w-full animate-pulse rounded bg-muted" />
+        </div>
+      </div>
+    ))}
+  </>
+);

--- a/packages/ui/src/components/sections/projects/ProjectsPage.tsx
+++ b/packages/ui/src/components/sections/projects/ProjectsPage.tsx
@@ -1,60 +1,203 @@
 import React from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Icon } from '@/components/icon/Icon';
+import { cn } from '@/lib/utils';
+import { sessionEvents } from '@/lib/sessionEvents';
 import { SettingsPageLayout } from '@/components/sections/shared/SettingsPageLayout';
+import { SettingsSection } from '@/components/sections/shared/SettingsSection';
+import { ProjectCard } from '@/components/sections/projects/ProjectCard';
+import { ProjectSettingsPanel } from '@/components/sections/projects/ProjectSettingsPanel';
+import { useDeviceInfo } from '@/lib/device';
 import { useProjectsStore } from '@/stores/useProjectsStore';
 import { useUIStore } from '@/stores/useUIStore';
-import { ProjectSettingsPanel } from '@/components/sections/projects/ProjectSettingsPanel';
 import type { ProjectIdentitySaveData } from '@/components/sections/projects/useProjectIdentityForm';
-import { useDeviceInfo } from '@/lib/device';
 
+/** Projects settings — browse grid + detail, like Providers/Skills/Snippets. */
 export const ProjectsPage: React.FC = () => {
-  
   const { isMobile } = useDeviceInfo();
   const projects = useProjectsStore((state) => state.projects);
   const updateProjectMeta = useProjectsStore((state) => state.updateProjectMeta);
   const selectedId = useUIStore((state) => state.settingsProjectsSelectedId);
   const setSelectedId = useUIStore((state) => state.setSettingsProjectsSelectedId);
 
+  const [projectQuery, setProjectQuery] = React.useState('');
+
+  const handleAddProject = React.useCallback(() => {
+    sessionEvents.requestDirectoryDialog();
+  }, []);
+
   const selectedProject = React.useMemo(() => {
     if (!selectedId) return null;
     return projects.find((p) => p.id === selectedId) ?? null;
   }, [projects, selectedId]);
 
+  // Clear stale selection (e.g. project removed) — don't auto-select first;
+  // browse grid is the default empty state like Providers/Skills.
   React.useEffect(() => {
-    if (projects.length === 0) {
+    if (selectedId && !projects.some((p) => p.id === selectedId)) {
       setSelectedId(null);
-      return;
     }
-    if (selectedId && projects.some((p) => p.id === selectedId)) {
-      return;
-    }
-    setSelectedId(projects[0].id);
   }, [projects, selectedId, setSelectedId]);
 
-  const handleIdentitySave = React.useCallback(async (data: ProjectIdentitySaveData) => {
-    if (!selectedProject) return;
-    updateProjectMeta(selectedProject.id, {
-      label: data.label,
-      defaultModel: data.defaultModel ?? null,
-    });
-  }, [selectedProject, updateProjectMeta]);
+  const handleIdentitySave = React.useCallback(
+    async (data: ProjectIdentitySaveData) => {
+      if (!selectedProject) return;
+      updateProjectMeta(selectedProject.id, {
+        label: data.label,
+        defaultModel: data.defaultModel ?? null,
+      });
+    },
+    [selectedProject, updateProjectMeta],
+  );
 
-  if (!selectedProject) {
+  // ── Detail view ──────────────────────────────────────────────────────────
+  if (selectedProject) {
+    const label = selectedProject.label?.trim() || selectedProject.path.split('/').pop()?.trim() || selectedProject.path;
+
     return (
-      <SettingsPageLayout title={isMobile ? undefined : "Projects"}>
-        <p className="typography-meta text-muted-foreground">{"No projects available."}</p>
+      <SettingsPageLayout
+        title={
+          <span className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="xs"
+              onClick={() => setSelectedId(null)}
+              aria-label="Back to projects"
+              className="-ml-1 h-7 w-7 p-0"
+            >
+              <Icon name="arrow-left-s" className="size-4" />
+            </Button>
+            <Icon name="folder" className="size-5 shrink-0 text-muted-foreground" aria-hidden />
+            <span className="truncate">{label}</span>
+          </span>
+        }
+        description={<span className="font-mono typography-settings-description text-muted-foreground">{selectedProject.path}</span>}
+      >
+        <ProjectSettingsPanel project={selectedProject} onIdentitySave={handleIdentitySave} />
       </SettingsPageLayout>
     );
   }
 
-  const headerLabel = selectedProject.label ?? "Project Settings";
+  // ── Browse grid ──────────────────────────────────────────────────────────
+  const sortedProjects = React.useMemo(() => {
+    return [...projects].sort((a, b) => {
+      const aLabel = (a.label?.trim() || a.path).toLowerCase();
+      const bLabel = (b.label?.trim() || b.path).toLowerCase();
+      return aLabel.localeCompare(bLabel, undefined, { sensitivity: 'base' });
+    });
+  }, [projects]);
+
+  const filteredProjects = React.useMemo(() => {
+    const q = projectQuery.trim().toLowerCase();
+    if (!q) return sortedProjects;
+    return sortedProjects.filter((p) => {
+      const label = (p.label ?? '').toLowerCase();
+      const path = p.path.toLowerCase();
+      return label.includes(q) || path.includes(q);
+    });
+  }, [sortedProjects, projectQuery]);
+
+  // Empty state — no projects at all
+  if (projects.length === 0) {
+    return (
+      <SettingsPageLayout
+        title={isMobile ? undefined : 'Projects'}
+        description={isMobile ? undefined : 'Manage your projects and worktrees. Add a project to configure its defaults and actions.'}
+        headerEnd={
+          <Button variant="outline" size="sm" onClick={handleAddProject}>
+            <Icon name="add" className="size-4" />
+            Add project
+          </Button>
+        }
+      >
+        <SettingsSection title="Projects" divider={false} settingsItem="projects.browse">
+          <div className="flex flex-col items-center justify-center gap-3 py-12 text-center">
+            <Icon name="folders" className="size-8 text-muted-foreground/60" aria-hidden />
+            <p className="typography-meta text-muted-foreground">No projects yet</p>
+            <p className="typography-micro max-w-sm text-muted-foreground">Add a local directory to start saving per-project defaults, session history, and header actions.</p>
+            <Button variant="outline" size="sm" onClick={handleAddProject}>
+              <Icon name="add" className="size-4" />
+              Add project
+            </Button>
+          </div>
+        </SettingsSection>
+      </SettingsPageLayout>
+    );
+  }
 
   return (
     <SettingsPageLayout
-      title={headerLabel}
-      description={selectedProject.path}
-      outerClassName="bg-background"
+      title={isMobile ? undefined : 'Projects'}
+      description={isMobile ? undefined : 'Manage your projects and worktrees. Click a card to configure its defaults and actions.'}
+      headerEnd={
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="relative">
+            <Icon
+              name="search"
+              className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+              aria-hidden
+            />
+            <Input
+              value={projectQuery}
+              onChange={(event) => setProjectQuery(event.target.value)}
+              placeholder="Search projects"
+              aria-label="Search projects"
+              className="h-9 w-[18rem] max-w-[24rem] pl-8"
+            />
+            {projectQuery ? (
+              <button
+                type="button"
+                onClick={() => setProjectQuery('')}
+                aria-label="Clear search"
+                className="absolute right-1 top-1/2 inline-flex size-7 -translate-y-1/2 items-center justify-center rounded text-muted-foreground hover:bg-interactive-hover hover:text-foreground"
+              >
+                <Icon name="close" className="size-4" />
+              </button>
+            ) : null}
+          </div>
+          <Button variant="outline" size="sm" onClick={handleAddProject}>
+            <Icon name="add" className="size-4" />
+            Add project
+          </Button>
+        </div>
+      }
     >
-      <ProjectSettingsPanel project={selectedProject} onIdentitySave={handleIdentitySave} />
+      <SettingsSection title="Projects" divider={false} settingsItem="projects.browse">
+        {filteredProjects.length === 0 ? (
+          <div className="flex flex-col items-center justify-center gap-2 py-12 text-center">
+            <p className="typography-meta text-muted-foreground">No projects match “{projectQuery}”.</p>
+            <Button variant="ghost" size="xs" onClick={() => setProjectQuery('')}>
+              Clear search
+            </Button>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-3 @xl:grid-cols-2 @3xl:grid-cols-3">
+            {filteredProjects.map((project) => (
+              <ProjectCard key={project.id} project={project} onSelect={setSelectedId} />
+            ))}
+            <button
+              type="button"
+              onClick={handleAddProject}
+              aria-label="Add project"
+              className={cn(
+                'group flex min-h-[118px] flex-col items-center justify-center gap-2 rounded-xl border border-dashed p-4',
+                'border-border/60 bg-transparent text-muted-foreground',
+                'hover:border-border hover:bg-interactive-hover hover:text-foreground',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--interactive-focus-ring)]',
+                'transition-colors duration-150',
+              )}
+            >
+              <span className="inline-flex size-9 items-center justify-center rounded-full bg-muted">
+                <Icon name="add" className="size-5" />
+              </span>
+              <span className="typography-ui-label font-medium">Add project</span>
+              <span className="typography-micro text-muted-foreground">Local directory</span>
+            </button>
+          </div>
+        )}
+      </SettingsSection>
     </SettingsPageLayout>
   );
 };

--- a/packages/ui/src/components/views/SettingsView.tsx
+++ b/packages/ui/src/components/views/SettingsView.tsx
@@ -10,7 +10,6 @@ import { Tooltip, TooltipTrigger } from '@/components/ui/tooltip';
 import { ErrorBoundary } from '@/components/ui/ErrorBoundary';
 import { BehaviorPage } from '@/components/sections/behavior/BehaviorPage';
 import { SkillsPage } from '@/components/sections/skills/SkillsPage';
-import { ProjectsSidebar } from '@/components/sections/projects/ProjectsSidebar';
 import { ProjectsPage } from '@/components/sections/projects/ProjectsPage';
 import { RemoteInstancesPage } from '@/components/sections/remote-instances/RemoteInstancesPage';
 import { ProvidersPage } from '@/components/sections/providers/ProvidersPage';
@@ -471,8 +470,6 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ onClose, forceMobile
 
   const renderPageSidebar = React.useCallback((slug: SettingsPageSlug, opts: { onItemSelect?: () => void }) => {
     switch (slug) {
-      case 'projects':
-        return <ProjectsSidebar onItemSelect={opts.onItemSelect} />;
       case 'magic-prompts':
         return <MagicPromptsSidebar onItemSelect={opts.onItemSelect} />;
       default:

--- a/packages/ui/src/lib/settings/metadata.ts
+++ b/packages/ui/src/lib/settings/metadata.ts
@@ -62,7 +62,7 @@ export const SETTINGS_PAGE_METADATA: readonly SettingsPageMeta[] = [
     slug: 'projects',
     title: 'Projects',
     group: 'projects',
-    kind: 'split',
+    kind: 'single',
     keywords: ['project', 'projects', 'worktree', 'worktrees', 'repo', 'repository', 'directory'],
   },
   {


### PR DESCRIPTION
## Intent

Consolidate UI tweaks that remove visual noise and bring tablet/desktop consistency:

- Remove unnecessary right border on the desktop left sidebar (`Sidebar` + vestigial `className` in `MainLayout`).
- Redesign **Projects** settings to match `Providers`/`Skills`/`Snippets` (card grid browse + detail with back navigation, search, empty states) instead of the nested `kind=split` sidebar.
- Remove `Manage` footer (+ icon) from `ProjectCard` cards (cards are now purely navigational).
- Align tablet collapsed-sidebar burger with right-rail header icons: burger was centered in full header height (including Android `safe-area-top`) while header content was below the inset. Make burger sit below the inset and match the context-usage chart button size (`size-10 rounded-full`, `18px` icon).
- Increase tablet user-message bottom padding and chat scroll bottom spacer so tablet matches desktop visual density and last message isn't under the nav bar / safe area.

## Non-goals

- No header bottom border removal (reverted per request — header keeps `border-b`/`border-t`).
- No changes to message content, session sync, Pi daemon, or persisted project model.
- No new dependencies or build config changes.

## Affected surfaces

- `packages/ui/src/components/layout/Sidebar.tsx` — removes `border-r`.
- `packages/ui/src/components/layout/MainLayout.tsx` — removes vestigial `border-border` prop; restores header `border-t` (undo).
- `packages/ui/src/components/layout/TitlebarLeftControls.tsx` — tablet toggle size/position + safe-area handling.
- `packages/ui/src/components/sections/projects/ProjectCard.tsx` *(new)* + `ProjectsPage.tsx` (grid/detail), `metadata.ts` (`kind=single`), `SettingsView.tsx` (drop split handling).
- `packages/ui/src/components/chat/ChatMessage.tsx`, `ChatContainer.tsx` — tablet/desktop padding + safe-area spacer; affects `packages/ui`, `packages/web`, `packages/electron` (shared UI) but only CSS/spacing, no runtime contract change.
- All runtimes (web, desktop, hosted-mobile, Capacitor) share the same `packages/ui` contracts; tablet fix is intentional and visible via `useTabletLayout` / `--oc-safe-area-top`.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` — read nearest `DOCUMENTATION.md`/`README`, load matching skills, keep changes minimal, no secrets | All are UI/component changes | Read `packages/ui/README`, `packages/ui/src/sync/DOCUMENTATION.md` (not touched), kept diffs scoped, no secrets |
| `pichamber-change-discipline` — smallest complete change, classify risk, validate | Multiple UI tweaks затрагивают shared contracts | Local implementation risk (private component styling) + module contract (exported `ProjectCard`), validated with `type-check:ui` |
| `theme-system` — use semantic tokens, shared primitives, Icon sprite, animation rules | Styling/colors/buttons/icons touched | Used `border-border`, `bg-[var(--surface-elevated)]`, `focus-visible:ring`, `Icon` sprite (`folder`, `layout-left`, `settings-3` removed), `Button` variants; no hardcoded hex |
| `settings-ui-patterns` | Settings UI/pages modified (`Projects`) | Followed `SettingsPageLayout`/`SettingsSection`, headerEnd search pattern from `Providers`/`Skills`, `kind=single` metadata |

## Validation

| Check | Result |
|---|---|
| `bunx --package typescript tsc --noEmit --project packages/ui/tsconfig.json` | `exit:0` (no errors) — verified after each tweak; repo's `bun run type-check:ui` uses bundled TS 4.7 which misparses `verbatimModuleSyntax`, hence checked with correct `typescript@5.9` |
| `bun run --cwd packages/ui test` baseline | `1138 pass / 72 fail` (pre-existing, stash on clean `main` gives same 72) — no new failures introduced (sidebar/header only removed borders, projects card is pure presentational) |
| `git diff HEAD~4..HEAD --stat` | 9 files, 261 insertions(+), 41 deletions(-) — 4 commits as requested |

Not verified: full `bun run build`, `lint`, `dead-code`, manual device testing (no WSL Android device attached). Static checks alone do not prove runtime/relay/platform correctness per `AGENTS.md`.

## Visual evidence

- Sidebar: before had `border-r border-border` on desktop left sidebar; after blends with content (no vertical line). Mobile drawer unaffected (`bg-sidebar` only).
- Projects settings: before split `ProjectsSidebar` + detail with `Manage` footer on cards; after single-page card grid (3 cols @3xl) with search + `Add project` dashed card, detail shows back arrow + folder + path + `ProjectSettingsPanel` (no Manage footer).
- Tablet header (collapsed): before burger `h-9 rounded-md h-5` centered in `var(--oc-header-height)` (50% of total including safe-area-top) vs right rail `size-10` chart `18px` below inset (misaligned). After burger `size-10 rounded-full size-[18px]`, `top:var(--oc-safe-area-top)` + `height:calc(header-safe)`, vertically aligned with right rail header icons.
- Chat: user bubble `pb-0`/`py-3` → `pb-2` outer + `pb-4` inner for non-mobile, plus scroll spacer `+ var(--oc-safe-area-bottom)` — last tablet user message now has ~12px extra bottom gap, matching desktop density.

Screenshots not attached in this environment; diff is CSS-only and can be verified via `bun run dev:web:hmr` on `5180` vs `10000` prod.

## Risks and failure behavior

- **Sidebar border removal** is visual only; no layout shift (width unchanged, only border). No persisted state.
- **Projects redesign** preserves `settingsProjectsSelectedId` store and `updateProjectMeta`; empty→browse, stale selection cleared via `useEffect`. `kind=single` changes `SettingsView` mobile `page-sidebar` → `page-content` flow for `projects` only; `magic-prompts` (also `split` but hidden) unaffected. No data loss.
- **Tablet header** uses `var(--oc-safe-area-top,0px)` fallback — desktop/no-inset devices unchanged (`top:0`, `height:header`). No JS logic change, only style.
- **Chat padding** is additive (`pb-2`/`pb-4` + safe-area spacer) — no removal of existing spacing, safe fallback `0px`. No performance impact (no new observers).
- Rollback: revert 4 commits in reverse order; each is isolated by surface.
