### PR TITLE
Fix remote server updates returning 404

### DIFF
--- a/packages/ui/src/components/ui/UpdateDialog.tsx
+++ b/packages/ui/src/components/ui/UpdateDialog.tsx
@@ -121,7 +121,7 @@ const WEB_UPDATE_MAX_WAIT_MS = 10 * 60 * 1000;
 
 async function installWebUpdate(): Promise<InstallWebUpdateResult> {
   try {
-    const response = await runtimeFetch('/api/pichamber/update-install', {
+    const response = await runtimeFetch('/api/pi/update-install', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
     });

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -22,7 +22,7 @@ Use `--api-only` for a host intended to be paired from a PiChamber desktop or mo
 ## Runtime contract
 
 - Pi session state and actions are served only through `/api/pi/*`.
-- PiChamber-owned UI settings, custom themes, and update metadata use `/api/pi/ui-settings`, `/api/pi/themes`, and `/api/pi/update-check`; removed `/api/config/*` and `/api/pichamber/*` aliases are not required.
+- PiChamber-owned UI settings, custom themes, and updates use `/api/pi/ui-settings`, `/api/pi/themes`, `/api/pi/update-check`, and `/api/pi/update-install`; removed `/api/config/*` and `/api/pichamber/*` aliases are not required.
 - Final-only speech-to-text uses authenticated `/api/stt/*` routes and `/api/stt/ws`. Local model inference runs in a forked worker, while remote provider credentials remain in server configuration.
 - Browser and paired clients authenticate with UI sessions or scoped client credentials.
 - `connect-url` creates a one-time pairing link; credentials are not written to URLs or logs.

--- a/packages/web/server/lib/package-manager.js
+++ b/packages/web/server/lib/package-manager.js
@@ -1,4 +1,4 @@
-import { spawnSync } from 'child_process';
+import { spawn, spawnSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -775,6 +775,37 @@ export async function checkForUpdates(options = {}) {
 /**
  * Execute the update (used by CLI)
  */
+export function launchUpdateCommand(options = {}) {
+  const isContainer = options.isContainer ?? (fs.existsSync('/.dockerenv') || Boolean(process.env.CONTAINER) || process.env.container === 'docker');
+  const isSystemd = options.isSystemd ?? Boolean(process.env.INVOCATION_ID || process.env.PICHAMBER_SYSTEMD_UNIT);
+  if (isContainer) {
+    return {
+      success: false,
+      error: 'Docker deployments must be updated by deploying a new container image. Run: pichamber update',
+    };
+  }
+  if (isSystemd) {
+    return {
+      success: false,
+      error: 'This PiChamber server runs as a systemd service. Run from a terminal: pichamber update',
+    };
+  }
+
+  const cliPath = path.resolve(__dirname, '..', '..', 'bin', 'cli.js');
+  try {
+    const child = (options.spawnProcess || spawn)(process.execPath, [cliPath, 'update', '--quiet'], {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+    child.once?.('error', () => {});
+    child.unref();
+    return { success: true };
+  } catch {
+    return { success: false, error: 'Could not start the updater. Run: pichamber update' };
+  }
+}
+
 export function executeUpdate(pm = detectPackageManager(), options = {}) {
   const command = getUpdateCommand(pm);
   if (!options?.silent) {

--- a/packages/web/server/lib/package-manager.test.js
+++ b/packages/web/server/lib/package-manager.test.js
@@ -11,6 +11,7 @@ const {
   detectPackageManager,
   executeUpdate,
   getCurrentVersion,
+  launchUpdateCommand,
   resolveTrustedUpdatePackageManager,
 } = await import('./package-manager.js');
 
@@ -360,6 +361,26 @@ describe('getCurrentVersion', () => {
   it('is exported for the CLI update command', () => {
     expect(typeof getCurrentVersion).toBe('function');
     expect(getCurrentVersion()).toMatch(/^\d+\.\d+\.\d+|unknown$/);
+  });
+});
+
+describe('launchUpdateCommand', () => {
+  it('starts the CLI updater detached so the live server can respond before shutdown', () => {
+    const unref = vi.fn();
+    const spawnProcess = vi.fn(() => ({ unref }));
+
+    expect(launchUpdateCommand({ isContainer: false, isSystemd: false, spawnProcess })).toEqual({ success: true });
+    expect(spawnProcess).toHaveBeenCalledWith(
+      process.execPath,
+      [expect.stringMatching(/bin[\\/]cli\.js$/), 'update', '--quiet'],
+      { detached: true, stdio: 'ignore', windowsHide: true },
+    );
+    expect(unref).toHaveBeenCalledOnce();
+  });
+
+  it('refuses deployment types that the CLI cannot safely replace in-process', () => {
+    expect(launchUpdateCommand({ isContainer: true, isSystemd: false }).success).toBe(false);
+    expect(launchUpdateCommand({ isContainer: false, isSystemd: true }).success).toBe(false);
   });
 });
 

--- a/packages/web/server/lib/pi/routes.js
+++ b/packages/web/server/lib/pi/routes.js
@@ -5,7 +5,11 @@
 
 import { createPiArchiveStore } from './archive-store.js';
 import { createPiAttachmentStore } from './attachment-store.js';
-import { checkForUpdates } from '../package-manager.js';
+import {
+  checkForUpdates,
+  launchUpdateCommand,
+  resolveTrustedUpdatePackageManager,
+} from '../package-manager.js';
 import { listPiCustomThemes } from './custom-themes.js';
 import { createPiSettingsStore } from './settings-store.js';
 import { isPiThinkingLevel } from './thinking-levels.js';
@@ -726,6 +730,8 @@ export const registerPiRuntimeRoutes = (app, {
   uiSettingsStore = createPiUiSettingsStore(),
   listCustomThemes = listPiCustomThemes,
   updateChecker = checkForUpdates,
+  updateLauncher = launchUpdateCommand,
+  resolveUpdatePackageManager = resolveTrustedUpdatePackageManager,
   smallModelGenerator = async (input) => (await import('./small-model-generation.js')).generateWithSmallModel(input),
   eventHeartbeatMs = 15_000,
 }) => {
@@ -775,10 +781,29 @@ export const registerPiRuntimeRoutes = (app, {
         currentVersion: typeof req.query.currentVersion === 'string' ? req.query.currentVersion : undefined,
         appType: typeof req.query.appType === 'string' ? req.query.appType : undefined,
         platform: typeof req.query.platform === 'string' ? req.query.platform : undefined,
+        instanceMode: typeof req.query.instanceMode === 'string' ? req.query.instanceMode : undefined,
       }));
     } catch {
       res.status(503).json({ error: 'Update check unavailable' });
     }
+  });
+
+  app.post('/api/pi/update-install', (_req, res) => {
+    const packageManager = resolveUpdatePackageManager();
+    if (!packageManager) {
+      res.status(409).json({
+        success: false,
+        error: 'This PiChamber copy is not a supported global package-manager install. Run: pichamber update',
+      });
+      return;
+    }
+
+    const result = updateLauncher();
+    if (!result.success) {
+      res.status(409).json({ success: false, error: result.error });
+      return;
+    }
+    res.json({ success: true, autoRestart: true });
   });
 
   app.get('/api/pi/runtime', async (_req, res) => {

--- a/packages/web/server/lib/pi/routes.test.js
+++ b/packages/web/server/lib/pi/routes.test.js
@@ -84,6 +84,8 @@ describe('Pi runtime route', () => {
       },
       listCustomThemes: async () => [{ metadata: { id: 'custom' } }],
       updateChecker: async () => ({ available: false, currentVersion: '1.0.0' }),
+      resolveUpdatePackageManager: () => 'npm',
+      updateLauncher: () => ({ success: true }),
     });
     server = await listen(app);
     const base = `http://127.0.0.1:${server.address().port}`;
@@ -98,6 +100,26 @@ describe('Pi runtime route', () => {
     })).json()).resolves.toEqual({ exists: true, version: 1, foldersMap: {}, collapsedFolderIds: [], updatedAt: 1 });
     await expect((await fetch(`${base}/api/pi/themes`)).json()).resolves.toEqual({ themes: [{ metadata: { id: 'custom' } }] });
     await expect((await fetch(`${base}/api/pi/update-check`)).json()).resolves.toEqual({ available: false, currentVersion: '1.0.0' });
+    const installResponse = await fetch(`${base}/api/pi/update-install`, { method: 'POST' });
+    expect(installResponse.status).toBe(200);
+    await expect(installResponse.json()).resolves.toEqual({ success: true, autoRestart: true });
+  });
+
+  it('rejects web updates when the current install is not owned by a trusted package manager', async () => {
+    const app = express();
+    registerPiRuntimeRoutes(app, {
+      getPiSessionDaemonRuntime: () => null,
+      resolveUpdatePackageManager: () => null,
+      updateLauncher: () => { throw new Error('must not run'); },
+    });
+    server = await listen(app);
+
+    const response = await fetch(`http://127.0.0.1:${server.address().port}/api/pi/update-install`, { method: 'POST' });
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      success: false,
+      error: 'This PiChamber copy is not a supported global package-manager install. Run: pichamber update',
+    });
   });
 
   it('generates a task name with the configured small model without exposing model details', async () => {


### PR DESCRIPTION
## Intent

Fix the remote server update button, which posted to an unregistered `/api/pichamber/update-install` endpoint and returned 404. Remote web updates now use authenticated `/api/pi/update-install`, launch the existing CLI updater outside the live server process, restart through the established CLI lifecycle, and pass `instanceMode` through update checks.

## Non-goals

This does not add in-app replacement for Docker containers or systemd-hosted servers. Those deployment types receive an actionable error and must use their existing terminal or image deployment flow.

## Affected surfaces

- `packages/ui`: the web update dialog now calls the canonical PiChamber update route.
- `packages/web`: adds the authenticated update-install route and detached updater launcher.
- Remote web and paired desktop/mobile clients targeting a remote server use this route.
- Electron's native auto-updater is unchanged.
- No persisted data or schema changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` and `pichamber-change-discipline` | Executable source and an external HTTP contract changed. | Kept the change in the owning web/runtime modules, added route and failure tests, updated the package README, and ran focused plus workspace validation. |
| `ui-api-decoupling` and implementation map | Shared UI runtime fetch and a server API route changed. | Uses `runtimeFetch`, keeps the route under authenticated `/api/pi/*`, resolves runtime state at request time, and tests the route contract. |
| `clack-cli-patterns` | The server launches the existing CLI updater with `--quiet`. | Reuses the established command and its policy checks rather than duplicating update and restart orchestration. Quiet mode does not bypass package ownership or deployment checks. |
| `packages/web/README.md` | It documents the web runtime HTTP contract. | Added `/api/pi/update-install` to the canonical update routes and did not restore removed `/api/pichamber/*` aliases. |

## Validation

| Check | Result |
|---|---|
| `bunx vitest run packages/web/server/lib/pi/routes.test.js packages/web/server/lib/package-manager.test.js` | Passed, 42 tests. |
| `bun run --cwd packages/web type-check` | Passed. |
| `bun run --cwd packages/web lint` | Passed. |
| `bun run --cwd packages/ui type-check` | Passed. |
| `bun run --cwd packages/ui lint` | Passed. |
| `bun run --cwd packages/web build` | Passed, including service worker build. |
| `bun run test` | Passed, including 1,764 UI tests and all web/Electron suites. |
| Real global package replacement | Not run because it would replace the development host's installed PiChamber package. Detached invocation, route behavior, refusal paths, and restart handoff are covered with injected tests. |

## Visual evidence

No screenshot is useful for this change. The dialog layout and copy are unchanged; the failing network operation changes from an immediate 404 to updater progress, or an existing error area containing deployment-specific guidance. The HTTP behavior is covered by route tests.

## Risks and failure behavior

- The route remains behind the existing `/api` authentication middleware.
- Only package-manager installations whose ownership can be proven may update.
- The live server does not block on package installation. It launches `pichamber update --quiet` detached, allowing the response to reach the client before the CLI shuts down and restarts the instance.
- Docker and systemd deployments are rejected before launch with terminal/image guidance rather than being partially modified.
- If launch fails synchronously, the route returns an actionable error. If the detached updater later fails, the UI's existing bounded polling ends with its terminal-update fallback.
- No data migration, rollback, or cleanup is required.
