### PR TITLE
feat(ui): add copy button next to composer branch name

### DIFF
--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -1596,6 +1596,7 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({ onOpenSettings, scrollTo
                     >
                     <MobileDraftTargetTriggers
                         selectedProject={selectedDraftProject}
+                        selectedBranchName={selectedBranchName}
                         selectedBranchLabel={selectedDraftBranchLabel}
                         branchInteractive={newSessionDraftOpen}
                         showBranchSelector={shouldShowDraftBranchSelector}

--- a/packages/ui/src/components/chat/composer/ui/DraftTargetSelectors.tsx
+++ b/packages/ui/src/components/chat/composer/ui/DraftTargetSelectors.tsx
@@ -4,6 +4,9 @@ import { Icon } from '@/components/icon/Icon';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { MobileOverlayPanel } from '@/components/ui/MobileOverlayPanel';
+import { toast } from '@/components/ui';
+import { useTransientValue } from '@/hooks/useTransientValue';
+import { copyTextToClipboard } from '@/lib/clipboard';
 import {
     Select,
     SelectContent,
@@ -116,6 +119,41 @@ const BranchValue = ({ label, startFrom = false }: { label: string | null; start
     );
 };
 
+function BranchCopyButton({ branchName }: { branchName: string | null }) {
+    const { value: copied, show } = useTransientValue(false, 2000);
+    const handleCopy = React.useCallback(async (event: React.MouseEvent<HTMLButtonElement>) => {
+        event.stopPropagation();
+        event.preventDefault();
+        if (!branchName) return;
+        const result = await copyTextToClipboard(branchName);
+        if (result.ok) {
+            show(true);
+        } else {
+            toast.error('Failed to copy');
+        }
+    }, [branchName, show]);
+    if (!branchName) return null;
+    return (
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-6 w-6 shrink-0 text-muted-foreground hover:text-foreground"
+                    aria-label="Copy branch name"
+                    onClick={(event) => { void handleCopy(event); }}
+                >
+                    {copied
+                        ? <Icon name="check" className="size-3.5 text-[color:var(--status-success)]" />
+                        : <Icon name="file-copy" className="size-3.5" />}
+                </Button>
+            </TooltipTrigger>
+            <TooltipContent sideOffset={6}>{copied ? 'Copied' : 'Copy branch name'}</TooltipContent>
+        </Tooltip>
+    );
+}
+
 /** Desktop project selector and branch target. Existing sessions render a read-only branch label. */
 export function DraftTargetSelectors(props: DraftTargetProps) {
     const {
@@ -184,8 +222,9 @@ export function DraftTargetSelectors(props: DraftTargetProps) {
                         </SelectContent>
                     </Select>
                 ) : showBranchSelector ? (
-                    <div className="inline-flex h-7 min-w-0 max-w-[20rem] items-center px-1.5 typography-micro text-muted-foreground">
+                    <div className="inline-flex h-7 min-w-0 max-w-[20rem] items-center gap-0.5 px-1.5 typography-micro text-muted-foreground">
                         <BranchValue label={selectedBranchLabel} startFrom={worktreeMode} />
+                        <BranchCopyButton branchName={selectedBranchName} />
                     </div>
                 ) : null}
 
@@ -202,11 +241,12 @@ export function DraftTargetSelectors(props: DraftTargetProps) {
 export function MobileDraftTargetTriggers(
     props: Pick<
         DraftTargetProps,
-        'selectedProject' | 'selectedBranchLabel' | 'branchInteractive' | 'showBranchSelector' | 'showProjectSelector' | 'showWorktreeSelector' | 'worktreeMode' | 'onWorktreeModeChange' | 'endAccessory' | 'theme'
+        'selectedProject' | 'selectedBranchName' | 'selectedBranchLabel' | 'branchInteractive' | 'showBranchSelector' | 'showProjectSelector' | 'showWorktreeSelector' | 'worktreeMode' | 'onWorktreeModeChange' | 'endAccessory' | 'theme'
     > & { onOpenPicker: (picker: 'project' | 'branch') => void },
 ) {
     const {
         selectedProject,
+        selectedBranchName,
         selectedBranchLabel,
         branchInteractive,
         showBranchSelector,
@@ -265,6 +305,7 @@ export function MobileDraftTargetTriggers(
                         <Icon name="git-branch" className="h-3 w-3 shrink-0" />
                         {worktreeMode && displayBranchLabel ? <span className="shrink-0 text-muted-foreground/70">from</span> : null}
                         <span className="truncate">{displayBranchLabel ?? 'Branch'}</span>
+                        <BranchCopyButton branchName={selectedBranchName} />
                     </div>
                 ) : null}
             </div>


### PR DESCRIPTION
## Intent

Adds a copy button next to the read-only branch name on the composer target row (existing sessions). Clicking it copies the full branch name via the shared clipboard helper, shows a transient check icon on success, and toasts `Failed to copy` on denial. This solves copying long/truncated branch names without manual selection.

## Non-goals

- New-session draft branch picker is intentionally unchanged (no copy control inside the branch `Select` or mobile picker sheets).
- No change to clipboard helpers, branch targeting/mutation, checkout, worktree, or persisted draft state.
- No documentation ownership/contract change.

## Affected surfaces

- `packages/ui/src/components/chat/composer/ui/DraftTargetSelectors.tsx`: new private `BranchCopyButton` rendered in the read-only branch row for `DraftTargetSelectors` (desktop) and `MobileDraftTargetTriggers` (mobile).
- `packages/ui/src/components/chat/ChatInput.tsx`: passes `selectedBranchName` through to `MobileDraftTargetTriggers`.
- Runtimes: web, desktop, hosted mobile, and Capacitor mobile all render this shared UI path, so all gain the button with no runtime-specific branching. No Electron, relay, CLI, settings, or persisted/external contract impact.
- User-visible states: composer target row for existing sessions gains a 24px ghost icon button after the branch label; hidden when there is no branch name to copy (e.g. detached HEAD, where the label reads `Detached HEAD`).

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` instruction order + docs discovery | Source change in the composer module | Read nearest `packages/ui/src/components/chat/composer/DOCUMENTATION.md` first; confirmed existing sessions render a read-only branch label with no branch list, and preserved that invariant |
| `pichamber-change-discipline` (local implementation) | Small UI behavior change in one package | Smallest complete change: private button component, no new deps/exports/files, existing callers traced (`ChatInput` only other consumer), no drive-by refactors |
| `theme-system` + `references/tokens-and-examples.md` + `references/icons.md` | New button + icon + feedback color | Shared `Button` (`ghost`, `icon`, `h-6 w-6` dense override per existing precedent), sprite `Icon` (`file-copy`/`check`, both already in sprite so no regeneration), hover only on the interactive button, `status-success` only for the copied feedback check |
| `locale-ui-patterns` | New accessible/tooltip copy | `aria-label="Copy branch name"`, tooltip `Copy branch name` / `Copied`, sentence case, direct copy co-located in JSX |

## Validation

| Check | Result |
|---|---|
| `bun run --cwd packages/ui type-check` (`tsc --noEmit`) on PR HEAD | Passed, no output |
| `bun run --cwd packages/ui lint` (eslint, `packages/ui/src/**`) on PR HEAD | Passed, no output |
| `bun test --isolate packages/ui/src/components/chat/composer/state/useDraftTarget.test.ts packages/ui/src/components/chat/composer/state/draftTargetBranches.test.ts` | 9 pass, 0 fail |
| `bun run dead-code` (knip, non-blocking) | Ran; no new entries for touched files (`ProjectLabel` unused-export entry is pre-existing) |
| Manual/runtime verification | Not performed: no DOM test env for this UI and no device/browser run; rendering, focus, tooltip, and clipboard behavior beyond unit-covered state not verified |

## Visual evidence

No before/after screenshots or recordings captured for this PR. The rendered change is a 24px ghost `file-copy` icon button immediately after the read-only branch label in the composer target row (desktop and mobile), switching to a success-colored `check` for 2s after a successful copy. Requesting an evidence waiver to merge without screenshots; happy to attach them on follow-up if the reviewer requires.

## Risks and failure behavior

- Clipboard denial/unavailability: `copyTextToClipboard` falls back to `execCommand`; if both fail, the label is unchanged and a `Failed to copy` toast surfaces the failure. No optimistic state to roll back.
- Copies the full `selectedBranchName`, so truncated display labels still copy correctly. Nothing is written to Git, drafts, or persistence.
- Detached HEAD (`selectedBranchName == null`): button is hidden; label behavior unchanged.
- No secrets logged or persisted; no measurable perf impact (one small button on an existing row, `transform`/`opacity`-only feedback via icon swap).
- Cross-runtime: shared component, no per-runtime branching; Electron/relay/CLI/mobile-shell behavior unaffected.
