### PR TITLE
feat(ui): reintroduce running-tool shimmer scoped to live verbs

### DIFF
--- a/packages/ui/src/components/chat/message/parts/MinDurationShineText.tsx
+++ b/packages/ui/src/components/chat/message/parts/MinDurationShineText.tsx
@@ -79,10 +79,31 @@ export const MinDurationShineText: React.FC<MinDurationShineTextProps> = ({
         };
     }, [active, minDurationMs, isBusy]);
 
+    // While busy the shimmer class owns the text fill (transparent +
+    // background-clip:text gradient, same as the AgentThinkingLoader label).
+    // The caller's inline title color is dropped so it cannot cover the
+    // gradient — and so the reduced-motion static fallback stays visible.
+    // Settled rows keep their inline dimmed color untouched.
+    const busyStyle = React.useMemo(() => {
+        if (!isBusy) {
+            return style;
+        }
+        if (!style) {
+            return undefined;
+        }
+        const rest = { ...style };
+        delete rest.color;
+        return rest;
+    }, [isBusy, style]);
+
     return (
         <span
-            className={cn('transition-opacity duration-200', isBusy && 'opacity-70', className)}
-            style={style}
+            // Running verbs shimmer exactly like the agent working label
+            // (`oc-shimmer-verb`). Applied in render so the first paint
+            // already carries it (no flash-visible frame); the busy cap
+            // above bounds the infinite sweep like the single status line.
+            className={cn('transition-opacity duration-200', isBusy && 'oc-shimmer-verb', className)}
+            style={busyStyle}
             title={title}
         >
             {children}

--- a/packages/ui/src/components/chat/message/parts/toolRevealAnimation.test.tsx
+++ b/packages/ui/src/components/chat/message/parts/toolRevealAnimation.test.tsx
@@ -48,16 +48,42 @@ describe('tool arrival animation', () => {
     expect(idle).not.toContain('oc-step-in');
   });
 
-  test('running verbs use a bounded opacity transition, settled verbs stay static', () => {
+  test('running verbs shimmer like the working animation, settled verbs stay static', () => {
     const running = renderToStaticMarkup(
       <MinDurationShineText active={true}>Read</MinDurationShineText>,
     );
-    expect(running).toContain('opacity-70');
-    expect(running).not.toContain('oc-shimmer-verb');
+    expect(running).toContain('oc-shimmer-verb');
+    expect(running).not.toContain('opacity-70');
+    // CSS owns the transparent fill — no inline transparent that could
+    // outlive the gradient (reduced-motion) or flash invisible on remount.
+    expect(running).not.toContain('color:transparent');
     const settled = renderToStaticMarkup(
       <MinDurationShineText active={false}>Read</MinDurationShineText>,
     );
     expect(settled).not.toContain('oc-shimmer-verb');
+  });
+
+  test('remount continuity: same running tool keeps the shimmer without flashing invisible', () => {
+    const runningProps = {
+      active: true as const,
+      style: { color: 'color-mix(in srgb, var(--tools-title) 72%, var(--tools-description))' } as React.CSSProperties,
+    };
+    const first = renderToStaticMarkup(
+      <MinDurationShineText {...runningProps}>Read</MinDurationShineText>,
+    );
+    const second = renderToStaticMarkup(
+      <MinDurationShineText {...runningProps}>Read</MinDurationShineText>,
+    );
+    // Both paints carry the shimmer class in render (no effect-delayed
+    // flash), drop the caller's inline title color so the gradient shows,
+    // and never inline transparent text that could stick without the gradient.
+    for (const markup of [first, second]) {
+      expect(markup).toContain('oc-shimmer-verb');
+      expect(markup).not.toContain('color-mix');
+      expect(markup).not.toContain('color:transparent');
+      expect(markup).not.toContain('opacity-70');
+    }
+    expect(second).toBe(first);
   });
 });
 
@@ -69,14 +95,14 @@ describe('thinking block arrival', () => {
     isStreaming,
   } as const);
 
-  test('live thinking fades in and dims its title', () => {
+  test('live thinking fades in and shimmers its title', () => {
     const markup = renderToStaticMarkup(
       <ReasoningTimelineBlock {...block(true)} />,
     );
     expect(markup).toContain('oc-step-in');
-    expect(markup).toContain('opacity-70');
-    expect(markup).toContain('color:color-mix(in srgb, var(--tools-title) 72%, var(--tools-description))');
-    expect(markup).not.toContain('oc-shimmer-verb');
+    expect(markup).toContain('oc-shimmer-verb');
+    expect(markup).not.toContain('opacity-70');
+    expect(markup).not.toContain('color:transparent');
   });
 
   test('settled thinking mounts statically with a dimmed title', () => {

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -1749,6 +1749,32 @@ input[aria-label="Terminal input"] {
   animation: oc-step-in 180ms ease-out both;
 }
 
+/* Running tool verb shimmer: the SAME treatment as the agent working
+   animation (`AgentThinkingLoader` label) — gradient sweep via the accepted
+   `shimmer-text` keyframes with semantic tokens, so all "working" shimmer
+   reads as one signal. Scoped to running verbs (few at a time) and capped by
+   `MinDurationShineText`'s busy cap, like the single status line.
+   CSS owns `color: transparent` (callers strip their inline title color
+   while busy) so the reduced-motion fallback below can restore a visible
+   static dim — an inline transparent would beat it and leave invisible text. */
+.oc-shimmer-verb {
+  background-image: linear-gradient(90deg, var(--muted-foreground) 35%, var(--foreground) 50%, var(--muted-foreground) 65%);
+  background-size: 200% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: shimmer-text 1.4s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  /* Reduced motion falls back to the static dimmed verb. */
+  .oc-shimmer-verb {
+    animation: none;
+    background-image: none;
+    color: var(--tools-description);
+  }
+}
+
 @keyframes border-glow-pulse {
   0%, 100% {
     border-color: var(--interactive-border);


### PR DESCRIPTION
## Intent

Reintroduce the running-tool shimmer that 85a0bc9d removed, scoped strictly to running tool verbs and streaming thinking titles. Running verbs sweep with the same gradient treatment as the AgentThinkingLoader working label; settled rows stay static dimmed.

Why it was removed (cause): 85a0bc9d stabilized streaming footers and tool states. The old shimmer set inline `color: transparent` in MinDurationShineText, which beat the reduced-motion CSS fallback (`color: var(--tools-description)` without `!important`) — leaving invisible text when the sweep was disabled/unsupported — and its infinite `background-position` sweep restarted on every streaming remount, churning the footers/autoscroll that commit was fixing. It also overrode the new stable color-mix title dim.

Safe return: CSS now owns the transparent fill. While busy, MinDurationShineText strips the caller's inline title color (no inline transparent leaks into reduced-motion), applies `oc-shimmer-verb` in render so first paint already carries it, and restores the inline dim when settled or after the 5min busy cap. Same gradient stops, same `shimmer-text` keyframes, same semantic tokens as AgentThinkingLoader — no new animation.

## Non-goals

- No changes to AgentThinkingLoader visuals, WorkingPlaceholder queue, sync/streaming batching, or turn-working derivation.
- No footer, ToolRevealOnMount, or lifecycle behavior changes from 85a0bc9d.
- No new animation, tokens, or dependencies.

## Affected surfaces

- packages/ui only: `index.css` (additive `.oc-shimmer-verb` + reduced-motion fallback), `MinDurationShineText.tsx` wiring, `toolRevealAnimation.test.tsx`.
- Runtimes: web, desktop, hosted mobile, Capacitor mobile — shared CSS/class change, no runtime-specific branches.
- User-visible: running tool verbs + streaming thinking titles shimmer; settled rows static dimmed; prefers-reduced-motion static dim.
- No persisted/external contracts.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| pichamber-change-discipline | Source change to shared UI | Smallest scoped diff (3 files), preserved 85a0bc9d footer stabilization, focused + full validation |
| theme-system | Styling/colors/animation | Semantic tokens only (`--muted-foreground`, `--foreground`, `--tools-description`); reused `shimmer-text` keyframes/stops; reduced-motion static fallback; no hex/palette literals |
| diagnosing-bugs | Why-it-broke analysis required | Built loop from existing markup tests, identified inline-transparent vs fallback + remount-restart cause before reintroducing |
| packages/ui DOCUMENTATION + chat message parts DOCUMENTATION.md | Module ownership for tool/header rendering | MinDurationShineText remains the single shimmer owner; callers (ToolPart, StaticToolRow, ReasoningPart) untouched |

## Validation

| Check | Result |
|---|---|
| bun run type-check:ui | PASS |
| bun run lint:ui | PASS (after fixing one unused-var) |
| Focused: bun --cwd packages/ui test --isolate src/components/chat/message/parts/toolRevealAnimation.test.tsx | PASS — 11 pass, 0 fail |
| Full: bun run --cwd packages/ui test | PASS — 2005 pass, 0 fail, 247 files |
| bun run dead-code | PASS (exit 0; only pre-existing type entries, none from this diff) |
| Visual in-app on tool-heavy turn | NOT VERIFIED headlessly — no screenshots; needs running-verb sweep vs settled-static check in app |

## Visual evidence

No screenshots attached — headless worktree run. Needs in-app check: tool-heavy turn running verb must sweep, settled rows static, reduced-motion static.

## Risks and failure behavior

- Reduced-motion/unsupported background-clip:text: fallback restores `--tools-description` dim; no inline transparent to stick. Risk if a future caller passes transparent inline while busy — mitigated by stripping only `color` and letting CSS own the fill.
- Performance: `background-position` sweep is non-composited per theme-system contract; bounded to few concurrent running verbs + busy cap, same as the single AgentThinkingLoader line. Settled rows animate nothing.
- Rollback: revert this commit returns to static opacity/color-mix titles; no persisted state.