### PR TITLE
Fix model picker closing on shortcut repeat

### DIFF
--- a/packages/ui/src/hooks/useKeyboardShortcuts.test.ts
+++ b/packages/ui/src/hooks/useKeyboardShortcuts.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'bun:test';
+
+import { shouldHandleModelSelectorShortcut } from './useKeyboardShortcuts';
+
+const modelSelectorKeydown = (repeat: boolean): KeyboardEvent =>
+  ({
+    key: 'm',
+    code: 'KeyM',
+    ctrlKey: true,
+    metaKey: false,
+    shiftKey: true,
+    altKey: false,
+    repeat,
+  }) as KeyboardEvent;
+
+describe('shouldHandleModelSelectorShortcut', () => {
+  test('accepts the initial model selector shortcut keydown', () => {
+    expect(shouldHandleModelSelectorShortcut(modelSelectorKeydown(false), 'mod+shift+m')).toBe(true);
+  });
+
+  test('rejects auto-repeated model selector shortcut keydowns', () => {
+    expect(shouldHandleModelSelectorShortcut(modelSelectorKeydown(true), 'mod+shift+m')).toBe(false);
+  });
+});

--- a/packages/ui/src/hooks/useKeyboardShortcuts.ts
+++ b/packages/ui/src/hooks/useKeyboardShortcuts.ts
@@ -28,6 +28,12 @@ import { getPiSessionStore } from '@/apps/pi-session-store';
 import { triggerPromptText } from '@/lib/pi/command-triggers';
 import { focusChatInput } from '@/components/chat/composer/editor/dom';
 import type { CommandTrigger } from '@/lib/pi/command-triggers';
+import type { ShortcutCombo } from '@/lib/shortcuts';
+
+export const shouldHandleModelSelectorShortcut = (
+  event: KeyboardEvent,
+  shortcut: ShortcutCombo,
+): boolean => !event.repeat && eventMatchesShortcut(event, shortcut);
 
 /** Run a command trigger through the normal authenticated prompt path. */
 const fireCommandTrigger = (trigger: CommandTrigger): void => {
@@ -452,7 +458,7 @@ export const useKeyboardShortcuts = () => {
       }
 
       // Cmd/Ctrl+Shift+M: Open model selector (same conditions as double-ESC: chat tab, no overlays)
-      if (eventMatchesShortcut(e, combo('open_model_selector'))) {
+      if (shouldHandleModelSelectorShortcut(e, combo('open_model_selector'))) {
         const {
           isSettingsDialogOpen,
           isCommandPaletteOpen,


### PR DESCRIPTION
## Intent

Prevent Ctrl+Shift+M keyboard auto-repeat from immediately closing the model picker and returning focus to the composer. The first keydown still opens the picker, while repeated keydowns from the same physical press are ignored.

## Non-goals

This does not change deliberate second-press toggling, Escape handling, model selection, or the existing composer focus restoration after a legitimate close.

## Affected surfaces

`packages/ui` keyboard shortcut handling used by web and desktop chat. Hosted and Capacitor mobile share the code, but the affected shortcut requires a hardware keyboard. No persisted data, API, runtime bridge, or external contract changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` | Shared UI source and interaction behavior changed. | The change stays in the owning UI hook, preserves close/focus behavior, and includes a focused repeated-event regression test. |
| `pichamber-change-discipline` | Executable source and a test file changed. | The diff is limited to the shortcut guard and test; focused tests, package checks, full tests, build, and dead-code analysis ran. |
| `performance-engineering` | This changes a global keydown event path and handles repeated events. | Auto-repeated events are skipped before store reads or state updates, and the regression test covers initial and repeated keydowns. |
| `CONTRIBUTING.md` | Defines PR and validation requirements. | The PR records intent, scope, checks, evidence limitations, and risk. No nearer package README or relevant module `DOCUMENTATION.md` exists. |

## Validation

| Check | Result |
|---|---|
| `bun test --isolate packages/ui/src/hooks/useKeyboardShortcuts.test.ts` | Passed, 2 tests. The test failed before implementation because the guarded shortcut predicate did not exist, then passed after the fix. |
| `bun run type-check:ui` | Passed. |
| `bun run lint:ui` | Passed. |
| `bun run test` | Passed: web, UI, and Electron suites; UI reported 2,026 passing tests and Electron reported 59 passing tests. |
| `bun run build` | Passed for all workspaces. Vite emitted existing large-chunk warnings. |
| `bun run dead-code` | Completed with the repository's existing non-blocking unused export/type report; no new finding for this change. |
| `git diff --check` | Passed. |

Manual browser interaction was not recorded or verified. The repeated-keydown state transition is covered by the focused automated test.

## Visual evidence

No screenshot applies because this diff changes no rendered markup, styling, labels, or layout. No interaction recording was captured. The observable behavior is the absence of an unintended close when the opening shortcut auto-repeats, covered by the focused test.

## Risks and failure behavior

Low risk. Only auto-repeated Ctrl+Shift+M events are ignored. Initial presses and later non-repeated presses retain the existing toggle behavior. If the guard regressed, the prior intermittent close and composer focus behavior would return; no data loss, compatibility, security, cleanup, or rollback path is involved.

### CI note

The GitHub `checks` job failed on three attempts in the unrelated `packages/web/server/lib/relay/host-client.test.js` integration test, timing out before relay readiness. The same focused relay test passed locally in 291 ms, and the complete local `bun run test` passed before the PR. CI stopped in the web suite before reaching UI tests; the changed UI regression test passed locally.