### PR TITLE
Fix relay integration test socket race

### DIFF
--- a/packages/web/server/lib/relay/host-client.test.js
+++ b/packages/web/server/lib/relay/host-client.test.js
@@ -172,7 +172,6 @@ const runScriptedClient = async ({ relayUrl, serverId, hostEncPubJwk }) => {
   url.searchParams.set('role', 'client');
   url.searchParams.set('serverId', serverId);
   url.searchParams.set('connectionId', connectionId);
-  const ws = new WebSocket(url.toString());
 
   const hostPub = await globalThis.crypto.subtle.importKey(
     'jwk',
@@ -183,6 +182,9 @@ const runScriptedClient = async ({ relayUrl, serverId, hostEncPubJwk }) => {
   );
   const ephemeral = await generateEcdhKeyPair();
   const nonce = generateHandshakeNonce();
+  // Finish async setup before dialing so the loopback socket cannot emit its
+  // one-shot open event before the scripted client attaches its listener.
+  const ws = new WebSocket(url.toString());
 
   let channel = null;
   const responseChunks = [];


### PR DESCRIPTION
## Intent

Fix the relay host-client integration test that timed out in PR #82's CI runs. The scripted client created its loopback WebSocket before awaiting WebCrypto setup and only attached the one-shot `open` listener afterward. Fast socket setup on GitHub runners could emit `open` during those awaits, leaving the client waiting forever without sending its handshake hello.

The test now completes asynchronous cryptographic setup before dialing, then attaches all socket listeners synchronously after construction.

## Non-goals

No production relay transport, protocol, crypto, timeout, or reconnect behavior changes.

## Affected surfaces

Only `packages/web/server/lib/relay/host-client.test.js`. This changes the relay integration test harness, not web, desktop, hosted mobile, or Capacitor runtime behavior. No persisted or external contract changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` | A web relay test changed. | The change stays in the owning relay test and does not modify runtime behavior or unrelated work. |
| `pichamber-change-discipline` | Repository source changed. | The diff removes the test race with the smallest ordering change and validates focused and full suites. |
| `relay-transport` | The failing test exercises the private relay handshake and tunnel. | The real auth, handshake, origin, encrypted framing, and cross-compat paths remain intact; the focused host and cross-compat tests pass. |
| `diagnosing-bugs` | CI reported a repeatable timeout. | The failure state `gotReady=false` was traced to a missed one-shot socket `open` event. Node 22 stress and complete suites verified the corrected ordering. |
| `packages/web/server/lib/relay/DOCUMENTATION.md` and `packages/web/README.md` | They define relay ownership and web validation. | No documented runtime invariant changed, so no documentation update is needed. |

## Validation

| Check | Result |
|---|---|
| Node 22 loop of `host-client.test.js` | Passed 20/20 runs. |
| `bun run --cwd packages/web test -- server/lib/relay/host-client.test.js server/lib/relay/cross-compat.test.js` | Passed, 5 tests. |
| `node --check packages/web/server/lib/relay/host-client.test.js` | Passed. |
| `bun run type-check:web` | Passed. |
| `bun run lint:web` | Passed. |
| `bun run test` | Passed: all web, UI, and Electron unit suites. |
| `bun run build` | Passed for all workspaces; Vite emitted existing large-chunk warnings. |
| `git diff --check` | Passed. |

## Visual evidence

No visual evidence applies. The diff only changes setup ordering inside a headless relay integration test and cannot alter rendered UI.

## Risks and failure behavior

Low risk. Moving socket construction after WebCrypto setup prevents a missed event without weakening assertions or transport gates. If the race returned, the test would again time out with `gotReady=false`; production behavior and user data are unaffected.
