### PR TITLE
fix(sessions): thread owning directory through retention archive/delete

### DIFF
--- a/packages/ui/src/apps/pi-session-retention-directory.test.ts
+++ b/packages/ui/src/apps/pi-session-retention-directory.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from 'bun:test';
+
+import { PiSessionStore } from '@/apps/pi-session-store';
+import { piClient } from '@/lib/pi/client';
+import { initialCatalog, type LiveSessionRecord } from '@/sync/pi-session-catalog';
+
+type StoreInternal = {
+  state: ReturnType<PiSessionStore['getState']>;
+};
+
+const asInternal = (store: PiSessionStore): StoreInternal =>
+  store as unknown as StoreInternal;
+
+const record = (id: string, directory: string): LiveSessionRecord => ({
+  id,
+  directory,
+  parentId: null,
+  title: id,
+  archived: false,
+  createdAt: 1,
+  updatedAt: 2,
+  lifecycle: 'idle',
+  hydrated: false,
+});
+
+const seed = (store: PiSessionStore) => {
+  asInternal(store).state = {
+    ...store.getState(),
+    directory: '/focused',
+    connection: 'ready',
+    sessions: [{ session: { id: 'focused-1', directory: '/focused' } } as never],
+    catalog: {
+      ...initialCatalog(),
+      byId: new Map([
+        ['foreign-1', record('foreign-1', '/other')],
+        ['focused-1', record('focused-1', '/focused')],
+      ]),
+      byDirectory: new Map([
+        ['/other', ['foreign-1']],
+        ['/focused', ['focused-1']],
+      ]),
+      listStatusByDirectory: new Map([
+        ['/other', 'ready'],
+        ['/focused', 'ready'],
+      ]),
+    },
+  };
+};
+
+const stubArchive = (captured: Array<string | undefined>) => {
+  const original = piClient.archiveSession.bind(piClient);
+  piClient.archiveSession = (async (_input, scope) => {
+    captured.push(scope?.directory);
+  }) as typeof piClient.archiveSession;
+  return () => {
+    piClient.archiveSession = original;
+  };
+};
+
+const stubDelete = (captured: Array<string | undefined>) => {
+  const original = piClient.deleteSession.bind(piClient);
+  piClient.deleteSession = (async (_input, scope) => {
+    captured.push(scope?.directory);
+    return true;
+  }) as typeof piClient.deleteSession;
+  return () => {
+    piClient.deleteSession = original;
+  };
+};
+
+describe('retention directory threading', () => {
+  test('archive uses catalog directory for foreign sessions, not focused dir', async () => {
+    const store = new PiSessionStore();
+    const captured: Array<string | undefined> = [];
+    const restore = stubArchive(captured);
+    try {
+      seed(store);
+      await store.archive('foreign-1', true);
+      expect(captured).toEqual(['/other']);
+    } finally {
+      restore();
+      store.dispose();
+    }
+  });
+
+  test('archive prefers explicit directory over catalog', async () => {
+    const store = new PiSessionStore();
+    const captured: Array<string | undefined> = [];
+    const restore = stubArchive(captured);
+    try {
+      seed(store);
+      await store.archive('foreign-1', true, '/explicit');
+      expect(captured).toEqual(['/explicit']);
+    } finally {
+      restore();
+      store.dispose();
+    }
+  });
+
+  test('remove forwards owning directory for foreign sessions', async () => {
+    const store = new PiSessionStore();
+    const captured: Array<string | undefined> = [];
+    const restore = stubDelete(captured);
+    try {
+      seed(store);
+      await store.remove('foreign-1');
+      expect(captured).toEqual(['/other']);
+    } finally {
+      restore();
+      store.dispose();
+    }
+  });
+
+  test('remove prefers explicit directory over catalog', async () => {
+    const store = new PiSessionStore();
+    const captured: Array<string | undefined> = [];
+    const restore = stubDelete(captured);
+    try {
+      seed(store);
+      await store.remove('foreign-1', '/explicit');
+      expect(captured).toEqual(['/explicit']);
+    } finally {
+      restore();
+      store.dispose();
+    }
+  });
+});

--- a/packages/ui/src/apps/pi-session-store.ts
+++ b/packages/ui/src/apps/pi-session-store.ts
@@ -1058,8 +1058,13 @@ export class PiSessionStore {
     if (catalogChanged) topics.push(TOPIC_CATALOG);
     this.emit(topics);
   }
-  async archive(sessionId: string, archived: boolean) {
-    const sessionDir = this.state.sessions.find((item) => item.session.id === sessionId)?.session.directory;
+  private resolveSessionDirectory(sessionId: string, explicitDirectory?: string): string | undefined {
+    return explicitDirectory
+      ?? this.state.catalog.byId.get(sessionId)?.directory
+      ?? this.state.sessions.find((item) => item.session.id === sessionId)?.session.directory;
+  }
+  async archive(sessionId: string, archived: boolean, directory?: string) {
+    const sessionDir = this.resolveSessionDirectory(sessionId, directory);
     await piClient.archiveSession({ sessionId, archived }, this.scope(sessionDir));
     const now = Date.now();
     const nextCatalog = applyArchiveChange(this.state.catalog, sessionId, archived, now);
@@ -1073,9 +1078,10 @@ export class PiSessionStore {
     if (catalogChanged) topics.push(TOPIC_CATALOG);
     this.emit(topics);
   }
-  async remove(sessionId: string) {
+  async remove(sessionId: string, directory?: string) {
     const expected = this.runtimeGeneration;
-    await piClient.deleteSession({ sessionId, ignoreMissing: true }, this.scope());
+    const sessionDir = this.resolveSessionDirectory(sessionId, directory);
+    await piClient.deleteSession({ sessionId, ignoreMissing: true }, sessionDir ? this.scope(sessionDir) : this.scope());
     if (expected !== this.runtimeGeneration) return;
     removeSessionActivityTiming(sessionId);
     removeSessionOrdering(sessionId);

--- a/packages/ui/src/hooks/useSessionAutoCleanup.test.ts
+++ b/packages/ui/src/hooks/useSessionAutoCleanup.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from 'bun:test';
+import type { Session } from '@/lib/chat/types';
+import { buildAutoDeleteCandidates } from './useSessionAutoCleanup';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = 1_700_000_000_000;
+
+const session = (
+  id: string,
+  updated: number | undefined,
+  extra: Partial<Session> = {},
+): Session =>
+  ({
+    id,
+    title: id,
+    time:
+      updated === undefined
+        ? { created: NOW - 40 * DAY_MS }
+        : { created: updated, updated },
+    ...extra,
+  }) as Session;
+
+describe('buildAutoDeleteCandidates', () => {
+  test('returns sessions older than the cutoff', () => {
+    const sessions = [
+      session('old', NOW - 40 * DAY_MS),
+      session('recent', NOW - 1 * DAY_MS),
+      session('old-2', NOW - 31 * DAY_MS),
+      session('old-3', NOW - 32 * DAY_MS),
+      session('old-4', NOW - 33 * DAY_MS),
+      session('old-5', NOW - 34 * DAY_MS),
+      session('old-6', NOW - 35 * DAY_MS),
+    ];
+    const ids = buildAutoDeleteCandidates({
+      sessions,
+      currentSessionId: null,
+      cutoffDays: 30,
+      now: NOW,
+    });
+    // 5 most recent are protected, so only the 2 oldest are eligible.
+    expect(ids).toEqual(['old-6', 'old']);
+  });
+
+  test('protects the current session even when old', () => {
+    const sessions = [
+      session('a', NOW - 40 * DAY_MS),
+      session('b', NOW - 41 * DAY_MS),
+      session('c', NOW - 42 * DAY_MS),
+      session('d', NOW - 43 * DAY_MS),
+      session('e', NOW - 44 * DAY_MS),
+      session('f', NOW - 45 * DAY_MS),
+      session('g', NOW - 46 * DAY_MS),
+    ];
+    const ids = buildAutoDeleteCandidates({
+      sessions,
+      currentSessionId: 'g',
+      cutoffDays: 30,
+      now: NOW,
+    });
+    expect(ids).not.toContain('g');
+    expect(ids).toEqual(['f']);
+  });
+
+  test('skips shared sessions and sessions without timestamps', () => {
+    const sessions = [
+      session('shared', NOW - 60 * DAY_MS, { share: { url: 'https://x' } } as Partial<Session>),
+      session('no-time', NOW - 60 * DAY_MS, { time: {} } as Partial<Session>),
+      session('old-1', NOW - 60 * DAY_MS),
+      session('old-2', NOW - 61 * DAY_MS),
+      session('old-3', NOW - 62 * DAY_MS),
+      session('old-4', NOW - 63 * DAY_MS),
+      session('old-5', NOW - 64 * DAY_MS),
+      session('old-6', NOW - 65 * DAY_MS),
+    ];
+    const ids = buildAutoDeleteCandidates({
+      sessions,
+      currentSessionId: null,
+      cutoffDays: 30,
+      now: NOW,
+    });
+    expect(ids).not.toContain('shared');
+    expect(ids).not.toContain('no-time');
+  });
+
+  test('returns empty for non-positive cutoff', () => {
+    expect(
+      buildAutoDeleteCandidates({ sessions: [session('a', NOW - 99 * DAY_MS)], currentSessionId: null, cutoffDays: 0, now: NOW }),
+    ).toEqual([]);
+  });
+});

--- a/packages/ui/src/hooks/useSessionAutoCleanup.ts
+++ b/packages/ui/src/hooks/useSessionAutoCleanup.ts
@@ -23,7 +23,7 @@ type BuildAutoDeleteCandidatesOptions = {
   now?: number;
 };
 
-const buildAutoDeleteCandidates = ({
+export const buildAutoDeleteCandidates = ({
   sessions,
   currentSessionId,
   cutoffDays,
@@ -158,9 +158,9 @@ export const useSessionAutoCleanup = (enabledOrOptions?: boolean | CleanupOption
 
           try {
             if (sessionRetentionAction === 'archive') {
-              await getPiSessionStore().archive(id, true);
+              await getPiSessionStore().archive(id, true, directory);
             } else {
-              await getPiSessionStore().remove(id);
+              await getPiSessionStore().remove(id, directory);
             }
             completedIds.push(id);
           } catch {

--- a/packages/ui/src/lib/pi/client.test.ts
+++ b/packages/ui/src/lib/pi/client.test.ts
@@ -140,6 +140,23 @@ describe("PiService", () => {
     expect(await client.deleteSession({ sessionId: "s1" })).toBe(true)
   })
 
+  test("deleteSession forwards owning directory as query", async () => {
+    installFetchMock(() => new Response(null, { status: 204 }))
+    const client = new PiService()
+    expect(await client.deleteSession({ sessionId: "s1" }, { directory: "/other" })).toBe(true)
+    expect(recordedCalls()[0].url).toBe("/api/pi/sessions/s1?directory=%2Fother")
+  })
+
+  test("archiveSession sends owning directory in body", async () => {
+    installFetchMock((call) => {
+      expect(call.url).toBe("/api/pi/sessions/s1/archive")
+      expect(JSON.parse(call.init?.body as string)).toEqual({ sessionId: "s1", archived: true, directory: "/other" })
+      return new Response(null, { status: 204 })
+    })
+    const client = new PiService()
+    await client.archiveSession({ sessionId: "s1", archived: true }, { directory: "/other" })
+  })
+
   test("listSessions retries transient 503 DAEMON_UNAVAILABLE and succeeds on second attempt", async () => {
     let attempt = 0;
     installFetchMock(() => {

--- a/packages/ui/src/lib/pi/client.ts
+++ b/packages/ui/src/lib/pi/client.ts
@@ -308,7 +308,11 @@ export class PiService {
     try {
       await jsonRequest<undefined, undefined>(
         `/api/pi/sessions/${encodeURIComponent(input.sessionId)}`,
-        { method: 'DELETE', ...(scope?.runtimeKey ? { runtimeKey: scope.runtimeKey } : {}) },
+        {
+          method: 'DELETE',
+          ...(scope?.directory ? { query: { directory: scope.directory } } : {}),
+          ...(scope?.runtimeKey ? { runtimeKey: scope.runtimeKey } : {}),
+        },
       );
       return true;
     } catch (error) {

--- a/packages/ui/src/sync/DOCUMENTATION.md
+++ b/packages/ui/src/sync/DOCUMENTATION.md
@@ -257,7 +257,7 @@ VS Code does not run the server permission-auto-accept runtime. The extension ho
     - archive
     - delete
     - move to another worktree directory
-   - retention cleanup batch archive/delete
+   - retention cleanup batch archive/delete (threads each session's owning directory via `resolveGlobalSessionDirectory`, the catalog, then the focused slice — never the focused directory alone, so cross-folder cleanup verifies membership against the correct daemon listing)
 
 This keeps cold/global lists responsive without requiring a refetch after every change.
 

--- a/packages/web/server/lib/pi/routes.test.js
+++ b/packages/web/server/lib/pi/routes.test.js
@@ -627,6 +627,45 @@ describe('Pi runtime route', () => {
     }
   });
 
+  it('verifies archive membership against the owning directory', async () => {
+    const calls = [];
+    const runtime = {
+      health: async () => ({ state: 'ready', protocolVersion: 1, capabilities: [] }),
+      request: async (command, payload) => {
+        calls.push({ command, payload });
+        if (command === 'sessions.list') {
+          if (payload?.directory === '/other') {
+            return { sessions: [{ session: { id: 'foreign-1', directory: '/other', createdAt: 1, updatedAt: 2 }, updatedAt: 2 }] };
+          }
+          return { sessions: [{ session: { id: 'focused-1', directory: '/focused', createdAt: 1, updatedAt: 2 }, updatedAt: 2 }] };
+        }
+        return {};
+      },
+    };
+    const archiveSets = [];
+    const app = express();
+    app.use(express.json());
+    registerPiRuntimeRoutes(app, {
+      getPiSessionDaemonRuntime: () => runtime,
+      archiveStore: { read: async () => ({}), set: async (...args) => archiveSets.push(args) },
+    });
+    server = await listen(app);
+    const base = `http://127.0.0.1:${server.address().port}/api/pi/sessions/foreign-1/archive`;
+
+    // Owning directory succeeds and forwards that directory to the daemon list.
+    expect((await fetch(base, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ archived: true, directory: '/other' }) })).status).toBe(204);
+    expect(archiveSets).toEqual([['foreign-1', true]]);
+    expect(calls).toContainEqual({ command: 'sessions.list', payload: { directory: '/other' } });
+
+    // Wrong directory fails membership without writing the sidecar.
+    calls.length = 0;
+    archiveSets.length = 0;
+    const wrong = await fetch(base, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ archived: true, directory: '/focused' }) });
+    expect(wrong.status).not.toBe(204);
+    expect(archiveSets).toEqual([]);
+    expect(calls).toContainEqual({ command: 'sessions.list', payload: { directory: '/focused' } });
+  });
+
   it('projects daemon file parts for image and attachment history instead of failing the session open', async () => {
     const detail = {
       session: { id: 'pi-session-files', directory: '/workspace', createdAt: 1, updatedAt: 2 },


### PR DESCRIPTION
## Intent

Session Retention cleanup (Settings → Session Retention → Run cleanup now / auto-cleanup) silently failed for any session outside the currently focused project. `useSessionAutoCleanup` resolved each candidate's owning directory but discarded it; `PiSessionStore.archive` looked only at the focused folder's `sessions[]` slice and fell back to the focused directory, so the server's per-directory membership check (`sessions.list` with that directory) rejected foreign sessions with `INVALID_SESSION` → `failedIds` / "Failed to archive N" or a silent auto-run no-op. `deleteSession` never forwarded a directory at all.

Behavior change: retention archive/delete now thread each session's owning directory end to end (explicit arg → catalog → focused slice), and `DELETE /api/pi/sessions/:id` carries `?directory=` when known. Cross-folder archive and delete now verify against the correct daemon listing.

## Non-goals

- No server schema/validation change for `settings.json` retention keys; invalid values are still dropped by client sanitizers as before.
- `autoDeleteLastRunAt` stays a local-only cooldown (not synced across devices).
- No Settings copy/layout/search-registry changes; no retention semantics change (cutoff, keep-5, shared/timeless skips unchanged).
- No daemon behavior change; the server membership check is unchanged, only now receives the correct directory.

## Affected surfaces

- Packages: `packages/ui` (Pi facade, session cluster, retention hook, docs, tests), `packages/web` (route regression test only; route behavior unchanged).
- Runtimes: web, desktop, hosted-mobile, Capacitor — all use `runtimeFetch`/`piClient` against the connected server; no `RuntimeAPIs.settings` fork exists, so one fix covers all. No Electron-native or Capacitor-native path touched.
- User-visible: Settings → Session Retention manual + automatic cleanup for multi-project workspaces. Single-project/focused-folder flows are behavior-identical (same directory as before).
- Persisted/external contracts: `PiSessionStore.archive/remove` gain an optional trailing `directory` (backward compatible); `DELETE /api/pi/sessions/:id` may now include `?directory=` (server already accepted it via `requestSessionOperation`). No `settings.json` shape change.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md instruction order + minimal scope | Source/contract change | Read root guide, skills, nearest docs first; kept diff to the directory-threading fix + regression tests + one doc line; preserved unrelated worktree state |
| `pichamber-change-discipline` (cross-workspace + persisted/external risk) | Shared UI → `/api/pi/*` → daemon contract; exported method signatures | Traced every `archive`/`remove` caller (`session-actions.ts` still compiles/behaves — optional param); focused tests + package type-check/lint; `dead-code` inspected (exit 0, no new hits) |
| `ui-api-decoupling` (+ `implementation-map`, `runtime-parity`) | Pi facade, `/api/pi/*` routes, runtime switching | All Pi calls stay in `piClient`; no hardcoded origins/credentials; runtime key still captured per call and re-checked; explicit per-runtime behavior unchanged across web/Electron/mobile |
| `sync-state-invariants` (+ `sync/DOCUMENTATION.md`) | Session sync, catalog vs focused slice, failure-is-not-empty | Resolution prefers authoritative catalog identity over focused-slice heuristic; no snapshot-difference cleanup changed; per-session failure still lands in `failedIds` without touching other sessions; updated owning doc line |
| `settings-ui-patterns` (+ `theme`, `locale` companions; `layout`/`controls`/`search` refs) | Change lives under a Settings surface | No Settings chrome/copy/anchor changes, so no primitive, token, string, or search-registry churn |
| `performance-engineering` | Requested no-regression check | Cold batch path only (≤1/day + manual); added work is one O(1) catalog `Map.get` with the old O(focused) `find` on miss only; no new subscriptions, renders, polls, sorts, caches, or RPCs |

## Validation

| Check | Result |
|---|---|
| `bun run --cwd packages/ui test src/hooks/useSessionAutoCleanup.test.ts src/apps/pi-session-retention-directory.test.ts src/lib/pi/client.test.ts` | 30 pass, 0 fail |
| `bun run --cwd packages/web test server/lib/pi/routes.test.js server/lib/pi/ui-settings-store.test.js` | 38 pass (routes 35/35 incl. new owning/wrong-directory archive test) |
| `bun run --cwd packages/ui type-check` / `lint` | pass |
| `bun run --cwd packages/web type-check` / `lint` | pass |
| `bun run test:ui` | 2034 pass, 0 fail |
| `bun run test:electron` | pass |
| `bun run test` (all) | web 622/623 — sole failure `server/lib/relay/host-client.test.js` 10s timeout in full run; passes in isolation (293ms); file untouched by this diff |
| `bun run dead-code` | exit 0, no new hits from this change |

Not verified: live daemon repro with two projects, manual Settings → Run cleanup now click-through, mobile/Capacitor packaged run. Unit + static only; no runtime/relay/perf claim beyond the cold-path reasoning above.

HEAD: `ba744f38b1b4ee2d1e5b588f44ba1c172a8d9275`

## Visual evidence

No user-visible change by design: same Settings section, same buttons/toasts, same eligible-count copy. The diff cannot affect rendered behavior — it changes only which `directory` accompanies the existing archive/delete requests. Evidence is the new failing-before/passing-after regression coverage: foreign-session archive/remove capture `/other` instead of `/focused`, and the server test proves owning-dir succeeds while wrong-dir is rejected without sidecar write.

## Risks and failure behavior

- Wrong-directory risk moves to callers passing a stale explicit dir; mitigation: explicit arg is only supplied from `resolveGlobalSessionDirectory` of the same session object being acted on, and catalog is second in line, so a stale caller still resolves to catalog truth.
- Partial failure: per-candidate try/catch preserved — one session's `INVALID_SESSION`/network error lands in `failedIds`, other candidates still process; successful ids still reconcile into `useGlobalSessionsStore`.
- Rollback: revert returns to old behavior (focused-dir fallback); no migration, no persisted data change, sidecar writes only on successful membership verification as before.
- Security: no new trust boundary; directory is an existing scoping parameter, no credentials/paths logged; server verification unchanged.
- Compatibility: optional params only; `session-actions.ts` and other callers compile and behave as before.
