### PR TITLE
Add copy working directory option to header session menu

### DIFF
--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -592,6 +592,13 @@ export const Header: React.FC<HeaderProps> = ({
     return normalize(openDirectory || activeProject?.path || '');
   }, [activeProject?.path, openDirectory]);
 
+  const copyCurrentWorkingDirectory = React.useCallback(() => {
+    if (!actionDirectory) return;
+    void copyTextToClipboard(actionDirectory).then((result) => {
+      toast[result.ok ? 'success' : 'error']((result.ok ? "Working directory copied" : "Failed to copy working directory"));
+    }).catch(() => toast.error("Failed to copy working directory"));
+  }, [actionDirectory]);
+
   const activeProjectRef = React.useMemo(() => {
     if (!activeProject) {
       return null;
@@ -1214,6 +1221,7 @@ export const Header: React.FC<HeaderProps> = ({
                   <DropdownMenuContent align="end" className="min-w-[190px]">
                     <DropdownMenuItem onClick={() => { pendingHeaderRenameRef.current = true; }}><Icon name="pencil-ai" className="mr-2 size-4" />{"Rename"}</DropdownMenuItem>
                     <DropdownMenuItem onClick={copyCurrentSessionId}><Icon name="file-copy" className="mr-2 size-4" />{"Copy session ID"}</DropdownMenuItem>
+                    <DropdownMenuItem onClick={copyCurrentWorkingDirectory} disabled={!actionDirectory}><Icon name="folder" className="mr-2 size-4" />{"Copy working directory"}</DropdownMenuItem>
                     <DropdownMenuSeparator />
                     <DropdownMenuItem onClick={() => void exportCurrentSession()}><Icon name="download" className="mr-2 size-4" />{"Export Markdown"}</DropdownMenuItem>
                     <DropdownMenuSeparator />


### PR DESCRIPTION
## Intent

Lets the user copy the current working directory (cwd) from the header session actions menu (the `…` dropdown next to the session title that already has Rename / Copy session ID / etc.), so they can paste it into a terminal and `cd` into it.

Adds a `Copy working directory` item directly after `Copy session ID`. It copies the effective action directory (`openDirectory || activeProject.path`, the same value project actions and mini-chat already use) via the shared `copyTextToClipboard` helper, with `Working directory copied` / `Failed to copy working directory` toast feedback. The item is disabled when there is no directory to copy.

## Non-goals

- No changes to Rename, Copy session ID, Export, Archive, or Delete behavior.
- No new clipboard helper, icon asset, dependency, export, or persisted contract.

## Affected surfaces

- `packages/ui` only (`Header.tsx` session actions menu). Consumed by web, desktop, and mobile shells through the shared UI, with no runtime-specific branching — all runtimes get the same menu item.
- User-visible states: new menu item (enabled with a directory, disabled without); success/error toasts on copy.
- No persisted/external contract changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `pichamber-change-discipline` | Source change in `packages/ui` | Smallest complete change (8 lines, 1 file); existing menu/copy behavior preserved; local-implementation risk → focused validation below |
| `theme-system` | Touches a UI menu item with an icon | Reuses shared `DropdownMenuItem` + `Icon` (`folder`, already in the sprite — no `icons:generate` run, no hardcoded colors/styles); see `references/icons.md` |
| `locale-ui-patterns` | Adds user-facing menu/toast copy | Title-case `Copy working directory` matches `Copy session ID` precedent; toasts mirror existing `Session ID copied` / `Failed to copy …` wording |
| `packages/ui/src/sync/DOCUMENTATION.md` | Cwd comes from session/project state | Copies `actionDirectory`, the established effective-directory value, instead of inventing a new cwd source |

## Validation

| Check | Result |
|---|---|
| `bun run --cwd packages/ui type-check` | Pass |
| `bun run --cwd packages/ui lint` | Pass |
| Focused header tests (`headerLocation.test.ts`, `header/headerHelpers.test.ts`) | 11 pass, 0 fail |
| Full `bun run test:ui` | 2040 pass, 1 fail — single failure is `createRelayTunnelClient > reconnects after a handshake timeout` (timing-flaky relay test, unrelated file); passes in isolation (17/17) on re-run |
| Manual runtime check (paste-verifies-path, disabled empty state) | Not performed — no browser harness in this environment; stated explicitly per PR contract |

Note: `bun install` was run to install missing worktree deps for validation; its incidental `bun.lock` version churn was reverted so the diff is Header-only.

## Visual evidence

User-visible one-line menu addition following the exact visual pattern of the adjacent `Copy session ID` item (same `DropdownMenuItem` + `mr-2 size-4` icon). No screenshot captured in this headless environment; the item renders identically to its neighbors by construction (shared component, no custom styling).

## Risks and failure behavior

- Clipboard denial/unsupported context: handled by the shared helper's fallback chain; surfaces the error toast, same as Copy session ID. No optimistic state, no persistence, no partial writes — nothing to roll back.
- Empty directory: item disabled, handler early-returns as a second guard.
- Security: copies only the already-visible session directory path; no secrets or credentials involved.
- Performance/cross-runtime: no new subscriptions, effects, or runtime branches; negligible.
