### PR TITLE
fix(ui): drop stray backslashes from quoted names in confirm dialogs

### DIFF
--- a/packages/ui/src/components/desktop/DesktopHostSwitcher.tsx
+++ b/packages/ui/src/components/desktop/DesktopHostSwitcher.tsx
@@ -343,7 +343,7 @@ export function DesktopHostSwitcherDialog({
       setStatusById((prev) => ({ ...prev, [host.id]: finalStatus }));
 
       if (!transport) {
-        toast.error(`Instance \\"${redactSensitiveUrl(host.label)}\\" is unreachable`);
+        toast.error(`Instance "${redactSensitiveUrl(host.label)}" is unreachable`);
         setSwitchingHostId(null);
         return;
       }
@@ -366,7 +366,7 @@ export function DesktopHostSwitcherDialog({
       }));
 
       if (isBlockedHostStatus(probe.status)) {
-        toast.error(`Instance \\"${redactSensitiveUrl(host.label)}\\" is unreachable`);
+        toast.error(`Instance "${redactSensitiveUrl(host.label)}" is unreachable`);
         setSwitchingHostId(null);
         return;
       }

--- a/packages/ui/src/components/layout/useProjectActionsRunner.ts
+++ b/packages/ui/src/components/layout/useProjectActionsRunner.ts
@@ -323,7 +323,7 @@ export function useProjectActionsRunner({
           ]);
           const devServer = await detectDevServerCommand(normalizedDirectory, actionsState.actions, scripts);
           if (!devServer) {
-            throw new Error("No dev server command found. Configure a project action or add a \\\"dev\\\" script to package.json.");
+            throw new Error("No dev server command found. Configure a project action or add a \"dev\" script to package.json.");
           }
           return {
             id: AUTO_DISCOVER_ACTION_ID,

--- a/packages/ui/src/components/sections/git-identities/GitIdentityEditorDialog.tsx
+++ b/packages/ui/src/components/sections/git-identities/GitIdentityEditorDialog.tsx
@@ -463,7 +463,7 @@ export const GitIdentityEditorDialog: React.FC<GitIdentityEditorDialogProps> = (
           <DialogHeader>
             <DialogTitle>{"Delete Profile"}</DialogTitle>
             <DialogDescription>
-              {`Are you sure you want to delete \\"${selectedProfile?.name || name}\\"?`}
+              {`Are you sure you want to delete "${selectedProfile?.name || name}"?`}
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>

--- a/packages/ui/src/components/sections/git-identities/GitPage.tsx
+++ b/packages/ui/src/components/sections/git-identities/GitPage.tsx
@@ -107,7 +107,7 @@ export const GitPage: React.FC = () => {
     setIsDeletePending(true);
     const success = await deleteProfile(deleteDialogProfile.id);
     if (success) {
-      toast.success(`Profile \\"${deleteDialogProfile.name}\\" deleted`);
+      toast.success(`Profile "${deleteDialogProfile.name}" deleted`);
       setDeleteDialogProfile(null);
     } else {
       toast.error("Failed to delete profile");
@@ -205,7 +205,7 @@ export const GitPage: React.FC = () => {
           <DialogHeader>
             <DialogTitle>{"Delete Profile"}</DialogTitle>
             <DialogDescription>
-              {`Are you sure you want to delete \\"${deleteDialogProfile?.name ?? ''}\\"?`}
+              {`Are you sure you want to delete "${deleteDialogProfile?.name ?? ''}"?`}
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>

--- a/packages/ui/src/components/session/sidebar/ConfirmDialogs.tsx
+++ b/packages/ui/src/components/session/sidebar/ConfirmDialogs.tsx
@@ -79,14 +79,14 @@ export function SessionDeleteConfirmDialog(props: {
             {value && value.descendantCount > 0
               ? value.archivedBucket
                 ? value.descendantCount === 1
-                  ? `\\"${sessionDisplayTitle(value.session)}\\" and its ${value.descendantCount} sub-task will be permanently deleted.`
-                  : `\\"${sessionDisplayTitle(value.session)}\\" and its ${value.descendantCount} sub-tasks will be permanently deleted.`
+                  ? `"${sessionDisplayTitle(value.session)}" and its ${value.descendantCount} sub-task will be permanently deleted.`
+                  : `"${sessionDisplayTitle(value.session)}" and its ${value.descendantCount} sub-tasks will be permanently deleted.`
                 : value.descendantCount === 1
-                  ? `\\"${sessionDisplayTitle(value.session)}\\" and its ${value.descendantCount} sub-task will be archived.`
-                  : `\\"${sessionDisplayTitle(value.session)}\\" and its ${value.descendantCount} sub-tasks will be archived.`
+                  ? `"${sessionDisplayTitle(value.session)}" and its ${value.descendantCount} sub-task will be archived.`
+                  : `"${sessionDisplayTitle(value.session)}" and its ${value.descendantCount} sub-tasks will be archived.`
               : value?.archivedBucket
-                ? `\\"${value?.session ? sessionDisplayTitle(value.session) : "Untitled Session"}\\" will be permanently deleted.`
-                : `\\"${value?.session ? sessionDisplayTitle(value.session) : "Untitled Session"}\\" will be archived.`}
+                ? `"${value?.session ? sessionDisplayTitle(value.session) : "Untitled Session"}" will be permanently deleted.`
+                : `"${value?.session ? sessionDisplayTitle(value.session) : "Untitled Session"}" will be archived.`}
           </DialogDescription>
         </DialogHeader>
         <SessionMutationDialogFooter
@@ -334,10 +334,10 @@ export function FolderDeleteConfirmDialog(props: {
             {value && (value.subFolderCount > 0 || value.sessionCount > 0)
               ? value.subFolderCount > 0
                 ? value.subFolderCount === 1
-                  ? `\\"${value.folderName}\\" will be deleted along with ${value.subFolderCount} sub-folder. Sessions inside will not be deleted.`
-                  : `\\"${value.folderName}\\" will be deleted along with ${value.subFolderCount} sub-folders. Sessions inside will not be deleted.`
-                : `\\"${value.folderName}\\" will be deleted. Sessions inside will not be deleted.`
-              : `\\"${value?.folderName ?? ''}\\" will be permanently deleted.`}
+                  ? `"${value.folderName}" will be deleted along with ${value.subFolderCount} sub-folder. Sessions inside will not be deleted.`
+                  : `"${value.folderName}" will be deleted along with ${value.subFolderCount} sub-folders. Sessions inside will not be deleted.`
+                : `"${value.folderName}" will be deleted. Sessions inside will not be deleted.`
+              : `"${value?.folderName ?? ''}" will be permanently deleted.`}
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>


### PR DESCRIPTION
## Intent

Archiving a session shows literal backslashes around the session name (reported as `\\"h\\"` in the "Archive session?" dialog instead of `"h"`). Template literals used `\\\\"` around interpolated names; inside backtick strings `\\\\` renders as one literal backslash, so every quoted name in these dialogs displayed as `\\"Name\\"`. Backtick strings do not need double-quote escaping, so this switches to plain quotes, matching the existing correct pattern in `HeaderRetentionDialog`.

## Non-goals

- No copy wording, pluralization, title resolution (`getSessionDisplayTitle`), or dialog behavior changes — only the stray backslash characters.
- `packages/ui/src/components/ui/sortable-tabs-strip.tsx:341` (`replace(/"/g, '\\\\"')`) intentionally escapes quotes for selector matching and is left unchanged, as are legitimate backslash uses in `pathNormalization.ts` and `document-attachments.ts`.

## Affected surfaces

- Package: `@pichamber/ui` only (shared dialog copy rendered on web, desktop, and mobile webviews; no runtime-specific branches).
- User-visible states fixed: session archive/delete confirm (with/without sub-tasks), folder delete confirm, desktop host-switcher unreachable toasts, git identity delete dialog + toast, dev-server auto-discover error message.
- No persisted/external contracts, exports, routes, or IDs changed.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `pichamber-change-discipline` | Any source change; local-implementation risk (private dialog copy in one package) | Smallest complete diff (16 insertions / 16 deletions, 5 files, copy only); preserved all wording/pluralization; no new deps, abstractions, or refactors |
| `locale-ui-patterns` | Edits dialog/toast user-facing strings | Copy stays co-located, concise, sentence-case; plural forms untouched; no dangling interpolation |
| `packages/ui/src/components/session/sidebar/DOCUMENTATION.md` | Nearest owning docs for `ConfirmDialogs.tsx` | Docs describe confirm wrappers generically; no ownership/contract/invariant change, so no doc update needed |

## Validation

| Check | Result |
|---|---|
| Template render proof (`node -e`, old vs new literal) | Old renders `\\\"h\\\"` (bug reproduced); new renders `"h"` — pass |
| `bun run type-check:ui` | Pass (after `bun install`; pre-install failure was a stale global tsc 4.7.4, unrelated) |
| `bun run lint:ui` | Pass |
| `bun run test:ui` | 2041 pass / 0 fail across 255 files |
| Focused regression test for the dialog copy | Not added: dialog body renders through a Base UI portal, which SSR (`renderToStaticMarkup`, the repo precedent) emits as empty — verified empirically — and the repo has no DOM test env; no existing tests/snapshots covered these strings |

`bun run dead-code` not required (no added/deleted/renamed files or export changes). Unrelated `bun.lock` churn from `bun install` was reverted out of the diff.

## Visual evidence

Before state is the reporter's screenshot (`\\"h\\"` will be archived). No after screenshot: headless environment, no running UI to capture; the render proof above plus the passing suite is the evidence. Reviewer can verify by archiving any session — expected: `"<title>" will be archived.`

## Risks and failure behavior

Copy-only change; no failure/rollback/cleanup paths, no data-loss surface, no security or performance considerations. Worst case is a typo in dialog copy, covered by the suite and reviewable in the 16-line diff.