### PR TITLE
fix(ui): make close-worktree warnings legible in dark and light themes

### DIFF
--- a/packages/ui/src/components/session/sidebar/ConfirmDialogs.tsx
+++ b/packages/ui/src/components/session/sidebar/ConfirmDialogs.tsx
@@ -246,8 +246,9 @@ export function WorktreeCloseConfirmDialog(props: {
         </DialogHeader>
 
         {statusCheckFailed ? (
-          <div role="alert" className="rounded-md bg-[var(--status-error-background)] p-3 typography-ui-label text-[var(--status-error-foreground)]">
-            {"Unable to check this worktree's status. Refresh and try again."}
+          <div role="alert" className="flex items-start gap-2 rounded-lg border border-[var(--status-error-border)] bg-[var(--status-error-background)] p-3">
+            <Icon name="alert" className="mt-0.5 size-4 shrink-0 text-[var(--status-error)]" />
+            <p className="typography-ui-label text-foreground">{"Unable to check this worktree's status. Refresh and try again."}</p>
           </div>
         ) : status === null ? (
           <p className="typography-ui-label text-muted-foreground" aria-live="polite">
@@ -256,17 +257,21 @@ export function WorktreeCloseConfirmDialog(props: {
         ) : null}
 
         {value?.hasActiveSession ? (
-          <div role="alert" className="rounded-md bg-[var(--status-warning-background)] p-3 typography-ui-label text-[var(--status-warning-foreground)]">
-            {"Stop the active session before closing this worktree."}
+          <div role="alert" className="flex items-start gap-2 rounded-lg border border-[var(--status-warning-border)] bg-[var(--status-warning-background)] p-3">
+            <Icon name="error-warning" className="mt-0.5 size-4 shrink-0 text-[var(--status-warning)]" />
+            <p className="typography-ui-label text-foreground">{"Stop the active session before closing this worktree."}</p>
           </div>
         ) : null}
 
         {isDirty ? (
-          <div className="space-y-3 rounded-md bg-[var(--status-warning-background)] p-3 text-[var(--status-warning-foreground)]">
-            <p className="typography-ui-label">
-              {"This worktree has uncommitted changes. They will be permanently removed."}
-            </p>
-            <label className="flex items-start gap-2 typography-ui-label">
+          <div className="space-y-3 rounded-lg border border-[var(--status-warning-border)] bg-[var(--status-warning-background)] p-3">
+            <div className="flex items-start gap-2">
+              <Icon name="error-warning" className="mt-0.5 size-4 shrink-0 text-[var(--status-warning)]" />
+              <p className="typography-ui-label text-foreground">
+                {"This worktree has uncommitted changes. They will be permanently removed."}
+              </p>
+            </div>
+            <label className="flex items-start gap-2 pl-6 typography-ui-label text-foreground">
               <Checkbox
                 checked={discardChangesConfirmed}
                 onChange={setDiscardChangesConfirmed}
@@ -286,11 +291,14 @@ export function WorktreeCloseConfirmDialog(props: {
                 : `This worktree has ${status?.ahead} unpushed commits. ${branchRetentionMessage}`}
             </p>
             {isDetachedWithUnpublishedCommits ? (
-              <div className="space-y-3 rounded-md bg-[var(--status-warning-background)] p-3 text-[var(--status-warning-foreground)]">
-                <p className="typography-ui-label">
-                  {"Because this worktree is detached, its unpushed commits may be lost."}
-                </p>
-                <label className="flex items-start gap-2 typography-ui-label">
+              <div className="space-y-3 rounded-lg border border-[var(--status-warning-border)] bg-[var(--status-warning-background)] p-3">
+                <div className="flex items-start gap-2">
+                  <Icon name="error-warning" className="mt-0.5 size-4 shrink-0 text-[var(--status-warning)]" />
+                  <p className="typography-ui-label text-foreground">
+                    {"Because this worktree is detached, its unpushed commits may be lost."}
+                  </p>
+                </div>
+                <label className="flex items-start gap-2 pl-6 typography-ui-label text-foreground">
                   <Checkbox
                     checked={discardChangesConfirmed}
                     onChange={setDiscardChangesConfirmed}

--- a/packages/ui/src/components/session/sidebar/SidebarSpacesBar.tsx
+++ b/packages/ui/src/components/session/sidebar/SidebarSpacesBar.tsx
@@ -259,7 +259,7 @@ const SortableFolderRow: React.FC<{
             ) : null}
             {worktreeError ? (
               <span title={worktreeError} aria-label="Worktree discovery failed">
-                <Icon name="error-warning" className="size-4 text-[var(--status-warning-foreground)]" />
+                <Icon name="error-warning" className="size-4 text-[var(--status-warning)]" />
               </span>
             ) : null}
             {hasWorktrees ? <Icon name={isExpanded ? 'arrow-down-s' : 'arrow-right-s'} className="size-4 text-muted-foreground" /> : null}


### PR DESCRIPTION
## Intent

The close-worktree confirmation dialog renders its active-session warning as black text (`--status-warning-foreground`, meant for text *on top of* a solid warning fill) on a translucent amber wash (`--status-warning-background`, ~8–12% opacity over the dialog surface). On dark themes this is near-unreadable dark-on-dark-brown; on light themes it is white-on-pale-beige. This PR switches all four callouts in `WorktreeCloseConfirmDialog` to the established repo callout pattern — bordered tinted container + status-colored icon + `text-foreground` message body — so the blocking warning is legible in both dark and light modes. It also fixes the same token misuse on the worktree-error icon in `SidebarSpacesBar` (black icon on sidebar surface, invisible on dark).

## Non-goals

- No copy changes; all user-facing strings are untouched.
- No behavior changes: Git status gating, dirty/detached acknowledgement checkboxes, branch retention, and the active-session block remain exactly as before.
- No theme token changes: all 30+ bundled themes keep their `status.*` values. The fix only uses the tokens the way the rest of the codebase already does.
- Nearby identical patterns with the same latent issue (`SessionSidebar` server-unreachable banner, `TerminalView` error bar) are intentionally left for a separate pass to keep this diff scoped to the worktree-close flow.

## Affected surfaces

- `packages/ui` only: `components/session/sidebar/ConfirmDialogs.tsx` (`WorktreeCloseConfirmDialog` error/active-session/dirty/detached callouts) and `components/session/sidebar/SidebarSpacesBar.tsx` (worktree-error icon class).
- Runtimes: shared UI component, so web, desktop, hosted-mobile, and Capacitor mobile all pick it up with no runtime-specific branching. No `RuntimeAPIs`, bridge, or server-route changes.
- User-visible states: close-worktree dialog with (a) status-check failure, (b) active session running, (c) uncommitted changes, (d) detached HEAD with unpushed commits — in light and dark themes.
- No persisted/external contracts, exports, or public API changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` instruction order + `pichamber-change-discipline` (source change) | Any source change must load matching skills/docs, classify risk, and validate narrowly | Read `theme-system` + `tokens-and-examples.md`, `pichamber-change-discipline`, nearest `DOCUMENTATION.md` (`session/sidebar`), and traced real consumers before editing. Risk is local implementation (private dialog markup in one package); kept the diff to 2 files, preserved all gating behavior, no new deps/exports |
| `theme-system` (UI colors) | Changing component colors | Semantic theme tokens only (`--status-warning-border/background`, `--status-warning`, `--status-error-*`, `text-foreground`); no hex or Tailwind palette colors. Shared `Button` variants (`outline`/`destructive`) and sprite-based `Icon` (`error-warning`, `alert`) reused — no new controls. Status color kept for feedback via border/bg/icon; body text uses `text-foreground` for AA contrast, matching `DraftBranchCheckoutDialog` / `KeyboardShortcutsSettings` precedent |
| `session/sidebar/DOCUMENTATION.md` | Owning-module docs for `ConfirmDialogs.tsx` | Docs already describe the dialog as blocking close on live sessions with dirty acknowledgement and branch preservation; behavior is unchanged so no doc update needed |

## Validation

| Check | Result |
|---|---|
| `pr checks` CI (`bun run build`, `type-check`, `lint`, `bun run test`, electron packaging tests) | Pending — will report once the run completes |
| Contrast measurement (WCAG, composited tokens over dialog `bg-background`, 14px label needs 4.5:1) | Before: dark `1.39:1`, light `1.11:1` (fail). After (`text-foreground`): dark `11.08:1`, light `12.28:1` (pass). Intermediate `text-warning` variant passed dark (`9.08:1`) but failed light (`2.86:1`), which is why the body uses `text-foreground` |
| Local `type-check:ui` / `lint` / unit tests | Could not run — this environment has no installed deps (`@eslint/js`, `clsx` unresolvable) and the repo `tsc` errors on pre-existing config before reaching our files. Change is className/markup-only on an already-imported `Icon`; relying on CI for real verification |
| Focused tests for the dialog | None exist in the repo for `ConfirmDialogs`; no new test infra introduced for a class-only change |

## Visual evidence

No screenshots attached: this is a headless environment with no running app/dev server, so before/after captures were not possible here. Empirical evidence instead: the contrast ratios above, computed from the actual `pichamber-dark` / `pichamber-light` token values composited over the dialog surface. The reported before state (dark-amber wash with black text, per the issue screenshot) corresponds to the measured `1.39:1`. A reviewer running the dialog will see the active-session alert as a bordered amber-tinted callout with an amber warning icon and high-contrast body text in both themes.

## Risks and failure behavior

- Render-only change: no logic, state, persistence, network, or destructive-path changes, so no new failure modes, rollback, or cleanup concerns. If the classes failed to apply, the dialog would fall back to unstyled text but all gating (active-session block, dirty acknowledgement, status-check failure) still enforces correctly.
- Cross-theme risk is bounded: only semantic tokens already consumed elsewhere in the same dialog surfaces are used; per-theme `warningForeground` values (designed for solid fills) are no longer misapplied to translucent backgrounds.
- Security/performance: none — no data handling, no new components, no animation changes.
