### PR TITLE
fix(web): preserve WebSocket auth across restarts

### DIFF
--- a/packages/web/server/lib/ui-auth/DOCUMENTATION.md
+++ b/packages/web/server/lib/ui-auth/DOCUMENTATION.md
@@ -7,7 +7,7 @@ Trusted-device access has one durable credential model: a remote client bearer t
 
 Pairing v2 is implemented by `packages/web/server/lib/client-auth/pairing.js`. It stores short-lived one-time pairing sessions with hashed secrets, exposes create/cancel/redeem routes under `/api/client-auth/pairing/*`, and redeems a valid pairing secret into the same remote client token used by password/passkey trusted-device flows.
 
-Browser WebSocket clients mint a 60-second `oc_url_token` through the authenticated `/auth/url-token` route because the WebSocket constructor cannot attach an Authorization header. The token is accepted only for the explicit WebSocket allowlist, currently `/api/terminal/ws` and `/api/stt/ws`; ordinary API routes and unknown upgrade paths reject it. The token resolves to the UI session or remote-client identity that minted it.
+Browser WebSocket clients mint a 60-second `oc_url_token` through the authenticated `/auth/url-token` route because the WebSocket constructor cannot attach an Authorization header. The token is encrypted with a key derived from the server's persisted JWT secret, so an ordinary server restart does not invalidate a token that the browser may still use. Global sign-out rotates that secret and invalidates outstanding tokens. The token is accepted only for the explicit WebSocket allowlist, currently `/api/terminal/ws` and `/api/stt/ws`; ordinary API routes and unknown upgrade paths reject it. The token resolves to the UI session or remote-client identity that minted it.
 
 ## Entrypoints and structure
 - `packages/web/server/lib/ui-auth/ui-auth.js`: UI auth controller runtime, cookie/session issuance, rate limiting, and auth route handlers.

--- a/packages/web/server/lib/ui-auth/ui-auth.js
+++ b/packages/web/server/lib/ui-auth/ui-auth.js
@@ -1,6 +1,6 @@
 import crypto from 'crypto';
 import { promisify } from 'util';
-import { SignJWT, jwtVerify } from 'jose';
+import { EncryptJWT, jwtDecrypt, SignJWT, jwtVerify } from 'jose';
 import fs from 'fs';
 import path from 'path';
 import { resolvePiChamberDataDir, resolvePiChamberDataPath } from '../pichamber-data-dir.js';
@@ -399,40 +399,39 @@ export const createUiAuth = ({
   requireClientAuth = false,
 } = {}) => {
   const normalizedPassword = normalizePassword(password);
-  const urlAuthTokens = new Map();
+  let jwtSecret = getOrCreateJwtSecret();
 
-  const sweepUrlAuthTokens = () => {
-    const now = Date.now();
-    for (const [token, entry] of urlAuthTokens.entries()) {
-      if (!entry || entry.expiresAt <= now) {
-        urlAuthTokens.delete(token);
-      }
-    }
-  };
+  const getUrlAuthEncryptionKey = () => crypto.createHash('sha256').update(jwtSecret).digest();
 
-  const issueUrlAuthTokenForSession = (sessionToken) => {
-    sweepUrlAuthTokens();
-    const token = `${URL_AUTH_TOKEN_PREFIX}${crypto.randomBytes(24).toString('base64url')}`;
+  const issueUrlAuthTokenForSession = async (sessionToken) => {
     const expiresAt = Date.now() + URL_AUTH_TOKEN_TTL_MS;
-    urlAuthTokens.set(token, { sessionToken, expiresAt });
-    return { token, expiresAt };
+    const encryptedToken = await new EncryptJWT({ type: 'url-auth', sessionToken })
+      .setProtectedHeader({ alg: 'dir', enc: 'A256GCM' })
+      .setIssuedAt()
+      .setExpirationTime(Math.floor(expiresAt / 1000))
+      .encrypt(getUrlAuthEncryptionKey());
+    return { token: `${URL_AUTH_TOKEN_PREFIX}${encryptedToken}`, expiresAt };
   };
 
-  const authenticateUrlAuthToken = (req) => {
+  const authenticateUrlAuthToken = async (req) => {
     if (!canUseUrlAuthTokenForRequest(req)) return null;
     const token = getUrlAuthTokenFromRequest(req);
     if (!token || !token.startsWith(URL_AUTH_TOKEN_PREFIX)) return null;
-    const entry = urlAuthTokens.get(token);
-    if (!entry || entry.expiresAt <= Date.now()) {
-      urlAuthTokens.delete(token);
+    try {
+      const { payload } = await jwtDecrypt(token.slice(URL_AUTH_TOKEN_PREFIX.length), getUrlAuthEncryptionKey(), {
+        keyManagementAlgorithms: ['dir'],
+        contentEncryptionAlgorithms: ['A256GCM'],
+      });
+      if (payload.type !== 'url-auth' || typeof payload.sessionToken !== 'string' || !payload.sessionToken) return null;
+      return { ok: true, sessionToken: payload.sessionToken };
+    } catch {
       return null;
     }
-    return { ok: true, sessionToken: entry.sessionToken || 'url:authenticated' };
   };
 
   const authenticateClientRequest = async (req, { allowUrlToken = true } = {}) => {
     if (allowUrlToken) {
-      const urlAuth = authenticateUrlAuthToken(req);
+      const urlAuth = await authenticateUrlAuthToken(req);
       if (urlAuth) return urlAuth;
     }
     const token = getBearerTokenFromRequest(req);
@@ -554,14 +553,14 @@ export const createUiAuth = ({
         const clientAuth = await authenticateClientRequest(req, { allowUrlToken: false });
         if (clientAuth) {
           res.setHeader('Cache-Control', 'no-store');
-          return res.json(issueUrlAuthTokenForSession(clientSessionToken(clientAuth)));
+          return res.json(await issueUrlAuthTokenForSession(clientSessionToken(clientAuth)));
         }
         if (requireClientAuth) {
           return res.status(401).json({ error: 'Client authentication required', locked: true, clientAuthRequired: true });
         }
         const sessionToken = await ensureSessionToken(req, res);
         res.setHeader('Cache-Control', 'no-store');
-        return res.json(issueUrlAuthTokenForSession(sessionToken));
+        return res.json(await issueUrlAuthTokenForSession(sessionToken));
       },
       handlePasskeyStatus: (_req, res) => {
         res.json({ enabled: false, hasPasskeys: false, passkeyCount: 0, rpID: null });
@@ -600,7 +599,6 @@ export const createUiAuth = ({
 
   const salt = crypto.randomBytes(16);
   const expectedHash = crypto.scryptSync(normalizedPassword, salt, 64);
-  let jwtSecret = getOrCreateJwtSecret();
   let passwordBinding = crypto.createHmac('sha256', jwtSecret).update(normalizedPassword).digest('hex');
   const resolveSessionTtlMs = (trustDevice) => (trustDevice ? TRUSTED_DEVICE_SESSION_TTL_MS : sessionTtlMs);
   let passkeyController = createUiPasskeys({
@@ -620,7 +618,6 @@ export const createUiAuth = ({
   const rotateJwtSecret = () => {
     const nextSecret = crypto.randomBytes(32).toString('hex');
     jwtSecret = persistJwtSecret(nextSecret);
-    urlAuthTokens.clear();
     rebuildPasskeyController();
   };
 
@@ -793,7 +790,7 @@ export const createUiAuth = ({
       return respondUnauthorized(req, res);
     }
     res.setHeader('Cache-Control', 'no-store');
-    return res.json(issueUrlAuthTokenForSession(sessionToken));
+    return res.json(await issueUrlAuthTokenForSession(sessionToken));
   };
 
   const handleSessionCreate = async (req, res) => {

--- a/packages/web/server/lib/ui-auth/ui-auth.test.js
+++ b/packages/web/server/lib/ui-auth/ui-auth.test.js
@@ -228,6 +228,33 @@ describe('ui auth client credential seam', () => {
     }
   });
 
+  it('keeps terminal and dictation URL tokens valid across a server restart', async () => {
+    const createUiAuth = await loadCreateUiAuth();
+    const clientAuthController = {
+      authenticateBearerToken: async (token) => token === 'client-token' ? { ok: true, clientId: 'device-1' } : null,
+    };
+    const beforeRestart = createUiAuth({ password: 'secret', clientAuthController });
+    const mintRes = createResponse();
+    await beforeRestart.handleUrlAuthToken({
+      method: 'POST',
+      path: '/auth/url-token',
+      headers: { authorization: 'Bearer client-token', accept: 'application/json' },
+    }, mintRes);
+    beforeRestart.dispose();
+
+    const afterRestart = createUiAuth({ password: 'secret', clientAuthController });
+    for (const path of ['/api/terminal/ws', '/api/stt/ws']) {
+      const websocketReq = {
+        method: 'GET',
+        path,
+        url: `${path}?oc_url_token=${encodeURIComponent(mintRes.body.token)}`,
+        headers: { connection: 'Upgrade', upgrade: 'websocket' },
+      };
+      expect(await afterRestart.ensureSessionToken(websocketReq, createResponse())).toBe('client:device-1');
+    }
+    afterRestart.dispose();
+  });
+
   it('issues desktop client tokens with the UI session expiry', async () => {
     const createUiAuth = await loadCreateUiAuth();
     let createClientInput = null;


### PR DESCRIPTION
## Intent

Terminal and dictation WebSocket reconnects could fail with HTTP 401 after the PiChamber backend restarted. The browser retained a still-unexpired 60-second `oc_url_token`, but the server stored those tokens only in an in-memory map that disappeared during restart.

This change seals URL-auth tokens with authenticated encryption derived from the server's persisted JWT secret. Tokens remain short-lived and keep the minting session or client identity, but an ordinary server restart can verify them. Terminal and dictation reconnects no longer fail solely because the backend restarted.

## Non-goals

- Change terminal or dictation protocols, buffering, replay, reconnect pacing, or long-session limits.
- Add WebSocket endpoints or broaden URL-token route access.
- Make tokens survive global sign-out. Global sign-out rotates the JWT secret and intentionally invalidates outstanding URL tokens.

## Affected surfaces

- `packages/web/server/lib/ui-auth`: URL-token issuance and validation contract.
- Web, Electron, hosted mobile, and Capacitor clients benefit because all terminal and dictation sockets use the same server auth gate.
- `/api/terminal/ws` and `/api/stt/ws` remain the only accepted WebSocket paths for URL auth.
- No rendered UI, persisted user data, relay wire format, origin policy, or client credential storage changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` and `pichamber-change-discipline` | Changes executable server auth and an external realtime contract. | Kept the fix in the owning auth module, preserved failure behavior and identity, added restart regression coverage, updated owning docs, and ran focused plus repository-wide validation. |
| `ui-api-decoupling` with `browser-assets-and-auth.md` and `implementation-map.md` | Browser WebSockets authenticate through short-lived URL-scoped tokens. | Keeps token minting at `/auth/url-token`, retains the 60-second lifetime and explicit path gate, and does not put bearer credentials in URLs. |
| `relay-transport` | Terminal and dictation WebSockets also use the shared relay transport. | Does not change paths, origins, tunnel routing, or codecs. The same URL token remains valid through direct and relay auth gates. Relay cross-compat tests pass. |
| `packages/web/README.md`, `ui-auth/DOCUMENTATION.md`, terminal and STT `DOCUMENTATION.md` | These define the server and realtime authentication contracts. | Updated the URL-token restart invariant while preserving documented terminal/STT ownership and allowlists. |

## Validation

| Check | Result |
|---|---|
| Regression test before fix | `bun test packages/web/server/lib/ui-auth/ui-auth.test.js` failed because a token minted before auth-controller restart resolved to `null`. |
| Focused auth, terminal, and relay tests | `bun test packages/web/server/lib/ui-auth/ui-auth.test.js packages/web/server/lib/terminal/runtime.test.js packages/web/server/lib/terminal/terminal-ws-protocol.test.js packages/web/server/lib/relay/cross-compat.test.js`: 51 passed, 0 failed. |
| Full test suite | `bun run test`: passed. UI reported 2046 tests passed; web and Electron suites also passed. |
| Workspace type-check | `bun run type-check`: all four workspaces exited 0. |
| Workspace lint | `bun run lint`: all four workspaces exited 0. |
| Workspace build | `bun run build`: passed. Vite emitted only existing chunk-size warnings. |
| Server JS syntax | `node --check packages/web/server/lib/ui-auth/ui-auth.js`: passed. |
| Documentation | `bun run docs:validate`: passed, 8 pages and 8 sidebar links. |
| Diff hygiene | `git diff --check origin/main...HEAD`: passed. |

No manual browser restart test was run. The regression test recreates the real `createUiAuth` controller, mints through `handleUrlAuthToken`, and validates the same `ensureSessionToken` gate used by both WebSocket upgrades after restart.

## Visual evidence

No visual change. The diff only changes server-side URL-token encoding and verification; it does not alter rendered UI, copy, styling, layout, or interaction states.

## Risks and failure behavior

- URL tokens remain valid for only 60 seconds and only on the existing terminal, dictation, and readable event allowlists.
- Tokens use authenticated encryption so the embedded session identity is not readable or forgeable from the URL.
- Ordinary restart retains validity because the server reuses its persisted JWT secret. Global sign-out rotates that secret, so prior tokens fail closed with the existing 401 behavior.
- Existing pre-fix random URL tokens cannot be verified after deploying this change. Clients already clear a pre-open failed token, mint a current token, and reconnect.
- Rollback returns to in-memory URL tokens. Tokens minted by this version then fail closed and clients remint against the rolled-back server.
