### PR TITLE
Add Electron process performance recording

### DIFF
--- a/packages/electron/README.md
+++ b/packages/electron/README.md
@@ -8,6 +8,12 @@ Electron is PiChamber's native desktop shell for macOS, Windows, and Linux.
 
 The preload bridge exposes only desktop-owned capabilities. Main-process handlers enforce every privileged action; remote pages do not receive local filesystem, shell, token, or host privileges.
 
+## Process performance recording
+
+Settings → General → Diagnostics can enable local Electron process recording. The main process samples Electron CPU and memory metrics, its Node heap, and the web-contents count every 10 seconds. It writes newline-delimited JSON under `<userData>/performance` and resumes recording after restart until disabled. Records contain aggregate process data only; they must never include session IDs, paths, URLs, credentials, prompts, filenames, or message content.
+
+`process-performance-recorder.mjs` owns sampling and file output. The renderer may only get or set the enabled state through local-origin-gated desktop IPC.
+
 ## Development
 
 ```bash

--- a/packages/electron/main.mjs
+++ b/packages/electron/main.mjs
@@ -18,6 +18,7 @@ import {
 } from './startup-url-selection.mjs';
 import { sanitizeRuntimeRequestHeaders } from './runtime-request-headers.mjs';
 import { resolveElectronUpdaterVersion } from './app-version.mjs';
+import { createProcessPerformanceRecorder } from './process-performance-recorder.mjs';
 import { assertUpdaterCapability } from './updater-capability.mjs';
 import { checkForDesktopUpdate } from './updater-check.mjs';
 import { resolveUpdaterChannel } from './updater-channel.mjs';
@@ -276,6 +277,26 @@ const state = {
   keepAwakeBlockerId: null,
 };
 
+const processPerformanceRecorder = createProcessPerformanceRecorder({
+  outputDirectory: path.join(app.getPath('userData'), 'performance'),
+  appMetadata: {
+    version: APP_VERSION,
+    platform: process.platform,
+    arch: process.arch,
+    packaged: app.isPackaged,
+  },
+  getProcessMetrics: () => app.getAppMetrics(),
+  getMainMemoryUsage: () => process.memoryUsage(),
+  getWebContentsCount: () => webContents.getAllWebContents().filter((contents) => !contents.isDestroyed()).length,
+  logger: log,
+});
+
+const readProcessPerformanceRecordingStatus = () => ({
+  supported: true,
+  enabled: readSettingsRoot().desktopProcessPerformanceRecordingEnabled === true,
+  active: processPerformanceRecorder.isActive(),
+});
+
 const setDesktopKeepAwakeActive = (enabled) => {
   const currentId = state.keepAwakeBlockerId;
   const isActive = Number.isInteger(currentId) && powerSaveBlocker.isStarted(currentId);
@@ -338,6 +359,7 @@ const shutdownBackgroundServices = () => {
   if (state.backgroundShutdownComplete) return;
   state.backgroundShutdownComplete = true;
   setDesktopKeepAwakeActive(false);
+  processPerformanceRecorder.stop();
   if (state.installingUpdate) return;
   killSidecar();
 };
@@ -3556,6 +3578,30 @@ const handleInvoke = async (browserWindow, command, args = {}) => {
       return { supported: true, enabled, active };
     }
 
+    case 'desktop_get_process_performance_recording': {
+      return readProcessPerformanceRecordingStatus();
+    }
+
+    case 'desktop_set_process_performance_recording': {
+      const enabled = args.enabled === true;
+      await mutateSettingsRoot((root) => {
+        root.desktopProcessPerformanceRecordingEnabled = enabled;
+      });
+
+      if (!enabled) {
+        processPerformanceRecorder.stop();
+        return readProcessPerformanceRecordingStatus();
+      }
+
+      const result = await processPerformanceRecorder.start();
+      if (!result.active) {
+        await mutateSettingsRoot((root) => {
+          root.desktopProcessPerformanceRecordingEnabled = false;
+        });
+      }
+      return readProcessPerformanceRecordingStatus();
+    }
+
     case 'desktop_browser_capture_page': {
       const wcId = Number.isFinite(args.webContentsId) ? Math.trunc(args.webContentsId) : null;
       if (wcId === null || wcId < 0) throw new Error('webContentsId is required');
@@ -4946,6 +4992,9 @@ app.whenReady().then(async () => {
     isBackgroundStart,
     loginItemSettings,
   });
+  if (readSettingsRoot().desktopProcessPerformanceRecordingEnabled === true) {
+    await processPerformanceRecorder.start();
+  }
   nativeTheme.themeSource = readThemeSource();
   registerPackagedUiProtocol();
   setupAutoUpdater();

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -36,7 +36,7 @@
     "bundle:main": "bun ./scripts/bundle-main.mjs",
     "generate:macos-icon": "node ./scripts/generate-macos-icon-assets.cjs",
     "rebuild:native": "node ./scripts/rebuild-native.mjs",
-    "test:architecture": "node --test ./startup-url-selection.test.mjs ./scripts/target-architecture.test.mjs ./scripts/verify-update-manifest.test.mjs ./scripts/ensure-electron.test.mjs ./path-open-utils.test.mjs",
+    "test:architecture": "node --test ./startup-url-selection.test.mjs ./scripts/target-architecture.test.mjs ./scripts/verify-update-manifest.test.mjs ./scripts/ensure-electron.test.mjs ./path-open-utils.test.mjs ./process-performance-recorder.test.mjs",
     "test:updater": "node --test ./app-version.test.mjs ./updater-capability.test.mjs ./updater-channel.test.mjs ./updater-check.test.mjs ./updater-feed.test.mjs ./scripts/finalize-latest-yml.test.mjs ./scripts/updater-e2e-fixture.test.mjs",
     "test:linux-desktop": "node --test ./linux-autostart.test.mjs && node ./scripts/smoke-linux-app-discovery.mjs && node ./scripts/smoke-path-open-utils.mjs",
     "updater:e2e:fixture": "node ./scripts/updater-e2e-fixture.mjs",

--- a/packages/electron/process-performance-recorder.mjs
+++ b/packages/electron/process-performance-recorder.mjs
@@ -1,0 +1,173 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const KIBIBYTE = 1024;
+const DEFAULT_SAMPLE_INTERVAL_MS = 10_000;
+
+const finiteNumberOrNull = (value) => (
+  typeof value === 'number' && Number.isFinite(value) ? value : null
+);
+
+const kibibytesToBytes = (value) => {
+  const number = finiteNumberOrNull(value);
+  return number === null ? null : Math.round(number * KIBIBYTE);
+};
+
+const sanitizeProcessMetric = (metric) => ({
+  pid: finiteNumberOrNull(metric?.pid),
+  type: typeof metric?.type === 'string' ? metric.type : 'unknown',
+  cpu: {
+    percent: finiteNumberOrNull(metric?.cpu?.percentCPUUsage),
+    idleWakeupsPerSecond: finiteNumberOrNull(metric?.cpu?.idleWakeupsPerSecond),
+  },
+  memory: {
+    workingSetBytes: kibibytesToBytes(metric?.memory?.workingSetSize),
+    peakWorkingSetBytes: kibibytesToBytes(metric?.memory?.peakWorkingSetSize),
+    privateBytes: kibibytesToBytes(metric?.memory?.privateBytes),
+  },
+});
+
+const sanitizeMainMemory = (memory) => ({
+  rssBytes: finiteNumberOrNull(memory?.rss),
+  heapTotalBytes: finiteNumberOrNull(memory?.heapTotal),
+  heapUsedBytes: finiteNumberOrNull(memory?.heapUsed),
+  externalBytes: finiteNumberOrNull(memory?.external),
+  arrayBuffersBytes: finiteNumberOrNull(memory?.arrayBuffers),
+});
+
+export const buildProcessPerformanceSample = ({
+  recordedAt,
+  elapsedMs,
+  appMetadata,
+  processMetrics,
+  mainMemory,
+  webContentsCount,
+}) => {
+  const processes = Array.isArray(processMetrics)
+    ? processMetrics.map(sanitizeProcessMetric)
+    : [];
+  const measuredWorkingSets = processes
+    .map((processMetric) => processMetric.memory.workingSetBytes)
+    .filter((value) => value !== null);
+  const totalWorkingSetBytes = measuredWorkingSets.length > 0
+    ? measuredWorkingSets.reduce((total, value) => total + value, 0)
+    : null;
+
+  return {
+    schemaVersion: 1,
+    kind: 'process-performance-sample',
+    recordedAt,
+    elapsedMs: Math.max(0, finiteNumberOrNull(elapsedMs) ?? 0),
+    app: {
+      version: typeof appMetadata?.version === 'string' ? appMetadata.version : 'unknown',
+      platform: typeof appMetadata?.platform === 'string' ? appMetadata.platform : 'unknown',
+      arch: typeof appMetadata?.arch === 'string' ? appMetadata.arch : 'unknown',
+      packaged: appMetadata?.packaged === true,
+    },
+    webContentsCount: Math.max(0, finiteNumberOrNull(webContentsCount) ?? 0),
+    totalWorkingSetBytes,
+    mainMemory: sanitizeMainMemory(mainMemory),
+    processes,
+  };
+};
+
+export const createProcessPerformanceRecorder = ({
+  outputDirectory,
+  appMetadata,
+  getProcessMetrics,
+  getMainMemoryUsage,
+  getWebContentsCount,
+  logger = console,
+  sampleIntervalMs = DEFAULT_SAMPLE_INTERVAL_MS,
+  now = () => new Date(),
+  monotonicNow = () => performance.now(),
+  createWriteStream = fs.createWriteStream,
+  makeDirectory = fs.mkdirSync,
+  setIntervalFn = setInterval,
+  clearIntervalFn = clearInterval,
+}) => {
+  let stream = null;
+  let timer = null;
+  let startedAt = 0;
+  let outputPath = null;
+  let active = false;
+
+  const stopAfterError = (error) => {
+    logger.error?.('[performance] process recorder stopped after a write failure', error);
+    active = false;
+    if (timer !== null) clearIntervalFn(timer);
+    timer = null;
+    const failedStream = stream;
+    stream = null;
+    failedStream?.destroy();
+  };
+
+  const capture = () => {
+    if (!active || !stream) return;
+    try {
+      const sample = buildProcessPerformanceSample({
+        recordedAt: now().toISOString(),
+        elapsedMs: monotonicNow() - startedAt,
+        appMetadata,
+        processMetrics: getProcessMetrics(),
+        mainMemory: getMainMemoryUsage(),
+        webContentsCount: getWebContentsCount(),
+      });
+      stream.write(`${JSON.stringify(sample)}\n`);
+    } catch (error) {
+      stopAfterError(error);
+    }
+  };
+
+  const start = async () => {
+    if (active) return { active: true, outputPath };
+
+    try {
+      makeDirectory(outputDirectory, { recursive: true, mode: 0o700 });
+      const timestamp = now().toISOString().replace(/[:.]/g, '-');
+      outputPath = path.join(outputDirectory, `process-performance-${timestamp}.ndjson`);
+      stream = createWriteStream(outputPath, { flags: 'wx', mode: 0o600 });
+      await new Promise((resolve, reject) => {
+        const handleOpenError = (error) => reject(error);
+        stream.once('error', handleOpenError);
+        stream.once('open', () => {
+          stream.off('error', handleOpenError);
+          resolve();
+        });
+      });
+      stream.on('error', stopAfterError);
+      startedAt = monotonicNow();
+      active = true;
+      capture();
+      timer = setIntervalFn(capture, sampleIntervalMs);
+      timer?.unref?.();
+      logger.info?.(`[performance] recording Electron process metrics to ${outputPath}`);
+      return { active: true, outputPath };
+    } catch (error) {
+      active = false;
+      stream?.destroy();
+      stream = null;
+      outputPath = null;
+      logger.error?.('[performance] failed to start process recorder', error);
+      return { active: false, outputPath: null };
+    }
+  };
+
+  const stop = () => {
+    if (timer !== null) clearIntervalFn(timer);
+    timer = null;
+    const currentStream = stream;
+    stream = null;
+    const wasActive = active;
+    active = false;
+    currentStream?.end();
+    if (wasActive) logger.info?.('[performance] stopped recording Electron process metrics');
+  };
+
+  return {
+    start,
+    stop,
+    isActive: () => active,
+    getOutputPath: () => outputPath,
+  };
+};

--- a/packages/electron/process-performance-recorder.test.mjs
+++ b/packages/electron/process-performance-recorder.test.mjs
@@ -1,0 +1,167 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import test from 'node:test';
+
+import {
+  buildProcessPerformanceSample,
+  createProcessPerformanceRecorder,
+} from './process-performance-recorder.mjs';
+
+test('buildProcessPerformanceSample reports process memory in bytes without sensitive fields', () => {
+  const sample = buildProcessPerformanceSample({
+    recordedAt: '2026-01-02T03:04:05.000Z',
+    elapsedMs: 1250,
+    appMetadata: { version: '1.2.3', platform: 'win32', arch: 'x64', packaged: true },
+    processMetrics: [{
+      pid: 42,
+      type: 'Tab',
+      cpu: { percentCPUUsage: 7.5, idleWakeupsPerSecond: 2 },
+      memory: { workingSetSize: 100, peakWorkingSetSize: 150, privateBytes: 80 },
+      serviceName: 'must-not-be-recorded',
+    }],
+    mainMemory: {
+      rss: 5000,
+      heapTotal: 4000,
+      heapUsed: 3000,
+      external: 2000,
+      arrayBuffers: 1000,
+    },
+    webContentsCount: 3,
+  });
+
+  assert.equal(sample.totalWorkingSetBytes, 100 * 1024);
+  assert.deepEqual(sample.processes[0], {
+    pid: 42,
+    type: 'Tab',
+    cpu: { percent: 7.5, idleWakeupsPerSecond: 2 },
+    memory: {
+      workingSetBytes: 100 * 1024,
+      peakWorkingSetBytes: 150 * 1024,
+      privateBytes: 80 * 1024,
+    },
+  });
+  assert.deepEqual(sample.mainMemory, {
+    rssBytes: 5000,
+    heapTotalBytes: 4000,
+    heapUsedBytes: 3000,
+    externalBytes: 2000,
+    arrayBuffersBytes: 1000,
+  });
+  assert.equal(JSON.stringify(sample).includes('must-not-be-recorded'), false);
+
+  const unavailableMemory = buildProcessPerformanceSample({
+    recordedAt: '2026-01-02T03:04:05.000Z',
+    elapsedMs: 0,
+    appMetadata: {},
+    processMetrics: [{ pid: 43, type: 'GPU' }],
+    mainMemory: {},
+    webContentsCount: 0,
+  });
+  assert.equal(unavailableMemory.totalWorkingSetBytes, null);
+});
+
+test('process performance recorder starts, samples immediately, and stops cleanly', async () => {
+  const writes = [];
+  let ended = false;
+  let scheduledCapture = null;
+  let clearedTimer = null;
+  const stream = new EventEmitter();
+  stream.write = (value) => { writes.push(value); };
+  stream.end = () => { ended = true; };
+  stream.destroy = () => {};
+  const timer = { unref() {} };
+
+  const recorder = createProcessPerformanceRecorder({
+    outputDirectory: '/tmp/pichamber-performance-test',
+    appMetadata: { version: '1.2.3', platform: 'win32', arch: 'x64', packaged: true },
+    getProcessMetrics: () => [],
+    getMainMemoryUsage: () => ({ rss: 1 }),
+    getWebContentsCount: () => 1,
+    logger: { info() {}, error() {} },
+    now: () => new Date('2026-01-02T03:04:05.000Z'),
+    monotonicNow: () => 10,
+    makeDirectory() {},
+    createWriteStream: () => {
+      queueMicrotask(() => stream.emit('open'));
+      return stream;
+    },
+    setIntervalFn: (capture) => {
+      scheduledCapture = capture;
+      return timer;
+    },
+    clearIntervalFn: (value) => { clearedTimer = value; },
+  });
+
+  const status = await recorder.start();
+  assert.equal(status.active, true);
+  assert.match(status.outputPath, /process-performance-2026-01-02T03-04-05-000Z\.ndjson$/);
+  assert.equal(writes.length, 1);
+
+  scheduledCapture();
+  assert.equal(writes.length, 2);
+
+  recorder.stop();
+  assert.equal(recorder.isActive(), false);
+  assert.equal(clearedTimer, timer);
+  assert.equal(ended, true);
+});
+
+test('process performance recorder closes its stream after a later write failure', async () => {
+  let destroyed = false;
+  let clearedTimer = null;
+  const stream = new EventEmitter();
+  stream.write = () => {};
+  stream.end = () => {};
+  stream.destroy = () => { destroyed = true; };
+  const timer = { unref() {} };
+
+  const recorder = createProcessPerformanceRecorder({
+    outputDirectory: '/tmp/pichamber-performance-test',
+    appMetadata: {},
+    getProcessMetrics: () => [],
+    getMainMemoryUsage: () => ({}),
+    getWebContentsCount: () => 0,
+    logger: { info() {}, error() {} },
+    makeDirectory() {},
+    createWriteStream: () => {
+      queueMicrotask(() => stream.emit('open'));
+      return stream;
+    },
+    setIntervalFn: () => timer,
+    clearIntervalFn: (value) => { clearedTimer = value; },
+  });
+
+  await recorder.start();
+  stream.emit('error', new Error('disk full'));
+
+  assert.equal(recorder.isActive(), false);
+  assert.equal(destroyed, true);
+  assert.equal(clearedTimer, timer);
+});
+
+test('process performance recorder stays inactive when the output file cannot open', async () => {
+  const errors = [];
+  const stream = new EventEmitter();
+  stream.destroy = () => {};
+
+  const recorder = createProcessPerformanceRecorder({
+    outputDirectory: '/tmp/pichamber-performance-test',
+    appMetadata: {},
+    getProcessMetrics: () => [],
+    getMainMemoryUsage: () => ({}),
+    getWebContentsCount: () => 0,
+    logger: { info() {}, error(...args) { errors.push(args); } },
+    makeDirectory() {},
+    createWriteStream: () => {
+      queueMicrotask(() => stream.emit('error', new Error('disk full')));
+      return stream;
+    },
+    setIntervalFn: () => {
+      throw new Error('timer must not start');
+    },
+  });
+
+  assert.deepEqual(await recorder.start(), { active: false, outputPath: null });
+  assert.equal(recorder.isActive(), false);
+  assert.equal(errors.length, 1);
+});

--- a/packages/ui/src/components/sections/pichamber/PiChamberVisualSettings.tsx
+++ b/packages/ui/src/components/sections/pichamber/PiChamberVisualSettings.tsx
@@ -5,8 +5,11 @@ import { useThemeSystem } from '@/contexts/useThemeSystem';
 import { useUIStore } from '@/stores/useUIStore';
 import { useMessageQueueStore } from '@/stores/messageQueueStore';
 import {
+    getDesktopProcessPerformanceRecording,
+    isDesktopLocalOriginActive,
     isDesktopShell,
     isWebRuntime,
+    setDesktopProcessPerformanceRecording,
     usesFramelessElectronChrome,
     type DesktopWindowControlsPosition,
     type DesktopWindowControlsStyle,
@@ -160,6 +163,12 @@ export const PiChamberVisualSettings: React.FC<PiChamberVisualSettingsProps> = (
     const desktopWindowControlsStyle = useUIStore((state) => state.desktopWindowControlsStyle);
     const setDesktopWindowControlsStyle = useUIStore((state) => state.setDesktopWindowControlsStyle);
     const perfHudEnabled = React.useSyncExternalStore(subscribePerfHudEnabled, isPerfHudEnabled, () => false);
+    const localDesktopDiagnostics = isDesktopShell() && isDesktopLocalOriginActive();
+    const [processRecordingSupported, setProcessRecordingSupported] = React.useState(false);
+    const [processRecordingEnabled, setProcessRecordingEnabled] = React.useState(false);
+    const [processRecordingActive, setProcessRecordingActive] = React.useState(false);
+    const [processRecordingSaving, setProcessRecordingSaving] = React.useState(false);
+    const [processRecordingError, setProcessRecordingError] = React.useState<string | null>(null);
 
     const handleWindowControlsPositionChange = React.useCallback((value: DesktopWindowControlsPosition) => {
         setDesktopWindowControlsPosition(value);
@@ -305,6 +314,75 @@ export const PiChamberVisualSettings: React.FC<PiChamberVisualSettingsProps> = (
         if (!visibleSettings) return true;
         return visibleSettings.includes(setting);
     };
+
+    const showDiagnostics = shouldShow('perfHud');
+
+    React.useEffect(() => {
+        if (!showDiagnostics || !localDesktopDiagnostics) {
+            setProcessRecordingSupported(false);
+            setProcessRecordingEnabled(false);
+            setProcessRecordingActive(false);
+            setProcessRecordingError(null);
+            return;
+        }
+
+        let cancelled = false;
+        void getDesktopProcessPerformanceRecording().then((status) => {
+            if (cancelled) return;
+            setProcessRecordingSupported(status?.supported === true);
+            setProcessRecordingEnabled(status?.enabled === true);
+            setProcessRecordingActive(status?.active === true);
+            setProcessRecordingError(status?.enabled === true && status.active !== true
+                ? 'Recording could not start. Disable it and try again.'
+                : null);
+        });
+        return () => {
+            cancelled = true;
+        };
+    }, [localDesktopDiagnostics, showDiagnostics]);
+
+    React.useEffect(() => {
+        if (!showDiagnostics || !localDesktopDiagnostics || !processRecordingEnabled) return;
+
+        let cancelled = false;
+        const timer = window.setInterval(() => {
+            void getDesktopProcessPerformanceRecording().then((status) => {
+                if (cancelled || !status?.supported) return;
+                setProcessRecordingActive(status.active);
+                if (!status.active) {
+                    setProcessRecordingError('Recording stopped after a file write failure. Disable it and try again.');
+                }
+            });
+        }, 10_000);
+        return () => {
+            cancelled = true;
+            window.clearInterval(timer);
+        };
+    }, [localDesktopDiagnostics, processRecordingEnabled, showDiagnostics]);
+
+    const handleProcessRecordingEnabledChange = React.useCallback(async (enabled: boolean) => {
+        if (!processRecordingSupported || processRecordingSaving) return;
+
+        const previousEnabled = processRecordingEnabled;
+        const previousActive = processRecordingActive;
+        setProcessRecordingEnabled(enabled);
+        setProcessRecordingSaving(true);
+        setProcessRecordingError(null);
+        try {
+            const status = await setDesktopProcessPerformanceRecording(enabled);
+            if (!status?.supported || status.enabled !== enabled || (enabled && !status.active)) {
+                throw new Error('Failed to update process performance recording');
+            }
+            setProcessRecordingEnabled(status.enabled);
+            setProcessRecordingActive(status.active);
+        } catch {
+            setProcessRecordingEnabled(previousEnabled);
+            setProcessRecordingActive(previousActive);
+            setProcessRecordingError('Failed to update process performance recording.');
+        } finally {
+            setProcessRecordingSaving(false);
+        }
+    }, [processRecordingActive, processRecordingEnabled, processRecordingSaving, processRecordingSupported]);
 
     const hasThemeSettings = shouldShow('theme');
     const showWindowControlsPositionSetting = shouldShow('windowControlsPosition') && showWindowControlsPosition;
@@ -697,6 +775,12 @@ export const PiChamberVisualSettings: React.FC<PiChamberVisualSettingsProps> = (
                     <DiagnosticsSection
                         perfHudEnabled={perfHudEnabled}
                         onPerfHudEnabledChange={setPerfHudEnabled}
+                        processRecordingSupported={processRecordingSupported}
+                        processRecordingEnabled={processRecordingEnabled}
+                        processRecordingActive={processRecordingActive}
+                        processRecordingSaving={processRecordingSaving}
+                        processRecordingError={processRecordingError}
+                        onProcessRecordingEnabledChange={handleProcessRecordingEnabledChange}
                     />
                 )}
 

--- a/packages/ui/src/components/sections/pichamber/visual/DiagnosticsSection.tsx
+++ b/packages/ui/src/components/sections/pichamber/visual/DiagnosticsSection.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {
+  SETTINGS_OPTION_STACK_CLASS,
   SettingsCheckboxRow,
   SettingsSection,
 } from '@/components/sections/shared/SettingsSection';
@@ -8,14 +9,26 @@ import {
 export interface DiagnosticsSectionProps {
   perfHudEnabled: boolean;
   onPerfHudEnabledChange: (enabled: boolean) => void;
+  processRecordingSupported: boolean;
+  processRecordingEnabled: boolean;
+  processRecordingActive: boolean;
+  processRecordingSaving: boolean;
+  processRecordingError: string | null;
+  onProcessRecordingEnabledChange: (enabled: boolean) => void;
 }
 
 export const DiagnosticsSection: React.FC<DiagnosticsSectionProps> = ({
   perfHudEnabled,
   onPerfHudEnabledChange,
+  processRecordingSupported,
+  processRecordingEnabled,
+  processRecordingActive,
+  processRecordingSaving,
+  processRecordingError,
+  onProcessRecordingEnabledChange,
 }) => {
   return (
-    <SettingsSection title={'Diagnostics'}>
+    <SettingsSection title={'Diagnostics'} contentClassName={SETTINGS_OPTION_STACK_CLASS}>
       <SettingsCheckboxRow
         checked={perfHudEnabled}
         onChange={onPerfHudEnabledChange}
@@ -26,6 +39,22 @@ export const DiagnosticsSection: React.FC<DiagnosticsSectionProps> = ({
         ariaLabel={'Performance overlay'}
         settingsItem="general.performance-overlay"
       />
+      {processRecordingSupported ? (
+        <SettingsCheckboxRow
+          checked={processRecordingEnabled}
+          onChange={onProcessRecordingEnabledChange}
+          disabled={processRecordingSaving}
+          label={'Record Electron process performance'}
+          info={
+            'Samples CPU and memory for Electron processes every 10 seconds and writes a local diagnostics file. Recording continues after restart until disabled.'
+          }
+          description={processRecordingError ?? (processRecordingEnabled && !processRecordingActive
+            ? 'Recording could not start. Disable it and try again.'
+            : undefined)}
+          ariaLabel={'Record Electron process performance'}
+          settingsItem="general.process-performance-recording"
+        />
+      ) : null}
     </SettingsSection>
   );
 };

--- a/packages/ui/src/lib/desktop.test.ts
+++ b/packages/ui/src/lib/desktop.test.ts
@@ -1,6 +1,66 @@
 import { describe, expect, test } from 'bun:test';
 
-import { isBrowserClientRuntime } from './desktop';
+import {
+  getDesktopProcessPerformanceRecording,
+  isBrowserClientRuntime,
+  setDesktopProcessPerformanceRecording,
+} from './desktop';
+
+const withLocalDesktopBridge = async <T>(
+  invoke: (command: string, args: Record<string, unknown>) => unknown,
+  run: () => Promise<T>,
+): Promise<T> => {
+  const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: {
+      __PICHAMBER_ELECTRON__: { runtime: 'electron' },
+      __PICHAMBER_DESKTOP__: { invoke },
+      location: { origin: 'http://127.0.0.1:57123' },
+    },
+  });
+  try {
+    return await run();
+  } finally {
+    if (previousWindow) {
+      Object.defineProperty(globalThis, 'window', previousWindow);
+    } else {
+      Reflect.deleteProperty(globalThis, 'window');
+    }
+  }
+};
+
+describe('desktop process performance recording', () => {
+  test('reads and updates recording through the desktop bridge', async () => {
+    const calls: Array<{ command: string; args: Record<string, unknown> }> = [];
+    await withLocalDesktopBridge((command, args) => {
+      calls.push({ command, args });
+      return { supported: true, enabled: command.startsWith('desktop_set'), active: command.startsWith('desktop_set') };
+    }, async () => {
+      expect(await getDesktopProcessPerformanceRecording()).toEqual({
+        supported: true,
+        enabled: false,
+        active: false,
+      });
+      expect(await setDesktopProcessPerformanceRecording(true)).toEqual({
+        supported: true,
+        enabled: true,
+        active: true,
+      });
+    });
+
+    expect(calls).toEqual([
+      { command: 'desktop_get_process_performance_recording', args: {} },
+      { command: 'desktop_set_process_performance_recording', args: { enabled: true } },
+    ]);
+  });
+
+  test('rejects malformed recorder status', async () => {
+    await withLocalDesktopBridge(() => ({ supported: true, enabled: true }), async () => {
+      expect(await getDesktopProcessPerformanceRecording()).toBeNull();
+    });
+  });
+});
 
 describe('browser client runtime', () => {
   test('uses browser file behavior only outside the Electron shell', () => {

--- a/packages/ui/src/lib/desktopSystemActions.ts
+++ b/packages/ui/src/lib/desktopSystemActions.ts
@@ -11,6 +11,7 @@ import type {
   KeepAwakeStatus,
   LaunchAtLoginStatus,
   MinimizeToTrayStatus,
+  ProcessPerformanceRecordingStatus,
   UpdateInfo,
   UpdateProgress,
 } from './desktopTypes';
@@ -113,6 +114,40 @@ export const setDesktopKeepAwake = async (enabled: boolean): Promise<KeepAwakeSt
     return result;
   } catch (error) {
     console.warn('Failed to set keep awake status', error);
+    return null;
+  }
+};
+
+export const getDesktopProcessPerformanceRecording = async (): Promise<ProcessPerformanceRecordingStatus | null> => {
+  if (!canUseElectronDesktopIPC() || !isDesktopLocalOriginActive()) {
+    return null;
+  }
+
+  try {
+    const result = await invokeDesktop<ProcessPerformanceRecordingStatus>('desktop_get_process_performance_recording');
+    if (!result || typeof result.supported !== 'boolean' || typeof result.enabled !== 'boolean' || typeof result.active !== 'boolean') {
+      return null;
+    }
+    return result;
+  } catch (error) {
+    console.warn('Failed to get process performance recording status', error);
+    return null;
+  }
+};
+
+export const setDesktopProcessPerformanceRecording = async (enabled: boolean): Promise<ProcessPerformanceRecordingStatus | null> => {
+  if (!canUseElectronDesktopIPC() || !isDesktopLocalOriginActive()) {
+    return null;
+  }
+
+  try {
+    const result = await invokeDesktop<ProcessPerformanceRecordingStatus>('desktop_set_process_performance_recording', { enabled });
+    if (!result || typeof result.supported !== 'boolean' || typeof result.enabled !== 'boolean' || typeof result.active !== 'boolean') {
+      return null;
+    }
+    return result;
+  } catch (error) {
+    console.warn('Failed to set process performance recording status', error);
     return null;
   }
 };

--- a/packages/ui/src/lib/desktopTypes.ts
+++ b/packages/ui/src/lib/desktopTypes.ts
@@ -46,6 +46,7 @@ export type DesktopSettings = {
   homeDirectory?: string;
   desktopLanAccessEnabled?: boolean;
   desktopKeepAwakeEnabled?: boolean;
+  desktopProcessPerformanceRecordingEnabled?: boolean;
   desktopMinimizeToTrayEnabled?: boolean;
   desktopMacMenuBarEnabled?: boolean;
   desktopUiPassword?: string;
@@ -205,6 +206,12 @@ export type KeepAwakeStatus = {
 export type MinimizeToTrayStatus = {
   supported: boolean;
   enabled: boolean;
+};
+
+export type ProcessPerformanceRecordingStatus = {
+  supported: boolean;
+  enabled: boolean;
+  active: boolean;
 };
 
 export type InstalledDesktopAppInfo = {

--- a/packages/ui/src/lib/persistence/settingsSanitizers.ts
+++ b/packages/ui/src/lib/persistence/settingsSanitizers.ts
@@ -98,6 +98,9 @@ export const sanitizeWebSettings = (payload: unknown): DesktopSettings | null =>
   if (typeof candidate.desktopKeepAwakeEnabled === 'boolean') {
     result.desktopKeepAwakeEnabled = candidate.desktopKeepAwakeEnabled;
   }
+  if (typeof candidate.desktopProcessPerformanceRecordingEnabled === 'boolean') {
+    result.desktopProcessPerformanceRecordingEnabled = candidate.desktopProcessPerformanceRecordingEnabled;
+  }
   if (typeof candidate.desktopMinimizeToTrayEnabled === 'boolean') {
     result.desktopMinimizeToTrayEnabled = candidate.desktopMinimizeToTrayEnabled;
   }

--- a/packages/ui/src/lib/settings/search.ts
+++ b/packages/ui/src/lib/settings/search.ts
@@ -193,6 +193,14 @@ const SETTINGS_SEARCH_ITEMS: readonly SettingsSearchItem[] = [
     keywords: ['fps', 'performance', 'hud', 'diagnostics', 'debug', 'jank', 'frame'],
   },
   {
+    id: 'general.process-performance-recording',
+    page: 'general',
+    title: "Record Electron process performance",
+    description: "Record Electron process CPU and memory samples to a local diagnostics file.",
+    keywords: ['performance', 'diagnostics', 'memory', 'cpu', 'electron', 'process', 'recording'],
+    isAvailable: (ctx) => ctx.isDesktopLocalOrigin,
+  },
+  {
     id: 'chat.reasoning-traces',
     page: 'chat',
     title: "Show Reasoning Traces",


### PR DESCRIPTION
## Intent

Add a small, opt-in Electron process performance recorder that can be enabled from Settings → General → Diagnostics. It samples Electron process CPU and memory, main-process Node memory, and web-contents count every 10 seconds, then writes local NDJSON records for investigating sustained CPU and memory growth.

The setting starts and stops recording without a relaunch, persists across restarts, and reports output failures while the Settings page is open.

## Non-goals

- This does not upload telemetry or add a remote analytics backend.
- This does not identify individual JavaScript functions or React renders; the existing CDP profilers remain responsible for detailed attribution.
- This does not set performance budgets or claim a memory/CPU improvement.
- This does not add charts, file management, or an analyzer for the generated NDJSON.

## Affected surfaces

- `packages/electron`: adds the recorder, local-origin-gated IPC control, persisted startup behavior, shutdown cleanup, and focused tests.
- `packages/ui`: adds the desktop-only Diagnostics setting, IPC helpers/types, settings search registration, persistence sanitization, and visible failure state.
- Persisted contract: adds optional `desktopProcessPerformanceRecordingEnabled`; missing values remain disabled.
- Web, hosted mobile, and Capacitor are unchanged. The control only renders for the local Electron runtime, and privileged commands are not in `COMMANDS_SAFE_FOR_REMOTE`.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` and `pichamber-change-discipline` | Source, persisted-setting, module, and cross-process changes | Kept the recorder in a focused Electron module, preserved missing-setting compatibility, added failure/cleanup tests, updated owning docs, and ran broad validation. |
| `performance-engineering` and `scripts/perf/DOCUMENTATION.md` | Adds performance instrumentation | Recorder is disabled by default, records explicit unavailable values as `null`, samples at a bounded 10-second interval, and does not replace the existing scenario profilers. |
| `desktop-shell` and `packages/electron/README.md` | Changes Electron main process and IPC | Main owns native metrics and files; renderer receives only get/set status. Commands remain local-origin gated, and shutdown closes the recorder. |
| `settings-ui-patterns` layout/controls/search references | Adds a stable Settings control | Uses `SettingsSection` and `SettingsCheckboxRow`, keeps explanatory text in `info`, shows failures as status text, and registers a matching conditional search anchor. |
| `theme-system` and `locale-ui-patterns` | Adds a visible control and copy | Reuses shared controls with no new colors/icons and provides direct visible and accessible text. |
| `ui-api-decoupling` runtime parity/implementation map | Crosses the Electron privilege seam | Uses the established preload IPC path, double-gates local desktop access, and explicitly leaves non-Electron runtimes unsupported and hidden. |

## Validation

| Check | Result |
|---|---|
| `bun run test` | Passed on final HEAD: 2,053 UI tests, 43 Electron architecture tests, and 20 Electron updater tests, plus the web suite. One earlier run hit the existing relay handshake-timeout timing test; the focused test and final full rerun passed. |
| `bun run type-check` | Passed for web, UI, Electron, and mobile. |
| `bun run lint` | Passed for web, UI, Electron, and mobile. |
| `bun run --cwd packages/electron bundle:main` | Passed; bundled `main.mjs` successfully. |
| `bun run dead-code` | Completed; report contained existing unused exports/types and no new recorder finding. |
| Two-axis code review against `origin/main` | Standards review found no documented-standard blocker; spec review found one stream-cleanup/live-failure issue, which was fixed and re-reviewed with no blockers. |
| Packaged Windows runtime | Not run. The agent is operating inside WSL through the active Windows-hosted PiChamber session; launching another Electron/server instance interfered with that session, so runtime launch testing was stopped at the maintainer's request. |

## Visual evidence

Before: the Diagnostics section only contains the existing Performance overlay control.

After: the local Electron Diagnostics section also contains `Record Electron process performance`, with an info hint, disabled state while saving, and visible file-write failure text.

Screenshots were not captured. The work is running inside WSL through the active Windows-hosted PiChamber server, and launching a second Electron instance stopped/interfered with the active Pi session. Per maintainer request, no further runtime launch was attempted. Web/mobile do not render this Electron-only control.

## Risks and failure behavior

- Output files can grow during long recordings. At one compact sample every 10 seconds, growth is bounded by sample frequency but files are not rotated in this first version.
- Output creation failure leaves recording disabled and rolls back the persisted setting. Later stream errors clear the interval, destroy the stream, and appear in Settings on its 10-second status poll.
- Shutdown clears the timer and ends the output stream. A completed recording remains local under `<userData>/performance`.
- Records allow-list aggregate process fields only. They omit URLs, paths, session IDs, filenames, prompts, messages, credentials, and Electron service names.
- Platform metric availability varies. Missing memory values are written as `null`, not a misleading zero.
