### PR TITLE
feat(ui): promote git history and graph to dedicated sidebar buttons

### DIFF
--- a/packages/ui/src/components/views/git/GitHeader.tsx
+++ b/packages/ui/src/components/views/git/GitHeader.tsx
@@ -281,7 +281,23 @@ export const GitHeader: React.FC<GitHeaderProps> = ({
           <TooltipContent sideOffset={8}>{"History"}</TooltipContent>
         </Tooltip>
       ) : null}
-      {onOpenGraph || onOpenStashes || onOpenUpdateBranch || onOpenReintegrateCommits ? (
+      {onOpenGraph ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8 w-8 px-0"
+              aria-label={"Graph"}
+              onClick={onOpenGraph}
+            >
+              <Icon name="git-branch" className="size-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent sideOffset={8}>{"Graph"}</TooltipContent>
+        </Tooltip>
+      ) : null}
+      {onOpenStashes || onOpenUpdateBranch || onOpenReintegrateCommits ? (
         <DropdownMenu>
           <Tooltip>
             <TooltipTrigger asChild>
@@ -299,12 +315,6 @@ export const GitHeader: React.FC<GitHeaderProps> = ({
             <TooltipContent sideOffset={8}>{"Repository views"}</TooltipContent>
           </Tooltip>
           <DropdownMenuContent align="end">
-            {onOpenGraph ? (
-              <DropdownMenuItem onSelect={onOpenGraph}>
-                <Icon name="git-branch" className="size-4" />
-                {"Graph"}
-              </DropdownMenuItem>
-            ) : null}
             {onOpenStashes ? (
               <DropdownMenuItem onSelect={onOpenStashes}>
                 <Icon name="archive-stack" className="size-4" />

--- a/packages/ui/src/components/views/git/GitHeader.tsx
+++ b/packages/ui/src/components/views/git/GitHeader.tsx
@@ -265,7 +265,23 @@ export const GitHeader: React.FC<GitHeaderProps> = ({
 
   const managementButtons = (
     <div className="flex items-center gap-1 shrink-0">
-      {onOpenHistory || onOpenGraph || onOpenStashes || onOpenUpdateBranch ? (
+      {onOpenHistory ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8 w-8 px-0"
+              aria-label={"History"}
+              onClick={onOpenHistory}
+            >
+              <Icon name="history" className="size-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent sideOffset={8}>{"History"}</TooltipContent>
+        </Tooltip>
+      ) : null}
+      {onOpenGraph || onOpenStashes || onOpenUpdateBranch || onOpenReintegrateCommits ? (
         <DropdownMenu>
           <Tooltip>
             <TooltipTrigger asChild>
@@ -283,12 +299,6 @@ export const GitHeader: React.FC<GitHeaderProps> = ({
             <TooltipContent sideOffset={8}>{"Repository views"}</TooltipContent>
           </Tooltip>
           <DropdownMenuContent align="end">
-            {onOpenHistory ? (
-              <DropdownMenuItem onSelect={onOpenHistory}>
-                <Icon name="history" className="size-4" />
-                {"History"}
-              </DropdownMenuItem>
-            ) : null}
             {onOpenGraph ? (
               <DropdownMenuItem onSelect={onOpenGraph}>
                 <Icon name="git-branch" className="size-4" />


### PR DESCRIPTION
## Intent

Git History and Graph were buried behind the `Repository views` overflow (`more-fill`) in the sidebar Git view, so they were mostly unseen. This promotes both to dedicated header icon buttons next to the overflow, matching the existing `h-8 w-8` ghost button chrome. Clicking them opens the same `history` / `graph` dialogs as before (`setGitLogDialogMode('history' | 'graph')` in `GitView`).

## Non-goals

- No inline history/graph below the changes list (discussed, deferred to a follow-up).
- No changes to `MobileGitChrome` (mobile Changes surface has neither button today; desktop only).
- No changes to Stashes, Update branch, Re-integrate commits behavior or to the History/Graph dialog contents.
- No API, store, or persisted-state changes.

## Affected surfaces

- `packages/ui` only: `src/components/views/git/GitHeader.tsx` (`managementButtons` block).
- User-visible: desktop/web sidebar Git view header (`GitView` desktop chrome). `MobileGitChrome` is unaffected (separate component, no header overflow).
- Runtimes: web, desktop, and hosted mobile share the same `GitHeader`; Capacitor mobile bundles the same web surface. No runtime-specific branching was added.
- Contracts: `GitHeader` props unchanged; same `onOpenHistory` / `onOpenGraph` callbacks, only the trigger chrome changed. No persisted/external contract changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` always-on constraints | Source change in shared UI; must keep changes minimal, preserve unrelated work, no secrets/deps | Single-file, 33+/13- change; no deps, no secrets, no unrelated refactors; kept `Button`/`Icon`/`Tooltip` precedent |
| `pichamber-change-discipline` | Any source/export/build-config change | Smallest complete change; preserved observable behavior (same callbacks/dialogs); classified as local implementation (private header chrome in one package); no export/contract change; focused test + honest validation report below |
| `theme-system` (+ `references/tokens-and-examples.md`, `references/icons.md`) | New buttons, styling, icons | Reused shared `Button` (`ghost`, `sm`, `h-8 w-8 px-0`) matching the existing overflow trigger; reused sprite `Icon` (`history`, `git-branch`, both already in use so no `icons:generate` needed); no hardcoded colors; hover only on interactive buttons |
| `locale-ui-patterns` | New icon-only buttons with tooltips | `aria-label="History"` / `aria-label="Graph"` plus matching `TooltipContent`; labels reuse the exact prior menu copy ("History", "Graph") |
| Nearest docs (`packages/ui/src/components/icon/README.md`, `packages/ui/src/components/session/sidebar/DOCUMENTATION.md`) | Icon contract + sidebar layout context | Followed sprite `Icon` usage (no direct Remix imports, sized via `size-4`); kept header row layout (`flex items-center gap-1 shrink-0`) unchanged |

Note: the overflow visibility condition now includes `onOpenReintegrateCommits` (`onOpenStashes || onOpenUpdateBranch || onOpenReintegrateCommits`). Previously `onOpenReintegrateCommits` alone would render nothing because the guard omitted it while the menu rendered it. This is bundled because the guard had to be rewritten when History/Graph left the menu.

## Validation

| Check | Result |
|---|---|
| `bun test --isolate src/components/views/git/gitStatusPredicates.test.ts` (cwd `packages/ui`) | 3 pass, 0 fail |
| `type-check:ui` / `lint:ui` / `build:ui` | Not runnable in this worktree: incomplete `node_modules` (`Cannot find type definition file for '@types/dom-speech-recognition'`, missing `@eslint/js`, `@base-ui/react/tooltip`, `cmdk`). Same failure exists without this diff (environment, not the change). |
| Manual runtime click-through | Not performed in this environment (no installed deps / dev server). Change is chrome-only; callbacks and dialogs are untouched. |

No new tests: there are no existing `GitHeader` tests, and the change is pure trigger chrome over existing callbacks.

## Visual evidence

No screenshots/recordings attached: this environment cannot run the web HMR/dev server (missing `node_modules` deps listed above), so captured pixels would not represent the current PR HEAD. Requesting reviewer capture or CI preview for the Git header before/after (History + Graph icon buttons visible; overflow retains Stashes/Update branch/Re-integrate only). The diff is limited to the `managementButtons` block quoted in the review, using the same button/tooltip pattern as the prior overflow trigger.

## Risks and failure behavior

- Low risk: same callbacks, same dialogs; if `onOpenHistory`/`onOpenGraph` are undefined the buttons omit (same conditional pattern as before).
- Overflow edge: when only History/Graph are provided, the overflow menu now correctly hides instead of showing an empty/single-item menu.
- No data-loss, rollback, persistence, security, or performance concerns: no fetches added (dialogs still lazy-fetch `graphLog` on open), no new listeners, no cross-runtime divergence.
