### PR TITLE
feat(cli): add guided serve and update flows

### DIFF
--- a/packages/web/bin/cli.js
+++ b/packages/web/bin/cli.js
@@ -192,7 +192,10 @@ commands.update = createUpdateCommand({
 
 async function main() {
   const parsed = parseArgs();
-  const { command, subcommand, tunnelAction, startupAction, options, removedFlagErrors, helpRequested, versionRequested } = parsed;
+  const { command, explicitCommand, subcommand, tunnelAction, startupAction, options, removedFlagErrors, helpRequested, versionRequested } = parsed;
+  if (command === 'serve' && explicitCommand) {
+    options.offerInteractiveSetup = true;
+  }
   activeCommandOptions = options;
 
   if (versionRequested || command === 'version') {
@@ -245,7 +248,7 @@ async function main() {
   }
 
   if (!commands[command]) {
-    const knownCommands = ['serve', 'stop', 'restart', 'status', 'tunnel', 'startup', 'logs', 'update', 'version'];
+    const knownCommands = ['serve', 'stop', 'restart', 'status', 'tunnel', 'startup', 'logs', 'connect-url', 'update', 'version'];
     const suggestion = findClosestMatch(command, knownCommands);
     const hint = suggestion ? ` Did you mean '${suggestion}'?` : '';
     if (isJsonMode(options)) {

--- a/packages/web/bin/cli.test.js
+++ b/packages/web/bin/cli.test.js
@@ -316,6 +316,13 @@ describe('cli args', () => {
     expect(parsed.options.lan).toBe(true);
   });
 
+  it('tracks explicit serve commands and update confirmation flags', () => {
+    expect(parseArgs(['serve']).explicitCommand).toBe(true);
+    expect(parseArgs([]).explicitCommand).toBe(false);
+    expect(parseArgs(['update', '--yes']).options.yes).toBe(true);
+    expect(parseArgs(['update', '-y']).options.yes).toBe(true);
+  });
+
   it('supports --hostname as top-level bind alias', () => {
     const parsed = parseArgs(['serve', '--hostname', '0.0.0.0']);
 
@@ -327,6 +334,43 @@ describe('cli args', () => {
 
     expect(parsed.options.hostname).toBe('app.example.com');
     expect(parsed.options.host).toBeUndefined();
+  });
+});
+
+describe('serve command helper', () => {
+  it('collects a reviewed LAN server configuration', async () => {
+    const { collectInteractiveServeOptions } = await import('./lib/commands-serve.js');
+    const answers = ['lan', '8080', 'generate', 'api', 'daemon', true];
+    const prompts = {
+      select: async () => answers.shift(),
+      text: async () => answers.shift(),
+      password: async () => answers.shift(),
+      confirm: async () => answers.shift(),
+      isCancel: () => false,
+      cancel: () => {},
+    };
+
+    const result = await collectInteractiveServeOptions({ port: 3000 }, prompts);
+
+    expect(result).toMatchObject({
+      host: '0.0.0.0',
+      lan: true,
+      port: 8080,
+      explicitPort: true,
+      uiPassword: '',
+      explicitUiPassword: true,
+      apiOnly: true,
+      foreground: false,
+    });
+  });
+
+  it('detects flags that suppress interactive server setup', async () => {
+    const { hasExplicitServeConfiguration } = await import('./lib/commands-serve.js');
+
+    expect(hasExplicitServeConfiguration({ explicitPort: true })).toBe(true);
+    expect(hasExplicitServeConfiguration({ foreground: true })).toBe(true);
+    expect(hasExplicitServeConfiguration({ apiOnly: true })).toBe(true);
+    expect(hasExplicitServeConfiguration({ port: 3000 })).toBe(false);
   });
 });
 

--- a/packages/web/bin/lib/DOCUMENTATION.md
+++ b/packages/web/bin/lib/DOCUMENTATION.md
@@ -4,15 +4,15 @@ This directory contains non-entrypoint PiChamber CLI implementation. `../cli.js`
 
 ## Commands
 
-- `commands-serve.js`: server startup, PID/instance registry, and foreground/background lifecycle.
-- `commands-lifecycle.js`: stop and restart behavior.
+- `commands-serve.js`: server startup, PID/instance registry, and foreground/background lifecycle. Explicit `pichamber serve` with no setup flags opens an interactive access, port, authentication, content, and process-mode wizard. Bare `pichamber`, flag-driven runs, non-TTY, `--quiet`, and `--json` remain non-interactive.
+- `commands-lifecycle.js`: stop and restart behavior. Interactive broad stops require confirmation when more than one instance will be affected; `--force` skips it.
 - `commands-status.js`: running-instance and tunnel status presentation.
-- `commands-logs.js`: log discovery, tailing, and follow behavior.
+- `commands-logs.js`: log discovery, tailing, and follow behavior. Quiet mode emits raw log lines, while multi-instance output retains port prefixes.
 - `commands-startup.js`: native startup service management. Interactive `startup enable` walks through access, port, authentication, and confirmation when no setup flags are supplied. Flag-driven, non-TTY, `--quiet`, and `--json` runs remain non-interactive. The command stores serve flags (`--port`, `--lan`/`--host`, `--ui-password`, `--api-only`) in the native service. Re-running enable rewrites and restarts a systemd unit so the new settings take effect immediately. LAN binds require a UI password, matching `pichamber serve`.
 - `commands-connect-url.js`: authenticated direct/relay pairing links.
 - `pichamber version` and `pichamber --version`: print the installed package version; `--json` returns the same value as JSON.
-- `commands-update.js`: package update and restart coordination. Updates only a global install owned by the running CLI. A Linux user systemd unit is restarted in place; the command does not spawn a replacement server on the same port.
-- `commands-tunnel.js`: tunnel lifecycle and profile management.
+- `commands-update.js`: package update and restart coordination. Interactive updates review the old and target versions and restart impact before installation; `--yes` skips confirmation. Updates only a global install owned by the running CLI. Results distinguish the previous, installed, and latest versions and report partial restart failures. A Linux user systemd unit is restarted in place; the command does not spawn a replacement server on the same port.
+- `commands-tunnel.js`: tunnel lifecycle and profile management. Interactive tunnel setup ends with a review and confirmation; fully specified flag and profile runs remain direct.
 
 ## Rules
 

--- a/packages/web/bin/lib/cli-args.js
+++ b/packages/web/bin/lib/cli-args.js
@@ -104,6 +104,7 @@ function parseArgs(argv = process.argv.slice(2)) {
     timeout: undefined,
     lastAssistant: false,
     withStatus: false,
+    yes: false,
   };
 
   const removedFlagErrors = [];
@@ -403,6 +404,10 @@ function parseArgs(argv = process.argv.slice(2)) {
       case 'q':
         options.quiet = true;
         break;
+      case 'yes':
+      case 'y':
+        options.yes = true;
+        break;
       case 'help':
       case 'h':
         helpRequested = true;
@@ -450,6 +455,7 @@ function parseArgs(argv = process.argv.slice(2)) {
     }
   }
 
+  const explicitCommand = positional.length > 0;
   const command = positional[0] || 'serve';
   const subcommand = command === 'tunnel' ? (positional[1] || 'help') : null;
   const tunnelAction = command === 'tunnel' ? (positional[2] || null) : null;
@@ -465,6 +471,7 @@ function parseArgs(argv = process.argv.slice(2)) {
 
   return {
     command,
+    explicitCommand,
     subcommand,
     tunnelAction,
     startupAction,
@@ -483,7 +490,7 @@ USAGE:
   pichamber [COMMAND] [OPTIONS]
 
 COMMANDS:
-  serve          Start the web server (daemon default)
+  serve          Configure and start the web server (guided in interactive terminals)
   stop           Stop running instance(s)
   restart        Stop and start the server
   status         Show server status
@@ -505,6 +512,7 @@ OPTIONS:
   --api-only              Start API routes only, without serving browser UI assets
   --foreground            Run server in foreground (use with systemd/process managers)
   --no-daemon             Alias for --foreground
+  -y, --yes               Confirm update without prompting
   -h, --help              Show help
   -v, --version           Show version
 
@@ -520,7 +528,8 @@ EXAMPLES:
   pichamber                    # Start in daemon mode on default port 3000 (or free port)
   pichamber --port 8080        # Start on port 8080 (daemon)
   pichamber --lan --port 3002  # Start on LAN at 0.0.0.0:3002
-  pichamber serve --foreground # Start in foreground (for systemd Type=simple)
+  pichamber serve              # Walk through interactive server setup
+  pichamber serve --foreground # Start in foreground without setup prompts
   pichamber connect-url --port 3000 --qr
   pichamber connect-url --server https://pichamber.example.com
   pichamber startup enable --lan --port 3002 --ui-password
@@ -719,10 +728,10 @@ _pichamber_tunnel() {
   cur="\${COMP_WORDS[COMP_CWORD]}"
   prev="\${COMP_WORDS[COMP_CWORD-1]}"
 
-    commands="serve stop restart status tunnel logs update"},{
+  commands="serve stop restart status tunnel startup logs connect-url update version"
   tunnel_commands="help providers ready doctor status start stop profile completion"
   profile_commands="list show add remove"
-  common_flags="--port --foreground --no-daemon --json --all --help --version --plain --quiet"
+  common_flags="--port --host --lan --ui-password --api-only --foreground --no-daemon --json --all --help --version --plain --quiet --yes"
   start_flags="--provider --mode --profile --config --token --token-file --token-stdin --hostname --connect-ttl --session-ttl --qr --no-qr --dry-run --show-secrets"
 
   if [[ \${COMP_CWORD} -eq 1 ]]; then
@@ -772,8 +781,11 @@ _pichamber() {
     'restart:Stop and start the server'
     'status:Show server status'
     'tunnel:Tunnel lifecycle commands'
+    'startup:Manage launch at system startup'
     'logs:Tail PiChamber logs'
+    'connect-url:Generate a client pairing URL'
     'update:Check for and install updates'
+    'version:Show the installed version'
   )
 
   tunnel_commands=(
@@ -834,8 +846,11 @@ complete -c pichamber -n '__fish_use_subcommand' -a 'stop' -d 'Stop running inst
 complete -c pichamber -n '__fish_use_subcommand' -a 'restart' -d 'Stop and start the server'
 complete -c pichamber -n '__fish_use_subcommand' -a 'status' -d 'Show server status'
 complete -c pichamber -n '__fish_use_subcommand' -a 'tunnel' -d 'Tunnel lifecycle commands'
+complete -c pichamber -n '__fish_use_subcommand' -a 'startup' -d 'Manage launch at system startup'
 complete -c pichamber -n '__fish_use_subcommand' -a 'logs' -d 'Tail logs'
+complete -c pichamber -n '__fish_use_subcommand' -a 'connect-url' -d 'Generate a client pairing URL'
 complete -c pichamber -n '__fish_use_subcommand' -a 'update' -d 'Check for updates'
+complete -c pichamber -n '__fish_use_subcommand' -a 'version' -d 'Show installed version'
 
 complete -c pichamber -n '__fish_seen_subcommand_from tunnel; and not __fish_seen_subcommand_from help providers ready doctor status start stop profile completion' -a 'help' -d 'Show tunnel help'
 complete -c pichamber -n '__fish_seen_subcommand_from tunnel; and not __fish_seen_subcommand_from help providers ready doctor status start stop profile completion' -a 'providers' -d 'Show providers'

--- a/packages/web/bin/lib/commands-lifecycle.js
+++ b/packages/web/bin/lib/commands-lifecycle.js
@@ -15,6 +15,10 @@ import {
 import {
   intro as clackIntro,
   outro as clackOutro,
+  cancel as clackCancel,
+  confirm,
+  isCancel,
+  canPrompt,
   isJsonMode,
   isQuietMode,
   shouldRenderHumanOutput,
@@ -53,6 +57,16 @@ async function stopCommand(options) {
     }
 
     let runningInstances = await discoverLifecycleInstances(options);
+    if (!options.explicitPort && runningInstances.length > 1 && !options.force && canPrompt(options)) {
+      const approved = await confirm({
+        message: `Stop all ${runningInstances.length} PiChamber instances?`,
+        initialValue: false,
+      });
+      if (isCancel(approved) || approved !== true) {
+        clackCancel('Stop cancelled.');
+        return;
+      }
+    }
     if (options.explicitPort) {
       if (runningInstances.length === 0) {
         const unconfirmedInstance = await discoverUnconfirmedRegistryInstanceOnPort(options.port, options);

--- a/packages/web/bin/lib/commands-logs.js
+++ b/packages/web/bin/lib/commands-logs.js
@@ -5,6 +5,7 @@ import {
   intro as clackIntro,
   outro as clackOutro,
   isJsonMode,
+  isQuietMode,
   shouldRenderHumanOutput,
   printJson,
   logStatus,
@@ -12,7 +13,7 @@ import {
 
 async function logsCommand(options) {
   const showFrames = shouldRenderHumanOutput(options);
-  const shouldPrefixLines = options.all || !showFrames;
+  const shouldPrefixLines = options.all || (!showFrames && !isQuietMode(options));
   let targets = [];
   const running = await discoverRunningInstances();
 

--- a/packages/web/bin/lib/commands-serve.js
+++ b/packages/web/bin/lib/commands-serve.js
@@ -13,6 +13,13 @@ import { isNetworkExposedBindHost } from '../../server/lib/security/bind-host.js
 import {
   intro as clackIntro,
   outro as clackOutro,
+  cancel as clackCancel,
+  isCancel,
+  select,
+  text,
+  password as passwordPrompt,
+  confirm,
+  canPrompt,
   isJsonMode,
   isQuietMode,
   shouldRenderHumanOutput,
@@ -22,6 +29,145 @@ import {
 } from '../cli-output.js';
 
 const DAEMON_READY_TIMEOUT_MS = 30000;
+const servePromptApi = { select, text, password: passwordPrompt, confirm, isCancel, cancel: clackCancel };
+
+function hasExplicitServeConfiguration(options) {
+  return options.explicitPort === true
+    || options.lan === true
+    || typeof options.host === 'string'
+    || options.explicitUiPassword === true
+    || options.apiOnly === true
+    || options.foreground === true;
+}
+
+async function collectInteractiveServeOptions(options, prompts = servePromptApi) {
+  const ask = async (method, config) => {
+    const answer = await prompts[method](config);
+    if (prompts.isCancel(answer)) {
+      prompts.cancel('Server setup cancelled.');
+      return { cancelled: true };
+    }
+    return { answer };
+  };
+
+  const accessResult = await ask('select', {
+    message: 'Where should PiChamber be accessible?',
+    options: [
+      { value: 'local', label: 'This machine only', hint: 'recommended' },
+      { value: 'lan', label: 'Local network', hint: 'other devices on your LAN or Wi-Fi' },
+      { value: 'custom', label: 'Custom bind address' },
+    ],
+    initialValue: 'local',
+  });
+  if (accessResult.cancelled) return null;
+
+  let host = '127.0.0.1';
+  let lan = false;
+  if (accessResult.answer === 'lan') {
+    host = '0.0.0.0';
+    lan = true;
+  } else if (accessResult.answer === 'custom') {
+    const hostResult = await ask('text', {
+      message: 'Bind address',
+      initialValue: '127.0.0.1',
+      validate: (value) => String(value ?? '').trim() ? undefined : 'Enter a bind address.',
+    });
+    if (hostResult.cancelled) return null;
+    host = String(hostResult.answer).trim();
+  }
+
+  const portResult = await ask('text', {
+    message: 'Port',
+    initialValue: String(options.port),
+    validate: (value) => {
+      const normalized = String(value ?? '').trim();
+      if (!/^\d+$/.test(normalized)) return 'Enter a port from 0 to 65535.';
+      const port = Number(normalized);
+      return port >= 0 && port <= 65535 ? undefined : 'Enter a port from 0 to 65535.';
+    },
+  });
+  if (portResult.cancelled) return null;
+  const port = Number(String(portResult.answer).trim());
+
+  const networkExposed = accessResult.answer !== 'local';
+  const authResult = await ask('select', {
+    message: networkExposed ? 'Choose a required UI password' : 'Protect the UI with a password?',
+    options: [
+      { value: 'enter', label: 'Enter a password' },
+      { value: 'generate', label: 'Generate a secure password' },
+      ...(!networkExposed ? [{ value: 'none', label: 'No password', hint: 'local access only' }] : []),
+    ],
+    initialValue: networkExposed ? 'generate' : 'none',
+  });
+  if (authResult.cancelled) return null;
+
+  let uiPassword;
+  let explicitUiPassword = false;
+  if (authResult.answer === 'enter') {
+    const passwordResult = await ask('password', {
+      message: 'UI password',
+      validate: (value) => String(value ?? '').length ? undefined : 'Enter a password.',
+    });
+    if (passwordResult.cancelled) return null;
+    uiPassword = String(passwordResult.answer);
+    const confirmationResult = await ask('password', {
+      message: 'Confirm UI password',
+      validate: (value) => value === uiPassword ? undefined : 'Passwords do not match.',
+    });
+    if (confirmationResult.cancelled) return null;
+    explicitUiPassword = true;
+  } else if (authResult.answer === 'generate') {
+    uiPassword = '';
+    explicitUiPassword = true;
+  }
+
+  const contentResult = await ask('select', {
+    message: 'What should this server provide?',
+    options: [
+      { value: 'ui', label: 'Browser UI and API', hint: 'recommended' },
+      { value: 'api', label: 'API only', hint: 'for paired clients' },
+    ],
+    initialValue: 'ui',
+  });
+  if (contentResult.cancelled) return null;
+
+  const processResult = await ask('select', {
+    message: 'How should the server run?',
+    options: [
+      { value: 'daemon', label: 'In the background', hint: 'recommended' },
+      { value: 'foreground', label: 'In the foreground', hint: 'for process managers' },
+    ],
+    initialValue: 'daemon',
+  });
+  if (processResult.cancelled) return null;
+
+  logStatus('info', 'Review server', [
+    `Access: ${accessResult.answer === 'local' ? 'this machine only' : host}`,
+    `Port: ${port === 0 ? 'automatic' : port}`,
+    `Authentication: ${authResult.answer === 'none' ? 'disabled' : authResult.answer === 'generate' ? 'generated password' : 'enabled'}`,
+    `Content: ${contentResult.answer === 'api' ? 'API only' : 'browser UI and API'}`,
+    `Process: ${processResult.answer === 'foreground' ? 'foreground' : 'background'}`,
+  ].join('\n'));
+
+  const confirmResult = await ask('confirm', { message: 'Start this server?', initialValue: true });
+  if (confirmResult.cancelled) return null;
+  if (confirmResult.answer !== true) {
+    prompts.cancel('Server setup cancelled.');
+    return null;
+  }
+
+  return {
+    ...options,
+    host,
+    lan,
+    port,
+    explicitPort: true,
+    uiPassword,
+    explicitUiPassword,
+    apiOnly: contentResult.answer === 'api',
+    foreground: processResult.answer === 'foreground',
+  };
+}
 
 function createServeCommand({
   serverPath,
@@ -31,6 +177,15 @@ function createServeCommand({
   setForegroundShutdown,
 }) {
 async function serveCommand(options) {
+    let usedInteractiveSetup = false;
+    if (options.offerInteractiveSetup === true && canPrompt(options) && !hasExplicitServeConfiguration(options)) {
+      clackIntro('PiChamber Server Setup');
+      const resolvedOptions = await collectInteractiveServeOptions(options);
+      if (!resolvedOptions) return;
+      options = resolvedOptions;
+      usedInteractiveSetup = true;
+    }
+
     const showOutput = shouldRenderHumanOutput(options);
     const jsonMessages = [];
     const emitNotice = (notice) => {
@@ -221,6 +376,15 @@ async function serveCommand(options) {
               : `${resolvedPort}\n`
           );
         }
+      } else if (usedInteractiveSetup && showOutput && !options.suppressStartupSummary) {
+        logStatus('success', `port ${resolvedPort} (foreground)`);
+        if (autoGeneratedUiPassword) {
+          logStatus('success', 'UI password', effectiveUiPassword);
+          logStatus('warning', 'save this password', 'it is not shown again');
+        }
+        logStatus('info', `visit: ${buildLocalUrl(resolvedPort, '/')}`);
+        logStatus('info', `logs: pichamber logs -p ${resolvedPort}`);
+        clackOutro('server running; press Ctrl+C to stop');
       } else if (autoGeneratedUiPassword && showOutput && !options.suppressStartupSummary) {
         console.log(`Generated UI password: ${effectiveUiPassword}`);
         console.log('Save this password — it is not shown again.');
@@ -399,7 +563,7 @@ async function serveCommand(options) {
     serveSpin?.clear();
 
     if (!options.suppressStartupSummary && showOutput) {
-      clackIntro('PiChamber Started');
+      if (!usedInteractiveSetup) clackIntro('PiChamber Started');
       logStatus('success', `port ${serveResult.port} (PID: ${serveResult.pid})`);
       if (autoGeneratedUiPassword) {
         logStatus('success', 'UI password', effectiveUiPassword);
@@ -416,4 +580,4 @@ async function serveCommand(options) {
   return serveCommand;
 }
 
-export { createServeCommand };
+export { createServeCommand, collectInteractiveServeOptions, hasExplicitServeConfiguration };

--- a/packages/web/bin/lib/commands-tunnel.js
+++ b/packages/web/bin/lib/commands-tunnel.js
@@ -1125,6 +1125,9 @@ async function tunnelCommand(options, subcommand, action, deps) {
         return;
       }
       case 'start': {
+        const interactiveWizard = canPrompt(options)
+          && !(typeof options.profile === 'string' && options.profile.trim().length > 0)
+          && !(typeof options.mode === 'string' && options.mode.trim().length > 0);
         let provider = typeof options.provider === 'string' && options.provider.trim().length > 0
           ? options.provider.trim().toLowerCase()
           : '';
@@ -1471,6 +1474,24 @@ async function tunnelCommand(options, subcommand, action, deps) {
             }
             options.port = Number(selectedPort);
             options.explicitPort = true;
+          }
+        }
+
+        if (interactiveWizard) {
+          logStatus('info', 'Review tunnel', [
+            `Provider: ${provider}`,
+            `Mode: ${mode}`,
+            `Target: ${options.explicitPort ? `port ${options.port}` : 'running or auto-started server'}`,
+            `Hostname: ${hostname || 'ephemeral URL'}`,
+            `Profile: ${selectedProfile?.name || 'none'}`,
+          ].join('\n'));
+          const approved = await clackConfirm({
+            message: 'Start this tunnel?',
+            initialValue: true,
+          });
+          if (clackIsCancel(approved) || approved !== true) {
+            clackCancel('Tunnel start cancelled.');
+            return;
           }
         }
 

--- a/packages/web/bin/lib/commands-update.js
+++ b/packages/web/bin/lib/commands-update.js
@@ -13,6 +13,10 @@ import {
 import {
   intro as clackIntro,
   outro as clackOutro,
+  cancel as clackCancel,
+  confirm,
+  isCancel,
+  canPrompt,
   isJsonMode,
   isQuietMode,
   shouldRenderHumanOutput,
@@ -37,6 +41,9 @@ function createUpdateCommand({
   isInsideSystemdService = () => Boolean(process.env.INVOCATION_ID) || Boolean(process.env.PICHAMBER_SYSTEMD_UNIT),
   isUserStartupServiceActive = defaultIsUserStartupServiceActive,
   restartUserStartupService = defaultRestartUserStartupService,
+  discoverInstances = discoverRunningInstances,
+  requestShutdown = requestServerShutdown,
+  stopProcess = stopInstanceProcess,
 }) {
   return async function updateCommand(options = {}) {
     const showOutput = shouldRenderHumanOutput(options);
@@ -150,10 +157,33 @@ function createUpdateCommand({
       throw new Error(UNOWNED_INSTALL_MESSAGE);
     }
 
-    if (showOutput && !updateSpin) {
-      logStatus('info', `updating ${updateInfo.currentVersion || currentVersion} -> ${updateInfo.version || 'latest'} with ${pm}`);
+    const latestVersion = updateInfo.version || 'latest';
+    const startupServiceActive = isUserStartupServiceActive();
+    const runningInstances = startupServiceActive ? [] : await discoverInstances();
+
+    if (canPrompt(options) && options.yes !== true) {
+      updateSpin?.clear();
+      logStatus('info', 'Review update', [
+        `Version: ${currentVersion} -> ${latestVersion}`,
+        `Package manager: ${pm}`,
+        startupServiceActive
+          ? 'Restart: startup service'
+          : `Restart: ${runningInstances.length} running instance(s)`,
+      ].join('\n'));
+      const approved = await confirm({
+        message: `Install PiChamber ${latestVersion}?`,
+        initialValue: true,
+      });
+      if (isCancel(approved) || approved !== true) {
+        clackCancel('Update cancelled.');
+        return;
+      }
     }
-    updateSpin?.message(`Updating to ${updateInfo.version || 'latest'}...`);
+
+    if (showOutput && !updateSpin) {
+      logStatus('info', `updating ${currentVersion} -> ${latestVersion} with ${pm}`);
+    }
+    updateSpin?.start(`Updating ${currentVersion} -> ${latestVersion}...`);
 
     const result = executeUpdate(pm, { silent: isJsonMode(options) || isQuietMode(options) });
     if (!result.success) {
@@ -164,10 +194,11 @@ function createUpdateCommand({
       throw new Error(`Update failed with exit code ${result.exitCode}`);
     }
 
-    let restartedCount = 0;
+    const installedVersion = getCurrentVersion();
+    const restartResults = [];
     let startupServiceRestarted = false;
 
-    if (isUserStartupServiceActive()) {
+    if (startupServiceActive) {
       updateSpin?.message('Restarting systemd user service...');
       try {
         restartUserStartupService();
@@ -181,59 +212,92 @@ function createUpdateCommand({
         }
         throw new Error(msg);
       }
-    } else {
-      const runningInstances = await discoverRunningInstances();
-      if (runningInstances.length > 0) {
-        updateSpin?.message(`Stopping ${runningInstances.length} running instance(s)...`);
-        for (const instance of runningInstances) {
-          try {
-            const requested = await requestServerShutdown(instance.port, instance.host);
-            await stopInstanceProcess(instance.pid, {
-              shutdownWaitMs: requested ? 5000 : 0,
-              gracefulTimeoutMs: 2500,
-              forceTimeoutMs: 3000,
-            });
-            removePidFile(instance.pidFilePath);
-          } catch {
-          }
+    } else if (runningInstances.length > 0) {
+      updateSpin?.message(`Restarting ${runningInstances.length} running instance(s)...`);
+      for (const instance of runningInstances) {
+        const storedOptions = readInstanceOptions(instance.instanceFilePath) || { port: instance.port };
+        if (storedOptions.launchMode === 'foreground') {
+          restartResults.push({ port: instance.port, ok: false, reason: 'foreground-restart-required' });
+          continue;
         }
-
-        updateSpin?.message(`Restarting ${runningInstances.length} instance(s)...`);
-        for (const instance of runningInstances) {
-          const storedOptions = readInstanceOptions(instance.instanceFilePath) || { port: instance.port };
-          await serveCommand({
+        try {
+          const requested = await requestShutdown(instance.port, instance.host);
+          const stopped = await stopProcess(instance.pid, {
+            shutdownWaitMs: requested ? 5000 : 0,
+            gracefulTimeoutMs: 2500,
+            forceTimeoutMs: 3000,
+          });
+          if (!stopped) {
+            restartResults.push({ port: instance.port, ok: false, reason: 'stop-failed' });
+            continue;
+          }
+          removePidFile(instance.pidFilePath);
+          const restartedPort = await serveCommand({
             port: storedOptions.port || instance.port,
             host: storedOptions.host,
             explicitPort: true,
             uiPassword: storedOptions.uiPassword,
+            apiOnly: storedOptions.apiOnly === true,
             suppressStartupSummary: true,
             suppressUiPasswordWarning: true,
+            suppressQuietOutput: true,
             quiet: true,
           });
+          restartResults.push({ port: instance.port, restartedPort, ok: true });
+        } catch (error) {
+          restartResults.push({
+            port: instance.port,
+            ok: false,
+            reason: error instanceof Error ? error.message : String(error),
+          });
         }
-        restartedCount = runningInstances.length;
       }
     }
 
-    if (showOutput && !updateSpin) {
-      logStatus('success', `updated to ${updateInfo.version || 'latest'}`);
+    const restartedCount = restartResults.filter((entry) => entry.ok).length;
+    const failedRestartCount = restartResults.length - restartedCount;
+    const versionVerified = latestVersion === 'latest' || installedVersion === latestVersion;
+    const messages = [];
+    if (!versionVerified) {
+      messages.push({
+        level: 'warning',
+        code: 'VERSION_MISMATCH',
+        message: `Package manager completed, but this install reports ${installedVersion} instead of ${latestVersion}.`,
+      });
     }
-    updateSpin?.stop(`Updated to ${updateInfo.version || 'latest'}`);
+    if (failedRestartCount > 0) {
+      messages.push({
+        level: 'warning',
+        code: 'RESTART_PARTIAL',
+        message: `${failedRestartCount} running instance(s) require manual restart.`,
+      });
+    }
+
+    updateSpin?.clear();
     if (isJsonMode(options)) {
       printJson({
-        currentVersion,
-        latestVersion: updateInfo.version || 'latest',
-        updated: true,
+        status: messages.length > 0 ? 'warning' : 'ok',
+        previousVersion: currentVersion,
+        currentVersion: installedVersion,
+        latestVersion,
+        versionVerified,
+        updated: installedVersion !== currentVersion || versionVerified,
         packageManager: pm,
         restartedCount,
         startupServiceRestarted,
+        restartResults,
+        messages,
       });
       return;
     }
     if (showOutput) {
-      clackOutro('update complete');
+      logStatus(versionVerified ? 'success' : 'warning', `version ${currentVersion} -> ${installedVersion}`);
+      for (const message of messages) {
+        logStatus('warning', `[${message.code}]`, message.message);
+      }
+      clackOutro(messages.length > 0 ? 'update complete with warnings' : 'update complete');
     } else if (isQuietMode(options)) {
-      process.stdout.write(`updated ${updateInfo.version || 'latest'}\n`);
+      process.stdout.write(`updated ${currentVersion} -> ${installedVersion} restarted:${restartedCount} failed:${failedRestartCount}\n`);
     }
   };
 }

--- a/packages/web/bin/lib/commands-update.test.js
+++ b/packages/web/bin/lib/commands-update.test.js
@@ -23,6 +23,9 @@ async function withTempPiChamberDataDir(fn) {
 
 function createTestUpdateCommand(overrides = {}) {
   const executeUpdate = overrides.executeUpdate || vi.fn(() => ({ success: true, exitCode: 0 }));
+  const getCurrentVersion = overrides.getCurrentVersion || vi.fn()
+    .mockReturnValueOnce('1.0.0')
+    .mockReturnValue('9.9.9');
   const serveCommand = overrides.serveCommand || vi.fn();
   const restartUserStartupService = overrides.restartUserStartupService || vi.fn();
   const updateCommand = createUpdateCommand({
@@ -31,11 +34,14 @@ function createTestUpdateCommand(overrides = {}) {
     isInsideSystemdService: overrides.isInsideSystemdService || (() => false),
     isUserStartupServiceActive: overrides.isUserStartupServiceActive || (() => false),
     restartUserStartupService,
+    discoverInstances: overrides.discoverInstances,
+    requestShutdown: overrides.requestShutdown,
+    stopProcess: overrides.stopProcess,
     importFromFilePath: vi.fn(async () => ({
       checkForUpdates: overrides.checkForUpdates || vi.fn(async () => ({ available: true, version: '9.9.9' })),
       resolveTrustedUpdatePackageManager: overrides.resolveTrustedUpdatePackageManager || vi.fn(() => 'npm'),
       executeUpdate,
-      getCurrentVersion: vi.fn(() => '1.0.0'),
+      getCurrentVersion,
     })),
   });
   return { updateCommand, executeUpdate, serveCommand, restartUserStartupService };
@@ -52,6 +58,95 @@ describe('update command', () => {
         await updateCommand({ json: true });
 
         expect(executeUpdate).toHaveBeenCalledWith('npm', { silent: true });
+      } finally {
+        process.stdout.write = originalWrite;
+      }
+    });
+  });
+
+  it('reports the version before and after a successful update', async () => {
+    await withTempPiChamberDataDir(async () => {
+      const output = [];
+      const originalWrite = process.stdout.write;
+      process.stdout.write = vi.fn((chunk) => {
+        output.push(String(chunk));
+        return true;
+      });
+      const { updateCommand } = createTestUpdateCommand();
+
+      try {
+        await updateCommand({ json: true });
+        expect(JSON.parse(output.join(''))).toMatchObject({
+          status: 'ok',
+          previousVersion: '1.0.0',
+          currentVersion: '9.9.9',
+          latestVersion: '9.9.9',
+          versionVerified: true,
+          updated: true,
+        });
+      } finally {
+        process.stdout.write = originalWrite;
+      }
+    });
+  });
+
+  it('reports a version mismatch as a warning', async () => {
+    await withTempPiChamberDataDir(async () => {
+      const output = [];
+      const originalWrite = process.stdout.write;
+      process.stdout.write = vi.fn((chunk) => {
+        output.push(String(chunk));
+        return true;
+      });
+      const { updateCommand } = createTestUpdateCommand({
+        getCurrentVersion: vi.fn().mockReturnValueOnce('1.0.0').mockReturnValue('1.0.0'),
+      });
+
+      try {
+        await updateCommand({ json: true });
+        expect(JSON.parse(output.join(''))).toMatchObject({
+          status: 'warning',
+          previousVersion: '1.0.0',
+          currentVersion: '1.0.0',
+          versionVerified: false,
+        });
+      } finally {
+        process.stdout.write = originalWrite;
+      }
+    });
+  });
+
+  it('reports partial instance restart failures without losing successful results', async () => {
+    await withTempPiChamberDataDir(async (dir) => {
+      const firstOptions = path.join(dir, 'first.json');
+      const secondOptions = path.join(dir, 'second.json');
+      fs.writeFileSync(firstOptions, JSON.stringify({ port: 3001, launchMode: 'daemon', apiOnly: true }));
+      fs.writeFileSync(secondOptions, JSON.stringify({ port: 3002, launchMode: 'daemon' }));
+      const output = [];
+      const originalWrite = process.stdout.write;
+      process.stdout.write = vi.fn((chunk) => {
+        output.push(String(chunk));
+        return true;
+      });
+      const { updateCommand, serveCommand } = createTestUpdateCommand({
+        discoverInstances: async () => [
+          { port: 3001, pid: 101, instanceFilePath: firstOptions, pidFilePath: path.join(dir, 'first.pid') },
+          { port: 3002, pid: 102, instanceFilePath: secondOptions, pidFilePath: path.join(dir, 'second.pid') },
+        ],
+        requestShutdown: async () => true,
+        stopProcess: async (pid) => pid === 101,
+        serveCommand: vi.fn(async (options) => options.port),
+      });
+
+      try {
+        await updateCommand({ json: true });
+        const payload = JSON.parse(output.join(''));
+        expect(payload).toMatchObject({ status: 'warning', restartedCount: 1 });
+        expect(payload.restartResults).toEqual([
+          expect.objectContaining({ port: 3001, restartedPort: 3001, ok: true }),
+          expect.objectContaining({ port: 3002, ok: false, reason: 'stop-failed' }),
+        ]);
+        expect(serveCommand).toHaveBeenCalledWith(expect.objectContaining({ port: 3001, apiOnly: true }));
       } finally {
         process.stdout.write = originalWrite;
       }


### PR DESCRIPTION
## Intent

Make the terminal CLI easier to configure safely without weakening scriptable behavior.

- `pichamber serve` now walks interactive users through access, port, authentication, content, process mode, review, and confirmation.
- Bare `pichamber` remains the existing quick-start command.
- `pichamber update` now reviews the current and target versions, supports `--yes`, verifies the installed version, and reports restart outcomes.
- Guided tunnel starts and broad multi-instance stops now confirm their planned action.
- Quiet logs and shell completions now have clearer, more complete output.

## Non-goals

- No changes to server APIs, browser UI, Electron lifecycle, persisted session data, or tunnel transport protocols.
- Fully specified commands remain flag-driven. Non-TTY, `--quiet`, and `--json` runs never prompt.
- This PR does not redesign every read-only CLI command as a wizard.

## Affected surfaces

- `packages/web/bin`: command parsing, terminal prompts, output contracts, serve/update lifecycle orchestration, completions, and focused tests.
- Web runtime only. Desktop, hosted mobile, and Capacitor clients are unaffected because no shared UI or runtime API contract changed.
- External CLI behavior changes add interactive prompts only under the TTY guard. Update JSON keeps existing fields and adds explicit previous/current/latest version and restart-result fields.
- Existing startup-service commands and stored instance records remain compatible.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` | Governs source changes, validation, ownership, and PR handoff | Kept command wiring thin, changed owning CLI modules, updated CLI documentation, and ran focused plus repository-wide validation. |
| `pichamber-change-discipline` | CLI output and lifecycle behavior are external contracts | Preserved non-interactive behavior, made partial restart failures explicit, added regression tests, and did not add dependencies. |
| `clack-cli-patterns` and `references/snippets.md` | The change adds prompts, Clack output, quiet output, and JSON fields | Prompts require a TTY and human mode, cancellation is handled, policy remains in command logic, JSON stays JSON-only, and quiet output remains deterministic. |
| `packages/web/README.md` | Defines the web runtime and serve behavior | LAN authentication enforcement and foreground/background ownership remain in the existing serve core. |
| `packages/web/bin/lib/DOCUMENTATION.md` | Owns CLI command boundaries and mode invariants | Updated it with the new wizard gates, update result behavior, destructive confirmation, and quiet-log contract. |
| `CONTRIBUTING.md` | Defines validation and evidence requirements | Ran the required build, type-check, lint, full tests, focused CLI tests, syntax checks, and completion validation against this HEAD. |

## Validation

| Check | Result |
|---|---|
| `bun install --frozen-lockfile` | Passed; lockfile remained unchanged. |
| `bun run --cwd packages/web test -- bin/cli.test.js bin/lib/commands-update.test.js` | Passed, 86 tests. |
| `bun run test` | Passed: web suite, 2,053 UI tests, 43 Electron architecture tests, and 20 Electron updater tests. |
| `bun run type-check` | Passed in web, UI, Electron, and mobile workspaces. |
| `bun run lint` | Passed in web, UI, Electron, and mobile workspaces. |
| `bun run build` | Passed for all configured workspaces; Vite emitted existing large-chunk warnings only. |
| `node --check` on changed CLI JS files | Passed. |
| Generated Bash completion plus `bash -n` | Passed. |
| `git diff --check origin/main...HEAD` | Passed. |

## Visual evidence

This is terminal-only output rather than browser or native UI. The focused CLI test run exercised and printed the current review summaries, including:

```text
Review server
Access: 0.0.0.0
Port: 8080
Authentication: generated password
Content: API only
Process: background
```

The update contract is also asserted at the current HEAD for `1.0.0 -> 9.9.9`, version mismatch warnings, and mixed successful/failed instance restarts. No browser, desktop, mobile, responsive, or theme state changes.

## Risks and failure behavior

- LAN exposure still passes through the existing core authentication policy; the wizard cannot bypass it.
- Generated and entered passwords are never included in review summaries. Generated passwords retain the existing one-time result behavior.
- Update execution still refuses containers, systemd-owned invocation, and unowned package-manager installs before replacement.
- A package-manager success followed by version mismatch returns a warning with both reported versions.
- Failed or foreground instance restarts remain visible in `restartResults`; successful instances are not erased by another failure.
- Prompt cancellation exits before the associated mutation. Scripts retain deterministic non-prompting behavior.
