### PR TITLE
fix(ui): bind WebSocket auth tokens to connections

### DIFF
--- a/packages/ui/src/lib/dictation/dictation-client.ts
+++ b/packages/ui/src/lib/dictation/dictation-client.ts
@@ -87,9 +87,9 @@ export class DictationClient {
     const generation = ++this.generation;
     if (this.failures > 0) this.onState(this.finishing ? 'transcribing' : 'reconnecting');
     try {
-      await refreshRuntimeUrlAuthToken();
+      const urlAuthToken = await refreshRuntimeUrlAuthToken();
       if (this.cancelled || generation !== this.generation) return;
-      const socket = openRuntimeWebSocket(getRuntimeUrlResolver().websocket('/api/stt/ws'));
+      const socket = openRuntimeWebSocket(getRuntimeUrlResolver().websocket('/api/stt/ws', undefined, urlAuthToken));
       socket.binaryType = 'arraybuffer';
       this.socket = socket;
       let opened = false;
@@ -129,7 +129,7 @@ export class DictationClient {
         if (this.socket !== socket) return;
         this.socket = null;
         this.socketStarted = false;
-        if (!opened) clearRuntimeUrlAuthToken();
+        if (!opened) clearRuntimeUrlAuthToken(urlAuthToken);
         if (!this.cancelled) this.scheduleReconnect();
       };
     } catch (error) {

--- a/packages/ui/src/lib/pi/transport.ts
+++ b/packages/ui/src/lib/pi/transport.ts
@@ -44,11 +44,12 @@ const resolveStreamQuery = (query: { fromSequence?: number; sessionId?: string }
 const resolveStreamUrl = (
   transport: 'ws' | 'sse',
   query: { fromSequence?: number; sessionId?: string },
+  urlAuthToken?: string,
 ): string => {
   const resolver = getRuntimeUrlResolver();
   const params = resolveStreamQuery(query);
   return transport === 'ws'
-    ? resolver.websocket('/api/pi/events', params)
+    ? resolver.websocket('/api/pi/events', params, urlAuthToken)
     : resolver.sse('/api/pi/events', params);
 };
 
@@ -470,9 +471,10 @@ export const createPiEventStream = (
     const connectionId = generation + 1;
     generation = connectionId;
 
+    let urlAuthToken: string | undefined;
     if (mode === 'ws') {
       try {
-        await refreshRuntimeUrlAuthToken();
+        urlAuthToken = await refreshRuntimeUrlAuthToken();
       } catch {
         if (connectionId !== generation || disposed || signal.aborted) return;
         if (options.transport !== 'ws') {
@@ -510,7 +512,7 @@ export const createPiEventStream = (
     const url = resolveStreamUrl(mode, {
       fromSequence: lastSequence,
       ...(options.sessionId ? { sessionId: options.sessionId } : {}),
-    });
+    }, urlAuthToken);
     const onReady = () => markReady(connectionId);
     const onEvent = (event: PiSessionEvent) => handleEvent(event, connectionId);
     const onDisconnect = (reason: string) => handleDisconnect(reason, connectionId);

--- a/packages/ui/src/lib/runtime-auth.test.ts
+++ b/packages/ui/src/lib/runtime-auth.test.ts
@@ -4,11 +4,13 @@ import {
   clearRuntimeAuthCredentialProvider,
   clearRuntimeUrlAuthToken,
   getRuntimeBearerTokenSync,
+  getRuntimeUrlAuthTokenSync,
   refreshRuntimeUrlAuthToken,
   refreshLocalRuntimeUrlAuthToken,
   getLocalRuntimeUrlAuthTokenSync,
   setRuntimeAuthCredentialProvider,
   setRuntimeBearerToken,
+  setRuntimeUrlAuthToken,
   setRuntimeExtraHeaders,
 } from './runtime-auth';
 
@@ -145,6 +147,19 @@ describe('runtime auth headers', () => {
       clearRuntimeUrlAuthToken();
       setRuntimeExtraHeaders(null);
       clearRuntimeAuthCredentialProvider();
+    }
+  });
+
+  test('does not let a stale connection clear a newer URL auth token', () => {
+    try {
+      setRuntimeUrlAuthToken('older-token', Date.now() + 60_000);
+      setRuntimeUrlAuthToken('newer-token', Date.now() + 60_000);
+
+      clearRuntimeUrlAuthToken('older-token');
+
+      expect(getRuntimeUrlAuthTokenSync()).toBe('newer-token');
+    } finally {
+      clearRuntimeUrlAuthToken();
     }
   });
 

--- a/packages/ui/src/lib/runtime-auth.ts
+++ b/packages/ui/src/lib/runtime-auth.ts
@@ -86,7 +86,8 @@ const clearLocalRuntimeUrlAuthToken = (): void => {
   localRuntimeUrlAuthGeneration += 1;
 };
 
-export const clearRuntimeUrlAuthToken = (): void => {
+export const clearRuntimeUrlAuthToken = (expectedToken?: string): void => {
+  if (expectedToken !== undefined && normalizeBearerToken(expectedToken) !== runtimeUrlAuthToken) return;
   runtimeUrlAuthToken = '';
   runtimeUrlAuthTokenExpiresAt = 0;
   clearLocalRuntimeUrlAuthToken();

--- a/packages/ui/src/lib/runtime-url.test.ts
+++ b/packages/ui/src/lib/runtime-url.test.ts
@@ -138,6 +138,19 @@ describe('createRuntimeUrlResolver', () => {
     }
   });
 
+  test('uses the token reserved for a WebSocket even when the shared token changes', () => {
+    setRuntimeUrlAuthToken('newer-shared-token', Date.now() + 60_000);
+    try {
+      const urls = createRuntimeUrlResolver({ apiBaseUrl: 'https://api.example' });
+
+      expect(urls.websocket('/api/terminal/ws', undefined, 'connection-token')).toBe(
+        'wss://api.example/api/terminal/ws?oc_url_token=connection-token',
+      );
+    } finally {
+      setRuntimeUrlAuthToken(null, null);
+    }
+  });
+
   test('replaces existing short-lived URL auth query on relative authenticated URLs', () => {
     setRuntimeUrlAuthToken('oc_url_secret', Date.now() + 60_000);
     try {

--- a/packages/ui/src/lib/runtime-url.ts
+++ b/packages/ui/src/lib/runtime-url.ts
@@ -17,7 +17,7 @@ export interface RuntimeUrlResolver {
   health(query?: RuntimeUrlQuery): string;
   rawFile(path: string, options?: { download?: boolean; allowOutsideWorkspace?: boolean; outsideFileGrant?: string }): string;
   sse(path: string, query?: RuntimeUrlQuery): string;
-  websocket(path: string, query?: RuntimeUrlQuery): string;
+  websocket(path: string, query?: RuntimeUrlQuery, urlAuthToken?: string): string;
 }
 
 const ABSOLUTE_URL_PATTERN = /^[a-z][a-z\d+.-]*:\/\//i;
@@ -87,8 +87,8 @@ const buildHttpUrl = (baseUrl: string, path: string, query?: RuntimeUrlQuery): s
   return url.toString();
 };
 
-const withUrlAuth = (urlValue: string): string => {
-  const token = getRuntimeUrlAuthTokenSync();
+const withUrlAuth = (urlValue: string, explicitToken?: string): string => {
+  const token = explicitToken === undefined ? getRuntimeUrlAuthTokenSync() : explicitToken;
   if (!token) return urlValue;
 
   const url = ABSOLUTE_URL_PATTERN.test(urlValue)
@@ -135,8 +135,8 @@ export const createRuntimeUrlResolver = (config: RuntimeUrlConfig = {}): Runtime
       const target = withUrlAuth(realtime(path, query));
       return target;
     },
-    websocket: (path, query) => {
-      const target = toWebSocketUrl(withUrlAuth(realtime(path, query)), config);
+    websocket: (path, query, urlAuthToken) => {
+      const target = toWebSocketUrl(withUrlAuth(realtime(path, query), urlAuthToken), config);
       return target;
     },
   };

--- a/packages/ui/src/lib/terminalApi.test.ts
+++ b/packages/ui/src/lib/terminalApi.test.ts
@@ -95,11 +95,11 @@ describe('terminal transport', () => {
 
   test('invalidates URL auth when the current socket closes before opening', async () => {
     const socket = new FakeSocket();
-    let cleared = 0;
+    const cleared: string[] = [];
     const transport = new TerminalTransport({
-      refreshAuth: async () => '',
+      refreshAuth: async () => 'connection-token',
       openSocket: () => socket,
-      clearUrlAuthToken: () => { cleared += 1; },
+      clearUrlAuthToken: (expectedToken) => { cleared.push(expectedToken ?? ''); },
     });
 
     const unsubscribe = transport.subscribe('term-1', { onEvent: () => {} });
@@ -107,25 +107,25 @@ describe('terminal transport', () => {
     socket.close();
     await tick();
 
-    expect(cleared).toBe(1);
+    expect(cleared).toEqual(['connection-token']);
     unsubscribe();
     transport.dispose();
   });
 
   test('invalidates URL auth before retrying a pre-open socket error', async () => {
     const socket = new FakeSocket();
-    let cleared = 0;
+    const cleared: string[] = [];
     const transport = new TerminalTransport({
-      refreshAuth: async () => '',
+      refreshAuth: async () => 'connection-token',
       openSocket: () => socket,
-      clearUrlAuthToken: () => { cleared += 1; },
+      clearUrlAuthToken: (expectedToken) => { cleared.push(expectedToken ?? ''); },
     });
 
     const unsubscribe = transport.subscribe('term-1', { onEvent: () => {} });
     await tick();
     socket.onerror?.();
 
-    expect(cleared).toBe(1);
+    expect(cleared).toEqual(['connection-token']);
     unsubscribe();
     transport.dispose();
   });
@@ -287,7 +287,7 @@ describe('terminal transport', () => {
     const sockets: FakeSocket[] = [];
     let authCalls = 0;
     const transport = new TerminalTransport({
-      refreshAuth: async () => { authCalls += 1; },
+      refreshAuth: async () => { authCalls += 1; return 'connection-token'; },
       openSocket: () => { const socket = new FakeSocket(); sockets.push(socket); return socket; },
     });
 
@@ -348,7 +348,7 @@ describe('terminal transport', () => {
     const sockets: FakeSocket[] = [];
     let authCalls = 0;
     const transport = new TerminalTransport({
-      refreshAuth: async () => { authCalls += 1; await tick(); },
+      refreshAuth: async () => { authCalls += 1; await tick(); return 'connection-token'; },
       openSocket: () => {
         const socket = new FakeSocket();
         sockets.push(socket);

--- a/packages/ui/src/lib/terminalApi.ts
+++ b/packages/ui/src/lib/terminalApi.ts
@@ -64,9 +64,9 @@ const trimProjection = (value: string): string => {
 };
 
 type TerminalTransportDependencies = {
-  refreshAuth: () => Promise<unknown>;
-  openSocket: () => RelayTunnelWebSocket;
-  clearUrlAuthToken?: () => void;
+  refreshAuth: () => Promise<string>;
+  openSocket: (urlAuthToken: string) => RelayTunnelWebSocket;
+  clearUrlAuthToken?: (expectedToken?: string) => void;
 };
 
 export class TerminalTransport {
@@ -84,7 +84,7 @@ export class TerminalTransport {
 
   constructor(private readonly dependencies: TerminalTransportDependencies = {
     refreshAuth: refreshRuntimeUrlAuthToken,
-    openSocket: () => openRuntimeWebSocket(getRuntimeUrlResolver().websocket('/api/terminal/ws')),
+    openSocket: (urlAuthToken) => openRuntimeWebSocket(getRuntimeUrlResolver().websocket('/api/terminal/ws', undefined, urlAuthToken)),
     clearUrlAuthToken: clearRuntimeUrlAuthToken,
   }) {}
 
@@ -172,7 +172,7 @@ export class TerminalTransport {
     }
     const generation = this.generation;
     const opening = (async () => {
-      await this.dependencies.refreshAuth();
+      const urlAuthToken = await this.dependencies.refreshAuth();
       if (generation !== this.generation || this.disposed) throw new Error('Terminal runtime changed');
       await new Promise<void>((resolve, reject) => {
         let settled = false;
@@ -188,7 +188,7 @@ export class TerminalTransport {
         const invalidatePreOpenAuth = () => {
           if (authInvalidated || opened || !isCurrentSocket()) return;
           authInvalidated = true;
-          this.dependencies.clearUrlAuthToken?.();
+          this.dependencies.clearUrlAuthToken?.(urlAuthToken);
         };
         const finish = (error?: Error) => {
           if (settled) return;
@@ -203,7 +203,7 @@ export class TerminalTransport {
           finish(new Error('Terminal connection timed out'));
         }, 10_000);
         try {
-          const socket = this.dependencies.openSocket();
+          const socket = this.dependencies.openSocket(urlAuthToken);
           pendingSocket = socket;
           socket.binaryType = 'arraybuffer';
           this.socket = socket;

--- a/packages/web/server/lib/stt/DOCUMENTATION.md
+++ b/packages/web/server/lib/stt/DOCUMENTATION.md
@@ -19,7 +19,7 @@ This module owns final-only composer dictation for web, Electron, hosted mobile,
 - `DELETE /api/stt/models/:modelId`
 - `WS /api/stt/ws`
 
-All routes use the existing `/api` authentication middleware. The WebSocket path is in both the URL-token and private-relay allowlists. Shared UI opens it through `openRuntimeWebSocket` after minting URL auth.
+All routes use the existing `/api` authentication middleware. The WebSocket path is in both the URL-token and private-relay allowlists. Shared UI opens it through `openRuntimeWebSocket` with the token returned by that connection's URL-auth mint. A failed older connection cannot clear a newer shared token.
 
 Remote URL and API-key values live in `<PiChamber data>/stt/config.json` with owner-only permissions where the platform supports them. Status responses redact API keys. WebSocket start frames carry only a stored provider configuration ID. They never accept a URL or credential.
 

--- a/packages/web/server/lib/terminal/DOCUMENTATION.md
+++ b/packages/web/server/lib/terminal/DOCUMENTATION.md
@@ -10,7 +10,7 @@
 
 - `attach` registers a connection for one terminal. One socket may attach to many terminals.
 - Every attach and reconnect begins with an authoritative `snapshot` containing bounded history and the current sequence.
-- A current socket that closes or errors before its initial `open` invalidates its URL-scoped auth token before retrying, so retries mint a fresh token instead of backing off against a rejected upgrade. Hidden or offline clients wait 60 seconds and wake promptly on visibility/online recovery.
+- A current socket that closes or errors before its initial `open` invalidates only the URL-scoped auth token used for that connection before retrying. A stale failure cannot clear a newer shared token minted for terminal, dictation, or events. Hidden or offline clients wait 60 seconds and wake promptly on visibility/online recovery.
 - `output`, `exit`, and `restarted` carry monotonically increasing per-terminal sequences. Output carries raw live bytes plus replay-safe bytes with terminal query exchanges removed.
 - Attach registers before capturing the snapshot, buffers concurrent events, drops events represented by the snapshot sequence, then enters live delivery.
 - `write` always includes the terminal ID; sockets never have mutable single-terminal binding state.


### PR DESCRIPTION
## Intent

Fix intermittent `HTTP Authentication failed; no valid credentials available` failures on long-lived `/api/terminal/ws` and `/api/stt/ws` WebSocket connections.

Terminal and dictation work at startup but stop working over time. The shared `oc_url_token` cache allowed a stale/failed connection to clear a newer token minted by another connection, and callers rebuilt the WebSocket URL from mutable global state instead of using the token they had just minted. Each WebSocket now uses the exact token returned by its own mint, and a failed connection only invalidates that same token.

Hypothesis that turned out correct: an older failed WebSocket cleared a newer shared URL-auth token, so simultaneous terminal/dictation/event reconnects poisoned each other.

## Non-goals

- No change to token TTL, server allowlists (`isUrlAuthWebSocketPath`, `ALLOWED_WS_PATHS`), or decrypt/secret behavior.
- No change to reconnect timing/backoff, idle-socket reuse, recording retention, or event-stream transport selection.
- No server-side auth or logging changes.

## Affected surfaces

- `packages/ui/src/lib/runtime-auth.ts`: `clearRuntimeUrlAuthToken(expectedToken?)` only clears when the cached token still matches.
- `packages/ui/src/lib/runtime-url.ts`: `websocket(path, query?, urlAuthToken?)` can embed a connection-bound token instead of re-reading global state.
- `packages/ui/src/lib/terminalApi.ts`, `packages/ui/src/lib/dictation/dictation-client.ts`, `packages/ui/src/lib/pi/transport.ts`: pass the minted token through to URL construction and scoped invalidation.
- Docs: `packages/web/server/lib/terminal/DOCUMENTATION.md`, `packages/web/server/lib/stt/DOCUMENTATION.md`.
- Runtimes: shared UI path, so web, desktop, hosted mobile, and Capacitor all use the same fix. Relay mode is preserved because minting still rides `runtimeFetch`/tunnel and sockets still open via `openRuntimeWebSocket`.
- No persisted data, routes, IDs, exports, or package entrypoints changed.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` instruction order, runtime boundaries, correctness invariants | Shared UI change touching runtime auth/transport contracts | Read nearest `DOCUMENTATION.md` files and package READMEs before editing; kept domain logic in owning modules; scoped the fix to the token lifecycle without inventing fallbacks |
| `pichamber-change-discipline` | Source, export-shape, and module-contract change | Smallest complete change; preserved existing behavior; updated owning docs; validated with focused plus workspace-wide checks |
| `ui-api-decoupling` + `references/browser-assets-and-auth.md`, `references/implementation-map.md` | Runtime URL/auth, browser-owned WebSocket URLs, scoped `oc_url_token` handling | No manual token appending; no long-lived bearer in URLs; resolver remains the only URL builder; runtime-switch cache behavior untouched |
| `relay-transport` | WebSocket/auth changes under UI/server relay modules | Still opens via `openRuntimeWebSocket`; URL token still minted before connect; no origin handling touched; no wire/codec change; both WS paths were already in both allowlists |
| `diagnosing-bugs` | Intermittent auth failure report | Built agent-runnable loops first (400 fresh-token upgrades green; 75s aging run green through expiry); minimized to the shared-cache race; regression test failed before, passes after; temp scripts removed |
| `packages/web/server/lib/terminal/DOCUMENTATION.md`, `packages/web/server/lib/stt/DOCUMENTATION.md`, `packages/web/server/lib/ui-auth/DOCUMENTATION.md`, `packages/web/server/lib/relay/DOCUMENTATION.md` | Owning docs for terminal transport, dictation transport, URL auth, and relay | Updated terminal/STT docs to state connection-bound invalidation; relay/ui-auth contracts unchanged |

## Validation

| Check | Result |
|---|---|
| Real upgrade loop, fresh tokens, both WS paths (temp script, since removed) | PASS: 400 upgrades succeeded |
| Real aging loop across 60s token expiry with shared client cache (temp script, since removed) | PASS: 150 upgrades succeeded |
| `bun test packages/ui/src/lib/runtime-auth.test.ts packages/ui/src/lib/runtime-url.test.ts packages/ui/src/lib/terminalApi.test.ts packages/ui/src/lib/pi/transport.test.ts` | PASS: 43 tests, 0 fail |
| New regression `does not let a stale connection clear a newer URL auth token` | Failed before fix, passes after |
| `bun run test` (web + ui + electron) | PASS |
| `bun run type-check` | PASS (all workspaces) |
| `bun run lint` | PASS (all workspaces) |
| `bun run --cwd packages/web build` | PASS |
| `bun run dead-code` | Ran; report inspected, no related issue |

Not verified: long-lived manual session against the updated production build; the running `pichamber.service` on port 10000 has not been rebuilt/restarted with these changes yet.

## Visual evidence

No user-visible change. The diff only changes which already-minted short-lived token string is embedded in WebSocket URLs and which token value a failed connection may clear. No components, styling, copy, layout, or interaction states changed, so there is no before/after screenshot or recording that could represent it.

## Risks and failure behavior

- Rollback: reverting restores the old shared-clear behavior; no migration or persisted state involved.
- Compatibility: `clearRuntimeUrlAuthToken()` with no argument still clears unconditionally, so existing callers/tests are unaffected. `websocket()` without an explicit token behaves exactly as before.
- Security: narrows invalidation; never logs or persists tokens; no long-lived credential enters URLs.
- Performance: no extra mints, timers, or retries; one string comparison on clear.
- Cross-runtime: direct and relay paths share the same helpers; Electron preload/IPC untouched; mobile/Capacitor use the same shared UI transport.
