### PR TITLE
fix(ui): use the registered filesystem clone route

### DIFF
--- a/packages/ui/src/components/session/useDirectoryCloneAndAdd.ts
+++ b/packages/ui/src/components/session/useDirectoryCloneAndAdd.ts
@@ -121,7 +121,7 @@ export function useDirectoryCloneAndAdd({
             toast.error('Enter a repository URL before cloning.');
             return;
           }
-          const response = await runtimeFetch('/api/git/clone', {
+          const response = await runtimeFetch('/api/fs/clone', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({

--- a/packages/web/server/lib/fs/DOCUMENTATION.md
+++ b/packages/web/server/lib/fs/DOCUMENTATION.md
@@ -12,6 +12,7 @@ Own filesystem API behavior for the web server runtime, including workspace-boun
   - Registers all filesystem routes:
     - `GET /api/fs/home`
     - `POST /api/fs/mkdir`
+    - `POST /api/fs/clone`
     - `GET /api/fs/read`
     - `GET /api/fs/raw`
     - `GET /api/fs/serve/:path(*)`
@@ -36,4 +37,5 @@ Own filesystem API behavior for the web server runtime, including workspace-boun
 - Keep filesystem policy (workspace root checks, error mapping, exec timeout behavior) inside this module, not in the composition root.
 - Filesystem `EPERM`/`EACCES` failures use the stable `reason: "os-permission"` response marker. Policy denials such as workspace-boundary or missing-grant failures must not use that marker because a native folder picker cannot remediate them.
 - If adding new `/api/fs/*` endpoints, add them in `routes.js` and extend this document.
-- `GET /api/fs/list` may resolve symlinks with `realpath` to read directory contents, but the response `path` and each entry `path` must stay in the caller's requested path space (`path.join(requestedPath, name)`). Returning real paths breaks file-tree expansion for directories reached through workspace symlinks.
+- `POST /api/fs/clone` clones a repository into the requested destination and can apply a stored Git identity. It returns the cloned path and rejects an existing destination with HTTP 409.
+- `GET /api/fs/list` may resolve symlinks with `realpath` to read directory contents, but the response `path` and each entry `path` must stay in the caller’s requested path space (`path.join(requestedPath, name)`). Returning real paths breaks file-tree expansion for directories reached through workspace symlinks.

--- a/packages/web/server/lib/fs/routes.test.js
+++ b/packages/web/server/lib/fs/routes.test.js
@@ -200,6 +200,26 @@ const registerMkdir = (fsPromises) => {
   return getRoute('POST', '/api/fs/mkdir');
 };
 
+const registerClone = ({ fsPromises, spawn }) => {
+  const { app, getRoute } = createRouteRegistry();
+  registerFsRoutes(app, {
+    os: { homedir: () => '/home/user' },
+    path: path.posix,
+    fsPromises: {
+      realpath: async (targetPath) => targetPath,
+      ...fsPromises,
+    },
+    spawn,
+    crypto: { randomUUID: () => 'job-0' },
+    normalizeDirectoryPath: (p) => p,
+    resolveProjectDirectory: async () => ({ directory: '/repo' }),
+    buildAugmentedPath: () => '/usr/bin',
+    resolveGitBinaryForSpawn: () => 'git',
+    pichamberUserConfigRoot: '/home/user/.config',
+  });
+  return getRoute('POST', '/api/fs/clone');
+};
+
 const registerReveal = ({ fsPromises, spawn, platform = 'linux' }) => {
   const { app, getRoute } = createRouteRegistry();
   registerFsRoutes(app, {
@@ -246,6 +266,12 @@ const callRaw = async (handler, query) => {
 };
 
 const callMkdir = async (handler, body) => {
+  const res = createMockResponse();
+  await handler({ body }, res);
+  return res;
+};
+
+const callClone = async (handler, body) => {
   const res = createMockResponse();
   await handler({ body }, res);
   return res;
@@ -455,6 +481,54 @@ describe('fs read', () => {
     expect(fsPromises.readFile).toHaveBeenCalledTimes(4);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('Read retry exhausted for /repo/file.txt'));
     warn.mockRestore();
+  });
+});
+
+describe('fs clone', () => {
+  it('clones into a new destination through the registered route', async () => {
+    const notFound = () => Promise.reject(Object.assign(new Error('not found'), { code: 'ENOENT' }));
+    const fsPromises = {
+      stat: vi.fn(notFound),
+      access: vi.fn(notFound),
+      mkdir: vi.fn(async () => undefined),
+    };
+    const { spawn } = createSpawn();
+    const handler = registerClone({ fsPromises, spawn });
+
+    const res = await callClone(handler, {
+      remoteUrl: 'https://github.com/example/repository.git',
+      destinationPath: '/home/user/projects/repository',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      success: true,
+      path: '/home/user/projects/repository',
+      output: '',
+    });
+    expect(fsPromises.mkdir).toHaveBeenCalledWith('/home/user/projects', { recursive: true });
+    expect(spawn).toHaveBeenCalledWith(
+      'git',
+      ['clone', '--', 'https://github.com/example/repository.git', 'repository'],
+      expect.objectContaining({
+        cwd: '/home/user/projects',
+        env: expect.objectContaining({ GIT_TERMINAL_PROMPT: '0' }),
+      }),
+    );
+  });
+
+  it('rejects a clone request without a repository URL', async () => {
+    const { spawn } = createSpawn();
+    const handler = registerClone({
+      fsPromises: { stat: vi.fn(), access: vi.fn(), mkdir: vi.fn() },
+      spawn,
+    });
+
+    const res = await callClone(handler, { destinationPath: '/home/user/projects/repository' });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: 'Repository URL is required' });
+    expect(spawn).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Intent

The Add new folder clone flow posts to `/api/git/clone`, but the web server registers the existing clone handler at `/api/fs/clone`. Express therefore returns 404 before any Git operation starts. This changes the shared UI to call the registered route and adds regression coverage for that route.

## Non-goals

The clone implementation, destination handling, Git identity selection, authentication, and dialog layout are unchanged.

## Affected surfaces

- `packages/ui`: the shared Add new folder flow now reaches the existing filesystem clone endpoint.
- `packages/web`: filesystem route coverage and documentation now include `POST /api/fs/clone`.
- Web, Electron, hosted mobile, and Capacitor mobile use the same active PiChamber server route. No runtime-specific implementation changes are needed.
- No persisted data or new external endpoint was added. The existing `/api/fs/clone` contract is now used by its caller.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` | This changes shared UI data access and a server route contract. | The fix stays within the owning UI and filesystem modules, preserves runtime parity, and adds no secrets or dependencies. |
| `pichamber-change-discipline` | Source, tests, and module documentation are changed. | The change is limited to the route mismatch, follows nearby route tests, and validates the affected workspaces plus the repository checks. |
| `ui-api-decoupling` and `references/implementation-map.md` | The shared UI calls a PiChamber HTTP endpoint and the reference maps filesystem route registration. | The UI uses `runtimeFetch` with the registered `/api/fs/clone` path, while the server implementation remains in `packages/web/server/lib/fs/routes.js`. |
| `packages/web/README.md` | The web package owns the server runtime used by the flow. | The existing server/runtime contract remains unchanged. |
| `packages/web/server/lib/fs/DOCUMENTATION.md` | The filesystem route list and behavior need to match the implementation. | The existing clone endpoint is now documented. |
| `CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md` | This is a pull request handoff. | The PR includes intent, scope, affected runtimes, guidance, validation, and failure behavior. |

## Validation

| Check | Result |
|---|---|
| `bun install --frozen-lockfile` | Passed. |
| `bun run --cwd packages/web test -- server/lib/fs/routes.test.js` | Passed: 1 file, 36 tests. |
| `bun run test:web` | Passed: 69 files, 635 tests. |
| `bun run type-check` | Passed for mobile, UI, web, and Electron. |
| `bun run lint` | Passed for mobile, UI, web, and Electron. |
| `bun run build` | Passed. |
| `bun run test` | Passed: UI, web, and Electron test suites all passed. |
| `bun run docs:validate` | Passed: 8 pages and 8 sidebar links. |
| `node --check packages/web/server/lib/fs/routes.js` | Passed. |
| `git diff --check` | Passed. |

## Visual evidence

No screenshots or recordings are needed. The rendered dialog and its styling are unchanged; only the endpoint used after submitting a clone was corrected.

## Risks and failure behavior

The existing filesystem clone handler still owns validation, destination conflict handling, Git execution, identity application, and error responses. A clone failure remains a failed request and the UI keeps its existing error toast. The change does not add a compatibility alias, alter credentials, or change persisted data. The route test verifies that a valid request reaches `git clone` and that invalid input is rejected before spawning Git.
