### PR TITLE
Fix model favorites persistence across sessions

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -15,6 +15,7 @@ import { WorktreeCreationToasts } from '@/components/worktree/WorktreeCreationTo
 import { useRouter } from '@/hooks/useRouter';
 import type { RuntimeAPIs } from '@/lib/api/types';
 import { syncDesktopSettings } from '@/lib/persistence';
+import { startModelPrefsAutoSave } from '@/lib/modelPrefsAutoSave';
 import { subscribeRuntimeEndpointChanged } from '@/lib/runtime-switch';
 import { WindowTitleEffect } from '@/hooks/useWindowTitle';
 
@@ -52,7 +53,19 @@ function App({ apis }: { apis?: RuntimeAPIs }) {
   // switch, an auth failure unmounts App before this reruns, so settings are
   // not fetched against a runtime that has not been unlocked yet.
   React.useEffect(() => {
-    void syncDesktopSettings();
+    let active = true;
+    let stopModelPrefsAutoSave: (() => void) | null = null;
+
+    void syncDesktopSettings().then(() => {
+      if (active) {
+        stopModelPrefsAutoSave = startModelPrefsAutoSave();
+      }
+    });
+
+    return () => {
+      active = false;
+      stopModelPrefsAutoSave?.();
+    };
   }, [runtimeEndpointEpoch]);
 
   React.useEffect(() => {

--- a/packages/ui/src/apps/renderElectronMiniChatApp.tsx
+++ b/packages/ui/src/apps/renderElectronMiniChatApp.tsx
@@ -16,13 +16,15 @@ import { ElectronMiniChatApp } from './ElectronMiniChatApp';
 
 const initializeSharedPreferences = () => {
 
-  void initializeAppearancePreferences().then(() => {
-    void Promise.all([
-      syncDesktopSettings(),
-      applyPersistedDirectoryPreferences(),
-    ]).catch((err) => {
+  void initializeAppearancePreferences().then(async () => {
+    try {
+      await Promise.all([
+        syncDesktopSettings(),
+        applyPersistedDirectoryPreferences(),
+      ]);
+    } catch (err) {
       console.error('[mini-chat-main] settings init failed:', err);
-    });
+    }
 
     startAppearanceAutoSave();
     startModelPrefsAutoSave();

--- a/packages/ui/src/apps/renderMobileApp.tsx
+++ b/packages/ui/src/apps/renderMobileApp.tsx
@@ -21,13 +21,15 @@ import { MobileApp } from './MobileApp';
 
 const initializeSharedPreferences = () => {
 
-  void initializeAppearancePreferences().then(() => {
-    void Promise.all([
-      syncDesktopSettings(),
-      applyPersistedDirectoryPreferences(),
-    ]).catch((err) => {
+  void initializeAppearancePreferences().then(async () => {
+    try {
+      await Promise.all([
+        syncDesktopSettings(),
+        applyPersistedDirectoryPreferences(),
+      ]);
+    } catch (err) {
       console.error('[mobile-main] settings init failed:', err);
-    });
+    }
 
     startAppearanceAutoSave();
     startModelPrefsAutoSave();

--- a/packages/ui/src/lib/modelPrefsAutoSave.ts
+++ b/packages/ui/src/lib/modelPrefsAutoSave.ts
@@ -74,11 +74,10 @@ export const startModelPrefsAutoSave = () => {
   }
 
   let timer: number | null = null;
-  let lastSent: ModelPrefsPayload | null = null;
-  let didSkipInitial = false;
+  let lastSent: ModelPrefsPayload | null = cloneModelPrefs(snapshotModelPrefs());
   let scheduledRuntimeKey: string | null = null;
 
-  const flush = () => {
+  const flush = (immediate = false) => {
     timer = null;
     const runtimeKey = scheduledRuntimeKey;
     scheduledRuntimeKey = null;
@@ -91,14 +90,10 @@ export const startModelPrefsAutoSave = () => {
 
     lastSent = cloneModelPrefs(payload);
 
-    void updateDesktopSettings(payload).catch(() => {});
+    void updateDesktopSettings(payload, { immediate }).catch(() => {});
   };
 
   const schedule = () => {
-    if (!didSkipInitial) {
-      didSkipInitial = true;
-      return;
-    }
     if (timer !== null) {
       window.clearTimeout(timer);
     }
@@ -106,10 +101,10 @@ export const startModelPrefsAutoSave = () => {
     timer = window.setTimeout(flush, 1200);
   };
 
-  const unsubscribeRuntime = subscribeRuntimeEndpointWillChange(() => {
+  const unsubscribeRuntime = subscribeRuntimeEndpointWillChange((detail) => {
+    if (detail.runtimeKey === detail.previousRuntimeKey) return;
     if (timer !== null) window.clearTimeout(timer);
-    timer = null;
-    scheduledRuntimeKey = null;
+    flush(true);
     lastSent = null;
   });
 
@@ -142,5 +137,6 @@ export const startModelPrefsAutoSave = () => {
     if (timer !== null) {
       window.clearTimeout(timer);
     }
+    flush(true);
   };
 };

--- a/packages/ui/src/lib/persistence.test.ts
+++ b/packages/ui/src/lib/persistence.test.ts
@@ -589,6 +589,57 @@ describe('updateDesktopSettings', () => {
     }
   });
 
+  test('flushes replaced favorites when the app lifecycle stops', async () => {
+    getWindow();
+    useUIStore.setState({
+      favoriteModels: [{ providerID: 'anthropic', modelID: 'claude-haiku-4' }],
+    });
+    const saveCalls: Array<Partial<SettingsPayload>> = [];
+    registerSettingsSave(async (changes) => {
+      saveCalls.push(changes);
+      return changes as SettingsPayload;
+    });
+    const stop = startModelPrefsAutoSave();
+
+    useUIStore.getState().toggleFavoriteModel('anthropic', 'claude-haiku-4');
+    useUIStore.getState().toggleFavoriteModel('openai', 'gpt-5');
+    stop();
+    await delay(20);
+
+    expect(saveCalls).toHaveLength(1);
+    expect(saveCalls[0]?.favoriteModels).toEqual([
+      { providerID: 'openai', modelID: 'gpt-5' },
+    ]);
+  });
+
+  test('flushes replaced favorites to the old runtime before switching', async () => {
+    getWindow();
+    switchRuntimeEndpoint({ apiBaseUrl: 'https://favorites-a.example', runtimeKey: 'favorites-a' });
+    useUIStore.setState({
+      favoriteModels: [{ providerID: 'anthropic', modelID: 'claude-haiku-4' }],
+    });
+    const saveCalls: Array<Partial<SettingsPayload>> = [];
+    registerSettingsSave(async (changes) => {
+      saveCalls.push(changes);
+      return changes as SettingsPayload;
+    });
+    const stop = startModelPrefsAutoSave();
+
+    try {
+      useUIStore.getState().toggleFavoriteModel('anthropic', 'claude-haiku-4');
+      useUIStore.getState().toggleFavoriteModel('openai', 'gpt-5');
+      switchRuntimeEndpoint({ apiBaseUrl: 'https://favorites-b.example', runtimeKey: 'favorites-b' });
+      await delay(20);
+
+      expect(saveCalls).toHaveLength(1);
+      expect(saveCalls[0]?.favoriteModels).toEqual([
+        { providerID: 'openai', modelID: 'gpt-5' },
+      ]);
+    } finally {
+      stop();
+    }
+  });
+
   test('autosaves reasoning preference changes to shared settings', async () => {
     getWindow();
     useUIStore.getState().setShowReasoningTraces(false);

--- a/packages/ui/src/lib/persistence.ts
+++ b/packages/ui/src/lib/persistence.ts
@@ -376,7 +376,8 @@ async function _flushSettingsUpdate(): Promise<void> {
 }
 
 export const updateDesktopSettings = async (
-  changes: Partial<DesktopSettings>
+  changes: Partial<DesktopSettings>,
+  options: { immediate?: boolean } = {},
 ): Promise<void> => {
   if (typeof window === 'undefined') {
     return;
@@ -402,10 +403,14 @@ export const updateDesktopSettings = async (
   const flushed = new Promise<void>((resolve) => {
     _settingsFlushWaiters.push(resolve);
   });
-  _settingsFlushTimer = setTimeout(
-    () => void _flushSettingsUpdate(),
-    SETTINGS_DEBOUNCE_MS
-  );
+  if (options.immediate) {
+    void _flushSettingsUpdate();
+  } else {
+    _settingsFlushTimer = setTimeout(
+      () => void _flushSettingsUpdate(),
+      SETTINGS_DEBOUNCE_MS
+    );
+  }
   return flushed;
 };
 

--- a/packages/ui/src/stores/DOCUMENTATION.md
+++ b/packages/ui/src/stores/DOCUMENTATION.md
@@ -15,6 +15,8 @@ Use a store only for state shared across distant component trees or for a cache 
 
 `useSessionFoldersStore.ts` keeps a runtime-scoped browser snapshot for immediate continuity and reconciles it with the active server's validated `/api/pi/session-folders` sidecar. Missing server state is not authoritative empty state, and in-flight hydration cannot replace newer local mutations.
 
+Model-picker preferences hydrate from the active runtime before autosave starts. Every later change is eligible for persistence, and pending changes flush to their captured runtime before app teardown or a runtime switch.
+
 Caches and async work must be scoped to the active runtime. A failed authoritative request must preserve existing state and remain distinguishable from a successful empty result.
 
 `useWorktreeStore.refreshProject()` coalesces discovery by runtime and project, rejects stale runtime completions, and keeps linked-worktree arrays reference-stable when topology is unchanged. `WorktreeDiscovery` refreshes with bounded concurrency while the app is visible; hidden UI does no polling.


### PR DESCRIPTION
## Intent

Model-picker favorites could revert after removing one favorite, adding another, and moving to a new session or runtime. The autosave skipped the first preference mutation, canceled pending work during lifecycle changes, and was not started by the main app.

This change starts model preference autosave after authoritative settings hydration on every app entrypoint. It records the first later mutation and flushes pending model preferences to their captured runtime before teardown or a runtime switch.

## Non-goals

- No changes to model-picker layout, favorite ordering, or visual states.
- No changes to the persisted settings schema.
- The normal 1.2-second model-preference debounce remains unchanged.

## Affected surfaces

- `packages/ui` shared settings persistence and model preference state.
- Web and desktop main app startup now enables model preference autosave.
- Capacitor mobile and Electron mini-chat now wait for settings hydration before enabling autosave.
- Persisted model preferences, including favorites, hidden models, collapsed providers, recent models and agents, and recent efforts.
- No server route or runtime API contract changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` | This changes shared UI persistence across runtimes. | Keeps the fix in the shared UI owner, preserves runtime identity, updates owning documentation, and validates the full suite. |
| `pichamber-change-discipline` | Executable source and persisted behavior changed. | Uses a focused change, adds lifecycle and runtime-switch regression coverage, and checks failure and ordering behavior. |
| `sync-state-invariants` | Favorites exist in memory and server-backed settings, with pending asynchronous writes. | Hydrates before autosave, no longer drops the first mutation, and flushes a pending write against its captured runtime before switching. |
| `ui-api-decoupling` and implementation map | Shared settings use `RuntimeAPIs` and runtime switching. | Reuses `updateDesktopSettings` and the established runtime-switch lifecycle instead of adding transport-specific behavior. |
| `packages/ui/src/stores/DOCUMENTATION.md` | This is the nearest owning module documentation. | Documents hydration ordering and pending-write durability. |

## Validation

| Check | Result |
|---|---|
| `bun test --isolate packages/ui/src/lib/persistence.test.ts --test-name-pattern 'flushes replaced favorites'` before the fix | Reproduced the bug: expected one save, received zero. |
| `bun test --isolate packages/ui/src/lib/persistence.test.ts --test-name-pattern 'flushes replaced favorites'` after the fix | 2 passed. |
| `bun test --isolate packages/ui/src/lib/persistence.test.ts` | 27 passed. |
| `bun run --cwd packages/ui type-check` | Passed. |
| `bun run --cwd packages/ui lint` | Passed. |
| `bun run --cwd packages/ui test` | 2,087 passed. |
| `bun run test` | Passed across web, UI, and Electron suites. |
| `bun run docs:validate` | Passed. |
| `bun run dead-code` | Completed; reported existing non-blocking unused exports/types, with no new finding from this change. |

No manual browser, desktop, or mobile runtime session was run.

## Visual evidence

Not applicable. The change only affects when existing model preference state is hydrated and saved. It does not alter rendered markup, styling, labels, or interaction controls.

## Risks and failure behavior

- Immediate lifecycle flushes bypass only the settings debounce. They still use the existing settings API, runtime context checks, save-state reporting, and authentication handling.
- A runtime switch starts the pending save while the old runtime is still authoritative. A stale response cannot overwrite state in the new runtime.
- If a save fails, the existing central settings failure behavior remains in effect. The local in-memory favorite selection is not rolled back.
- Existing persisted payloads remain compatible because the settings shape is unchanged.
- No credentials, routes, privilege boundaries, or dependencies changed.
