### PR TITLE
fix(ui): compact mobile live-feed activity spacing

### DIFF
--- a/packages/ui/src/components/chat/ChatMessage.tsx
+++ b/packages/ui/src/components/chat/ChatMessage.tsx
@@ -504,7 +504,8 @@ const ChatMessage: React.FC<ChatMessageProps> = ({
                           borderBottomRightRadius: 'var(--radius-sm)',
                         }}
                         className={cn(
-                          'px-5 py-3 shadow-none border border-primary/5',
+                          'shadow-none border border-primary/5',
+                          isMobile ? 'px-3 py-2' : 'px-5 py-3',
                           !isMobile && 'pb-4',
                         )}
                       >

--- a/packages/ui/src/components/chat/components/TurnActivityRail.tsx
+++ b/packages/ui/src/components/chat/components/TurnActivityRail.tsx
@@ -373,7 +373,7 @@ const TurnActivityRail: React.FC<{
                                         Load earlier activity
                                     </Button>
                                 ) : null}
-                                <div className="min-w-0 space-y-1">
+                                <div className="min-w-0 space-y-1" data-chat-activity-list="true">
                                     {visibleActivity.activities.map(renderActivity)}
                                 </div>
                             </div>

--- a/packages/ui/src/components/chat/message/parts/AssistantTextPart.tsx
+++ b/packages/ui/src/components/chat/message/parts/AssistantTextPart.tsx
@@ -82,6 +82,8 @@ const AssistantTextPart: React.FC<AssistantTextPartProps> = ({
                 'group/assistant-text relative w-full min-w-0 break-words',
                 withinActivityRail ? 'py-1' : 'pt-3 pb-1',
             )}
+            data-chat-activity-text={withinActivityRail ? 'true' : undefined}
+            data-chat-assistant-text="true"
             key={part.id || `${messageId}-text`}
         >
             <MarkdownRenderer

--- a/packages/ui/src/components/chat/message/parts/ReasoningPart.tsx
+++ b/packages/ui/src/components/chat/message/parts/ReasoningPart.tsx
@@ -423,6 +423,7 @@ export const ReasoningTimelineBlock: React.FC<ReasoningTimelineBlockProps> = ({
                 className={cn(
                     'group/tool flex items-center gap-1.5 py-1 pr-2 pl-px cursor-pointer',
                 )}
+                data-chat-activity-row="true"
                 onClick={handleToggle}
                 onKeyDown={handleKeyDown}
             >
@@ -462,7 +463,7 @@ export const ReasoningTimelineBlock: React.FC<ReasoningTimelineBlockProps> = ({
 
                 {!isExpanded && summary ? (
                     <span
-                        className={cn('flex h-5 flex-1 items-center min-w-0 truncate typography-code font-mono text-[length:var(--text-markdown)] leading-none tracking-normal')}
+                        className={cn('flex h-5 flex-1 items-center min-w-0 truncate typography-code font-mono text-[length:var(--text-code)] leading-none tracking-normal')}
                         style={{ color: 'var(--tools-description)', opacity: 0.8 }}
                         title={summary}
                     >
@@ -503,7 +504,7 @@ export const ReasoningTimelineBlock: React.FC<ReasoningTimelineBlockProps> = ({
                         <ScrollableOverlay
                             ref={innerScrollRef}
                             as="div"
-                            outerClassName="max-h-80 w-full min-w-0"
+                            outerClassName="oc-reasoning-scroll max-h-80 w-full min-w-0"
                             className="p-0"
                             useScrollShadow
                             scrollShadowSize={36}

--- a/packages/ui/src/components/chat/message/parts/StaticToolRow.tsx
+++ b/packages/ui/src/components/chat/message/parts/StaticToolRow.tsx
@@ -458,12 +458,13 @@ const StaticToolRowInner: React.FC<{
 
     return (
         <div
-            // oc-static-tool-row: on touch devices mobile.css raises this to the
-            // same 36px floor the [role="button"] expandable/reasoning rows get,
-            // so static and expandable rows have identical rhythm.
+            // oc-static-tool-row: on touch devices mobile.css gives this the
+            // same compact 28px floor as the expandable/reasoning rows, so
+            // static and expandable rows keep the same rhythm.
             className={cn(
                 'oc-static-tool-row flex w-full items-center gap-x-1.5 pr-2 pl-px py-1 min-w-0'
             )}
+            data-chat-activity-row="true"
         >
             <div className="inline-flex h-5 items-center flex-shrink-0" style={{ color: 'var(--tools-icon)' }}>
                 {icon}

--- a/packages/ui/src/components/chat/message/parts/TaskToolSummary.tsx
+++ b/packages/ui/src/components/chat/message/parts/TaskToolSummary.tsx
@@ -162,7 +162,7 @@ const TaskSummaryEntriesList = React.memo(({
 
     return (
         <ToolScrollableSection maxHeightClass={isExpanded ? 'max-h-[40vh]' : 'max-h-[min(17.5rem,45vh)]'} disableHorizontal>
-            <div className="w-full min-w-0 space-y-1">
+            <div className="w-full min-w-0 space-y-1" data-chat-task-entries-list="true">
                 {hiddenCount > 0 ? (
                     <div className="typography-micro text-muted-foreground/70">+{hiddenCount} more…</div>
                 ) : null}
@@ -226,7 +226,7 @@ export const TaskToolSummary: React.FC<{
 
     if (entries.length === 0 && !hasOutput && !sessionId) {
         return (
-            <div className="relative pr-2 pb-2 pt-2 space-y-2 pl-[1.4375rem]">
+            <div className="oc-task-tool-summary relative pr-2 pb-2 pt-2 space-y-2 pl-[1.4375rem]">
                 <div className="typography-meta text-muted-foreground/70">
                     {isActive ? 'Waiting for subagent activity...' : 'No subagent session id on task metadata.'}
                 </div>
@@ -237,7 +237,7 @@ export const TaskToolSummary: React.FC<{
     return (
         <div
             className={cn(
-                'relative pr-2 pb-2 pt-2 space-y-2 pl-[1.4375rem]',
+                'oc-task-tool-summary relative pr-2 pb-2 pt-2 space-y-2 pl-[1.4375rem]',
                 'before:absolute before:left-[0.4375rem] before:w-px before:bg-[var(--tools-border)] before:content-[""]',
                 'before:top-[-0.25rem] before:bottom-0'
             )}

--- a/packages/ui/src/components/chat/message/parts/ToolExpandedContent.tsx
+++ b/packages/ui/src/components/chat/message/parts/ToolExpandedContent.tsx
@@ -597,7 +597,7 @@ export const ToolExpandedContent: React.FC<ToolExpandedContentProps> = React.mem
     if (isTodoTool) {
         if (state.status === 'error' && 'error' in state) {
             return (
-                <div className="relative pr-2 pb-2 pt-2 space-y-2 pl-4">
+                <div className="oc-tool-expanded-body relative pr-2 pb-2 pt-2 space-y-2 pl-4">
                     <div className="typography-meta font-medium text-muted-foreground/80 mb-1">{"Error:"}</div>
                     <div className="typography-meta p-2 rounded-xl border" style={{
                         backgroundColor: 'var(--status-error-background)',
@@ -619,7 +619,7 @@ export const ToolExpandedContent: React.FC<ToolExpandedContentProps> = React.mem
         }, { unstyled: true });
 
         return (
-            <div className="relative pr-2 pb-2 pt-2 space-y-2 pl-4">
+            <div className="oc-tool-expanded-body relative pr-2 pb-2 pt-2 space-y-2 pl-4">
                 {renderScrollableBlock(
                     todoOutput ?? (
                         <ToolScrollableTextOutput
@@ -638,7 +638,7 @@ export const ToolExpandedContent: React.FC<ToolExpandedContentProps> = React.mem
     return (
         <div
             className={cn(
-                'relative pr-2 pb-2 pt-2 space-y-2 pl-4'
+                'oc-tool-expanded-body relative pr-2 pb-2 pt-2 space-y-2 pl-4'
             )}
         >
             {part.tool === 'question' ? (

--- a/packages/ui/src/components/chat/message/parts/ToolPart.tsx
+++ b/packages/ui/src/components/chat/message/parts/ToolPart.tsx
@@ -499,6 +499,7 @@ const ToolPartContent: React.FC<ToolPartProps> = ({
                     'group/tool flex w-full min-w-0 gap-x-1.5 rounded-md pr-2 pl-px py-1 transition-colors hover:bg-[var(--interactive-hover)]',
                     isMultiFileApplyPatch ? 'flex-wrap items-start cursor-pointer' : 'items-center cursor-pointer',
                 )}
+                data-chat-activity-row="true"
                 onClick={isMultiFileApplyPatch ? () => onToggle(part.id) : handleMainClick}
                 onKeyDown={isMultiFileApplyPatch ? (event) => {
                     if (event.target !== event.currentTarget) return;
@@ -692,6 +693,7 @@ const ToolPartContent: React.FC<ToolPartProps> = ({
                     {shouldRenderExpandedContent ? (
                         <div
                             className="relative ml-2 pl-3"
+                            data-chat-tool-indent="true"
                         >
                             <span
                                 aria-hidden="true"
@@ -747,7 +749,7 @@ class ToolPartErrorBoundary extends React.Component<{
 
         const message = this.state.error?.message;
         return (
-            <div className="flex items-center gap-1.5 pr-2 pl-px py-1 min-w-0">
+            <div className="flex items-center gap-1.5 pr-2 pl-px py-1 min-w-0" data-chat-activity-row="true">
                 <div className="h-3.5 w-3.5 flex-shrink-0" style={TOOL_ERROR_ICON_STYLE}>
                     {getToolIcon(this.props.toolName)}
                 </div>

--- a/packages/ui/src/styles/mobile.css
+++ b/packages/ui/src/styles/mobile.css
@@ -2,54 +2,115 @@
 
 /* General mobile improvements for all mobile devices */
 @media (max-width: 1024px) {
-  /* Override CSS custom properties for mobile */
-  :root.mobile-pointer:not(.desktop-runtime) {
-    --text-markdown: 1rem;
-    --text-code: 0.875rem;
-    --text-ui-header: 0.9375rem;
-    --text-ui-label: 0.875rem;
-    --text-meta: 0.875rem;
-    --text-micro: 0.8125rem;
-    --text-settings-page-title: 1.125rem;
+  /* Keep the feed on the same semantic scale as desktop, with one small step
+     down for phone-width reading. Components consume these variables directly;
+     class-name-based font overrides make tool titles and thinking inherit
+     unrelated sizes and are intentionally avoided. */
+  :root:is(.mobile-pointer, .device-mobile):not(.desktop-runtime) {
+    --text-markdown: 0.875rem;
+    --text-code: 0.75rem;
+    --text-ui-header: 0.875rem;
+    --text-ui-label: 0.8125rem;
+    --text-meta: 0.8125rem;
+    --text-micro: 0.75rem;
+    --text-settings-page-title: 1.0625rem;
   }
 
-  /* Force override with higher specificity */
-  :root.mobile-pointer:not(.desktop-runtime) * {
-    --text-markdown: 1rem !important;
-    --text-code: 0.875rem !important;
-    --text-ui-header: 0.9375rem !important;
-    --text-ui-label: 0.875rem !important;
-    --text-meta: 0.875rem !important;
-    --text-micro: 0.8125rem !important;
-    --text-settings-page-title: 1.125rem !important;
+  /* Theme updates can write typography variables on descendants, so keep the
+     mobile scale authoritative without changing the explicit 16px input rule. */
+  :root:is(.mobile-pointer, .device-mobile):not(.desktop-runtime) * {
+    --text-markdown: 0.875rem !important;
+    --text-code: 0.75rem !important;
+    --text-ui-header: 0.875rem !important;
+    --text-ui-label: 0.8125rem !important;
+    --text-meta: 0.8125rem !important;
+    --text-micro: 0.75rem !important;
+    --text-settings-page-title: 1.0625rem !important;
   }
 
-  /* Additional override for elements using typography classes */
-  :root.mobile-pointer:not(.desktop-runtime) .typography-markdown,
-  :root.mobile-pointer:not(.desktop-runtime) .typography-code,
-  :root.mobile-pointer:not(.desktop-runtime) .typography-ui-header,
-  :root.mobile-pointer:not(.desktop-runtime) .typography-ui-label,
-  :root.mobile-pointer:not(.desktop-runtime) .typography-meta,
-  :root.mobile-pointer:not(.desktop-runtime) .typography-micro {
-    font-size: unset !important;
+  /* Phone chat gutters are narrower than the desktop column gutters, while
+     still respecting the user's global padding scale. */
+  :root:is(.mobile-pointer, .device-mobile):not(.desktop-runtime) .chat-message-column {
+    padding-inline: calc(clamp(0.625rem, 2.5vw, 0.75rem) * var(--padding-scale, 1));
   }
 
-  /* Fix font size for tool displays */
-  :root.mobile-pointer:not(.desktop-runtime) [class*="tool"],
-  :root.mobile-pointer:not(.desktop-runtime) [class*="code"] {
-    --text-code: 0.875rem !important;
-    font-size: var(--text-code) !important;
+  :root:is(.mobile-pointer, .device-mobile):not(.desktop-runtime) [data-chat-activity-list] > :not(:first-child) {
+    margin-block-start: 0;
+  }
+
+  :root:is(.mobile-pointer, .device-mobile):not(.desktop-runtime) [data-chat-task-entries-list] > :not(:first-child) {
+    margin-block-start: 0.0625rem;
+  }
+
+  :root:is(.mobile-pointer, .device-mobile):not(.desktop-runtime) [data-turn-activity-rail] {
+    padding-left: 0.75rem;
+  }
+
+  :root:is(.mobile-pointer, .device-mobile):not(.desktop-runtime) [data-turn-activity-panel] > span[aria-hidden="true"] {
+    left: -0.75rem;
+  }
+
+  :root:is(.mobile-pointer, .device-mobile):not(.desktop-runtime) [data-chat-activity-row] {
+    padding-block: 0.125rem;
+    padding-right: 0.25rem;
+  }
+
+  :root:is(.mobile-pointer, .device-mobile):not(.desktop-runtime) [data-chat-tool-indent] {
+    margin-left: 0;
+    padding-left: 0.375rem;
+  }
+
+  :root:is(.mobile-pointer, .device-mobile):not(.desktop-runtime) .oc-tool-expanded-body {
+    padding: 0.125rem 0.125rem 0.125rem 0.5rem;
+  }
+
+  :root:is(.mobile-pointer, .device-mobile):not(.desktop-runtime) .oc-task-tool-summary {
+    padding: 0.125rem 0.125rem 0.125rem 0.375rem;
+  }
+
+  :root:is(.mobile-pointer, .device-mobile):not(.desktop-runtime) .oc-task-tool-summary::before {
+    left: 0;
+  }
+
+  :root:is(.mobile-pointer, .device-mobile):not(.desktop-runtime) .oc-tool-expanded-body > :not(:first-child),
+  :root:is(.mobile-pointer, .device-mobile):not(.desktop-runtime) .oc-task-tool-summary > :not(:first-child) {
+    margin-block-start: 0.25rem;
+  }
+
+  :root:is(.mobile-pointer, .device-mobile):not(.desktop-runtime) .oc-tool-expanded-body .tool-output-surface[class~="p-2"],
+  :root:is(.mobile-pointer, .device-mobile):not(.desktop-runtime) .oc-task-tool-summary .tool-output-surface[class~="p-2"] {
+    padding: 0.25rem;
+  }
+
+  :root:is(.mobile-pointer, .device-mobile):not(.desktop-runtime) [data-chat-assistant-text]:not([data-chat-activity-text]) {
+    padding-top: 0.5rem;
+    padding-bottom: 0.125rem;
+  }
+
+  :root:is(.mobile-pointer, .device-mobile):not(.desktop-runtime) .chat-message-column .message-content-text > :not(:first-child) {
+    margin-block-start: 0.375rem;
+  }
+
+  :root:is(.mobile-pointer, .device-mobile):not(.desktop-runtime) .oc-reasoning-scroll {
+    max-height: min(16rem, 40vh);
   }
 
   /* Improve touch targets for mobile */
   :root.mobile-pointer:not(.desktop-runtime) button:not([role="radio"]):not([role="checkbox"]):not([role="switch"]),
   :root.mobile-pointer:not(.desktop-runtime) .btn,
   :root.mobile-pointer:not(.desktop-runtime) [role="button"],
-  /* Static chat tool rows: not interactive as a whole, but they must share
-     the 36px rhythm of the [role="button"] expandable/reasoning rows. */
+  /* Static chat tool rows: not interactive as a whole, but they still need a
+     touch-sized floor. Activity rows opt into the compact 28px desktop rhythm
+     below without shrinking other mobile controls. */
   :root.mobile-pointer:not(.desktop-runtime) .oc-static-tool-row {
     min-height: 36px;
     min-width: 36px;
+  }
+
+  /* Keep the feed at desktop row height while leaving other mobile controls
+     on their larger touch target floor. */
+  :root:is(.mobile-pointer, .device-mobile):not(.desktop-runtime) [data-chat-activity-row] {
+    min-height: 1.75rem;
   }
 
   /* Composer footer icon-only actions (attach / settings). Hug the icon so
@@ -215,35 +276,9 @@
       -webkit-overflow-scrolling: touch;
     }
 
-    /* Mobile typography improvements */
-    .typography-markdown {
-      font-size: 1rem !important;
-    }
-
-    .typography-code {
-      font-size: 0.875rem !important;
-    }
-
-    .typography-ui-header {
-      font-size: 0.9375rem !important;
-    }
-
-    .typography-ui-label {
-      font-size: 0.875rem !important;
-    }
-
-    .typography-meta {
-      font-size: 0.875rem !important;
-    }
-
-    .typography-micro {
-      font-size: 0.8125rem !important;
-    }
-
-    /* Fix font size for tool displays */
-    [class*="tool"], [class*="code"] {
-      font-size: 0.875rem !important;
-    }
+    /* Feed typography is controlled by the semantic mobile variables in the
+       phone-width block above. Keep standalone surfaces on that same scale;
+       form controls retain their separate 16px anti-zoom rule. */
   }
 
   /* Fallback for non-iOS standalone mode */


### PR DESCRIPTION
## Intent

Compact the mobile chat live feed so tool calls, thinking rows, shell output, and task summaries use less vertical space and less nested indentation. Desktop styling remains unchanged.

## Non-goals

This PR does not change feed ordering, streaming state, tool behavior, API contracts, persisted data, or desktop touch targets.

## Affected surfaces

- `packages/ui` chat message parts and mobile styles.
- Mobile web and Capacitor-hosted chat layouts at phone/tablet widths.
- No server, Electron, API, persistence, or runtime contract changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` and `/home/ryder/.pi/agent/AGENTS.md` | Repository workflow, ownership, and git identity rules apply to every source change. | Kept the change in shared UI, used semantic theme variables, avoided dependencies and secrets, and committed as `RyderAsKing`. |
| `pichamber-change-discipline` | This changes shared UI source and module behavior. | Kept the selectors scoped to mobile roots and limited the component changes to explicit styling hooks. |
| `theme-system` and `theme-system/references/tokens-and-examples.md` | The change modifies UI typography, spacing, and visual states. | Reused semantic typography variables and existing theme colors instead of adding hard-coded theme colors. |
| `performance-engineering` | Chat activity rows and streaming tool output are render-sensitive paths. | Added static data attributes and CSS-only spacing rules without adding render-time work or new list processing. |
| `packages/ui/src/components/chat/message/parts/DOCUMENTATION.md` | The modified tool, reasoning, and task parts live in this documented module. | Preserved the existing part ownership and kept the change presentational. |
| Root `README.md` and `packages/mobile/README.md` | The change affects shared UI consumed by web and mobile builds. | Validated the workspace build and mobile web asset preparation; no native contract was changed. |

## Validation

| Check | Result |
|---|---|
| `git diff --check` | Passed. |
| `bun run build` | Passed. Web packages built and mobile web assets were prepared. |
| `bun run type-check` | Passed for web, UI, Electron, and mobile packages. |
| `bun run lint` | Passed for web, UI, Electron, and mobile packages. |
| `bun run test` | Passed: 2,090 tests across 262 files, plus Electron architecture and updater suites with 43 and 20 tests. |
| Manual simulator visual check | Not run. This session is on WSL2/Linux, so the macOS iOS simulator is unavailable. |

## Visual evidence

No screenshots are attached because the available environment cannot run the iOS simulator. The scoped rules target `.mobile-pointer` and `.device-mobile` roots, exclude desktop runtimes, and preserve the larger 36px floor for general mobile controls. Phone-width wrapping and dark/light theme rendering still need a device or browser visual pass.

## Risks and failure behavior

The main risk is visual wrapping on unusually narrow screens because tool and reasoning rows are intentionally smaller. The rules are scoped to mobile roots and do not affect desktop. No data or API state changes are involved. Reverting commit `a279414a` rolls back the change cleanly.
