### PR TITLE
Fix settings persistence before the first folder

### DIFF
--- a/packages/ui/src/App.settings-bootstrap.test.tsx
+++ b/packages/ui/src/App.settings-bootstrap.test.tsx
@@ -1,0 +1,137 @@
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+
+let resolveSettingsSync: (() => void) | null = null;
+let appearanceAutoSaveStarts = 0;
+let appearanceAutoSaveStops = 0;
+let modelPrefsAutoSaveStarts = 0;
+let modelPrefsAutoSaveStops = 0;
+
+mock.module('@/components/layout/MainLayout', () => ({ MainLayout: () => null }));
+mock.module('@/components/ui/sonner', () => ({ Toaster: () => null }));
+mock.module('@/components/ui/ErrorBoundary', () => ({ ErrorBoundary: () => null }));
+mock.module('@/components/ui/tooltip', () => ({ TooltipProvider: ({ children }: React.PropsWithChildren) => children }));
+mock.module('@/contexts/RuntimeAPIProvider', () => ({ RuntimeAPIProvider: ({ children }: React.PropsWithChildren) => children }));
+mock.module('@/contexts/runtimeAPIRegistry', () => ({
+  getRegisteredRuntimeAPIs: () => null,
+  registerRuntimeAPIs: () => undefined,
+}));
+mock.module('@/apps/AppEffects', () => ({ SyncAppEffects: () => null }));
+mock.module('@/apps/runtimeEndpointReset', () => ({ resetAppForRuntimeEndpointChange: () => undefined }));
+mock.module('@/apps/useAppFontEffects', () => ({ useAppFontEffects: () => undefined }));
+mock.module('@/sync/pi-session-context', () => ({ PiSessionProvider: ({ children }: React.PropsWithChildren) => children }));
+mock.module('@/contexts/FireworksContext', () => ({ FireworksProvider: ({ children }: React.PropsWithChildren) => children }));
+mock.module('@/components/perf/PerfHudHost', () => ({ PerfHudHost: () => null }));
+mock.module('@/components/worktree/WorktreeCreationToasts', () => ({ WorktreeCreationToasts: () => null }));
+mock.module('@/hooks/useRouter', () => ({ useRouter: () => undefined }));
+mock.module('@/hooks/useWindowTitle', () => ({ WindowTitleEffect: () => null }));
+mock.module('@/lib/runtime-switch', () => ({ subscribeRuntimeEndpointChanged: () => () => undefined }));
+mock.module('@/lib/persistence', () => ({
+  syncDesktopSettings: () => new Promise<void>((resolve) => {
+    resolveSettingsSync = resolve;
+  }),
+}));
+mock.module('@/lib/appearanceAutoSave', () => ({
+  startAppearanceAutoSave: () => {
+    appearanceAutoSaveStarts += 1;
+    return () => {
+      appearanceAutoSaveStops += 1;
+    };
+  },
+}));
+mock.module('@/lib/modelPrefsAutoSave', () => ({
+  startModelPrefsAutoSave: () => {
+    modelPrefsAutoSaveStarts += 1;
+    return () => {
+      modelPrefsAutoSaveStops += 1;
+    };
+  },
+}));
+
+const installMinimalDom = () => {
+  const descriptors = new Map<string, PropertyDescriptor | undefined>();
+  const setGlobal = (name: string, value: unknown) => {
+    descriptors.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
+    Object.defineProperty(globalThis, name, { configurable: true, writable: true, value });
+  };
+  class ElementStub {}
+  const documentStub: Record<string, unknown> = {
+    nodeType: 9,
+    defaultView: globalThis,
+    activeElement: null,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+  };
+  const container = {
+    nodeType: 1,
+    tagName: 'DIV',
+    nodeName: 'DIV',
+    namespaceURI: 'http://www.w3.org/1999/xhtml',
+    ownerDocument: documentStub,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+  };
+  documentStub.documentElement = container;
+  documentStub.body = container;
+  setGlobal('document', documentStub);
+  setGlobal('window', globalThis);
+  setGlobal('Element', ElementStub);
+  setGlobal('HTMLElement', ElementStub);
+  setGlobal('HTMLIFrameElement', ElementStub);
+  setGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  return {
+    container: container as unknown as Element,
+    restore: () => {
+      for (const [name, descriptor] of descriptors) {
+        if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+        else Reflect.deleteProperty(globalThis, name);
+      }
+    },
+  };
+};
+
+const roots: Root[] = [];
+const restoreDom: Array<() => void> = [];
+
+afterEach(async () => {
+  for (const root of roots.splice(0)) {
+    await act(async () => root.unmount());
+  }
+  restoreDom.splice(0).forEach((restore) => restore());
+  resolveSettingsSync = null;
+  appearanceAutoSaveStarts = 0;
+  appearanceAutoSaveStops = 0;
+  modelPrefsAutoSaveStarts = 0;
+  modelPrefsAutoSaveStops = 0;
+});
+
+describe('App settings bootstrap', () => {
+  test('starts all shared settings autosave after the initial settings sync', async () => {
+    const App = (await import('./App')).default;
+    const dom = installMinimalDom();
+    restoreDom.push(dom.restore);
+    const root = createRoot(dom.container);
+    roots.push(root);
+
+    await act(async () => {
+      root.render(<App apis={{ runtime: { platform: 'web', isDesktop: false } } as never} />);
+    });
+
+    expect(appearanceAutoSaveStarts).toBe(0);
+    expect(modelPrefsAutoSaveStarts).toBe(0);
+
+    await act(async () => {
+      resolveSettingsSync?.();
+      await Promise.resolve();
+    });
+
+    expect(appearanceAutoSaveStarts).toBe(1);
+    expect(modelPrefsAutoSaveStarts).toBe(1);
+
+    await act(async () => root.unmount());
+    roots.pop();
+    expect(appearanceAutoSaveStops).toBe(1);
+    expect(modelPrefsAutoSaveStops).toBe(1);
+  });
+});

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -15,6 +15,7 @@ import { WorktreeCreationToasts } from '@/components/worktree/WorktreeCreationTo
 import { useRouter } from '@/hooks/useRouter';
 import type { RuntimeAPIs } from '@/lib/api/types';
 import { syncDesktopSettings } from '@/lib/persistence';
+import { startAppearanceAutoSave } from '@/lib/appearanceAutoSave';
 import { startModelPrefsAutoSave } from '@/lib/modelPrefsAutoSave';
 import { subscribeRuntimeEndpointChanged } from '@/lib/runtime-switch';
 import { WindowTitleEffect } from '@/hooks/useWindowTitle';
@@ -54,16 +55,19 @@ function App({ apis }: { apis?: RuntimeAPIs }) {
   // not fetched against a runtime that has not been unlocked yet.
   React.useEffect(() => {
     let active = true;
+    let stopAppearanceAutoSave: (() => void) | null = null;
     let stopModelPrefsAutoSave: (() => void) | null = null;
 
     void syncDesktopSettings().then(() => {
       if (active) {
+        stopAppearanceAutoSave = startAppearanceAutoSave();
         stopModelPrefsAutoSave = startModelPrefsAutoSave();
       }
     });
 
     return () => {
       active = false;
+      stopAppearanceAutoSave?.();
       stopModelPrefsAutoSave?.();
     };
   }, [runtimeEndpointEpoch]);

--- a/packages/ui/src/lib/appearanceAutoSave.ts
+++ b/packages/ui/src/lib/appearanceAutoSave.ts
@@ -45,14 +45,12 @@ type AppearanceSlice = {
   gitChangesViewMode: 'flat' | 'tree';
 };
 
-let initialized = false;
+let activeStop: (() => void) | null = null;
 
-export const startAppearanceAutoSave = (): void => {
-  if (initialized || typeof window === 'undefined') {
-    return;
+export const startAppearanceAutoSave = (): (() => void) => {
+  if (typeof window === 'undefined' || activeStop) {
+    return () => undefined;
   }
-
-  initialized = true;
 
   let previous: AppearanceSlice = {
     showReasoningTraces: useUIStore.getState().showReasoningTraces,
@@ -89,7 +87,7 @@ export const startAppearanceAutoSave = (): void => {
     gitChangesViewMode: useUIStore.getState().gitChangesViewMode,
   };
 
-  useUIStore.subscribe((state) => {
+  const unsubscribe = useUIStore.subscribe((state) => {
     const current: AppearanceSlice = {
       showReasoningTraces: state.showReasoningTraces,
       collapsibleThinkingBlocks: state.collapsibleThinkingBlocks,
@@ -230,4 +228,13 @@ export const startAppearanceAutoSave = (): void => {
     }
   });
 
+  let stopped = false;
+  const stop = () => {
+    if (stopped) return;
+    stopped = true;
+    unsubscribe();
+    if (activeStop === stop) activeStop = null;
+  };
+  activeStop = stop;
+  return stop;
 };

--- a/packages/ui/src/lib/persistence.test.ts
+++ b/packages/ui/src/lib/persistence.test.ts
@@ -400,6 +400,9 @@ describe('updateDesktopSettings', () => {
       settings: {
         showReasoningTraces: false,
         terminalShell: 'fish',
+        autoDeleteEnabled: true,
+        autoDeleteAfterDays: 45,
+        sessionRetentionAction: 'delete',
         favoriteModels: [{ providerID: 'anthropic', modelID: 'claude-sonnet-4' }],
         followUpBehavior: 'steer',
         // Legacy command starters are parsed defensively but removed on
@@ -414,6 +417,9 @@ describe('updateDesktopSettings', () => {
 
     expect(useUIStore.getState().showReasoningTraces).toBe(false);
     expect(useUIStore.getState().terminalShell).toBe('fish');
+    expect(useUIStore.getState().autoDeleteEnabled).toBe(true);
+    expect(useUIStore.getState().autoDeleteAfterDays).toBe(45);
+    expect(useUIStore.getState().sessionRetentionAction).toBe('delete');
     expect(useUIStore.getState().favoriteModels).toHaveLength(1);
     expect(useUIStore.getState().globalDraftStarters).toEqual([]);
     expect(useUIStore.getState().draftStartersVisible).toBe(false);
@@ -428,6 +434,9 @@ describe('updateDesktopSettings', () => {
 
     expect(useUIStore.getState().showReasoningTraces).toBe(true);
     expect(useUIStore.getState().terminalShell).toBe('auto');
+    expect(useUIStore.getState().autoDeleteEnabled).toBe(false);
+    expect(useUIStore.getState().autoDeleteAfterDays).toBe(30);
+    expect(useUIStore.getState().sessionRetentionAction).toBe('archive');
     expect(useUIStore.getState().favoriteModels).toEqual([]);
     expect(useUIStore.getState().globalDraftStarters).toBeNull();
     expect(useUIStore.getState().draftStartersVisible).toBe(true);
@@ -638,6 +647,98 @@ describe('updateDesktopSettings', () => {
     } finally {
       stop();
     }
+  });
+
+  test('restores session pruning settings from shared settings', async () => {
+    getWindow();
+    invalidateSettingsCache();
+    useUIStore.setState({
+      autoDeleteEnabled: false,
+      autoDeleteAfterDays: 30,
+      sessionRetentionAction: 'archive',
+    });
+    registerSettingsApi(async () => ({}), async () => ({
+      settings: {
+        autoDeleteEnabled: true,
+        autoDeleteAfterDays: 45,
+        sessionRetentionAction: 'delete',
+        draftStartersScheduleTaskAdded: true,
+      },
+      source: 'web',
+    }));
+
+    await syncDesktopSettings();
+
+    expect(useUIStore.getState().autoDeleteEnabled).toBe(true);
+    expect(useUIStore.getState().autoDeleteAfterDays).toBe(45);
+    expect(useUIStore.getState().sessionRetentionAction).toBe('delete');
+  });
+
+  test('migrates local session pruning settings when an older shared settings file omits them', async () => {
+    getWindow();
+    switchRuntimeEndpoint({ apiBaseUrl: 'http://localhost', runtimeKey: 'local' });
+    invalidateSettingsCache();
+    useUIStore.setState({
+      autoDeleteEnabled: true,
+      autoDeleteAfterDays: 45,
+      sessionRetentionAction: 'delete',
+    });
+    const saveCalls: Array<Partial<SettingsPayload>> = [];
+    registerSettingsApi(async (changes) => {
+      saveCalls.push(changes);
+      return changes as SettingsPayload;
+    }, async () => ({
+      settings: { autoSaveEnabled: true, draftStartersScheduleTaskAdded: true },
+      source: 'web',
+    }));
+
+    await syncDesktopSettings();
+
+    expect(useUIStore.getState().autoDeleteEnabled).toBe(true);
+    expect(useUIStore.getState().autoDeleteAfterDays).toBe(45);
+    expect(useUIStore.getState().sessionRetentionAction).toBe('delete');
+    expect(saveCalls.find((changes) => changes.autoDeleteEnabled === true)).toEqual({
+      autoDeleteEnabled: true,
+      autoDeleteAfterDays: 45,
+      sessionRetentionAction: 'delete',
+    });
+  });
+
+  test('autosaves session pruning settings to shared settings', async () => {
+    getWindow();
+    useUIStore.setState({
+      autoDeleteEnabled: false,
+      autoDeleteAfterDays: 30,
+      sessionRetentionAction: 'archive',
+    });
+    const saveCalls: Array<Partial<SettingsPayload>> = [];
+    registerSettingsSave(async (changes) => {
+      saveCalls.push(changes);
+      return changes as SettingsPayload;
+    });
+    const stopAutoSave = startAppearanceAutoSave();
+
+    useUIStore.getState().setAutoDeleteEnabled(true);
+    useUIStore.getState().setAutoDeleteAfterDays(45);
+    useUIStore.getState().setSessionRetentionAction('delete');
+    await delay(500);
+
+    expect(saveCalls.some((changes) => (
+      changes.autoDeleteEnabled === true
+      && changes.autoDeleteAfterDays === 45
+      && changes.sessionRetentionAction === 'delete'
+    ))).toBe(true);
+
+    stopAutoSave();
+    const saveCountAfterStop = saveCalls.length;
+    useUIStore.getState().setAutoDeleteAfterDays(60);
+    await delay(300);
+    expect(saveCalls).toHaveLength(saveCountAfterStop);
+
+    startAppearanceAutoSave();
+    useUIStore.getState().setAutoDeleteAfterDays(75);
+    await delay(500);
+    expect(saveCalls.some((changes) => changes.autoDeleteAfterDays === 75)).toBe(true);
   });
 
   test('autosaves reasoning preference changes to shared settings', async () => {

--- a/packages/ui/src/lib/persistence.ts
+++ b/packages/ui/src/lib/persistence.ts
@@ -230,6 +230,14 @@ export const syncDesktopSettings = async (): Promise<void> => {
       });
     const shouldSeedAutoSaveEnabled =
       typeof settings.autoSaveEnabled !== 'boolean';
+    const shouldMigrateLocalAutoDeleteEnabled =
+      context.runtimeKey === 'local' && typeof settings.autoDeleteEnabled !== 'boolean';
+    const shouldMigrateLocalAutoDeleteAfterDays =
+      context.runtimeKey === 'local' && typeof settings.autoDeleteAfterDays !== 'number';
+    const shouldMigrateLocalSessionRetentionAction =
+      context.runtimeKey === 'local'
+      && settings.sessionRetentionAction !== 'archive'
+      && settings.sessionRetentionAction !== 'delete';
     const authoritativeSettings =
       materializeAuthoritativeUiSettings(settings);
     try {
@@ -239,9 +247,18 @@ export const syncDesktopSettings = async (): Promise<void> => {
     }
     await waitForHydration();
     if (!isSettingsRuntimeContextCurrent(context)) return;
+    const hydratedUiSettings = useUIStore.getState();
     if (shouldSeedAutoSaveEnabled) {
-      authoritativeSettings.autoSaveEnabled =
-        useUIStore.getState().autoSaveEnabled;
+      authoritativeSettings.autoSaveEnabled = hydratedUiSettings.autoSaveEnabled;
+    }
+    if (shouldMigrateLocalAutoDeleteEnabled) {
+      authoritativeSettings.autoDeleteEnabled = hydratedUiSettings.autoDeleteEnabled;
+    }
+    if (shouldMigrateLocalAutoDeleteAfterDays) {
+      authoritativeSettings.autoDeleteAfterDays = hydratedUiSettings.autoDeleteAfterDays;
+    }
+    if (shouldMigrateLocalSessionRetentionAction) {
+      authoritativeSettings.sessionRetentionAction = hydratedUiSettings.sessionRetentionAction;
     }
     if (settings.draftStarters === undefined) {
       useUIStore.setState({ globalDraftStarters: null });
@@ -266,6 +283,15 @@ export const syncDesktopSettings = async (): Promise<void> => {
     }
     if (shouldSeedAutoSaveEnabled) {
       migrationPatch.autoSaveEnabled = authoritativeSettings.autoSaveEnabled;
+    }
+    if (shouldMigrateLocalAutoDeleteEnabled) {
+      migrationPatch.autoDeleteEnabled = authoritativeSettings.autoDeleteEnabled;
+    }
+    if (shouldMigrateLocalAutoDeleteAfterDays) {
+      migrationPatch.autoDeleteAfterDays = authoritativeSettings.autoDeleteAfterDays;
+    }
+    if (shouldMigrateLocalSessionRetentionAction) {
+      migrationPatch.sessionRetentionAction = authoritativeSettings.sessionRetentionAction;
     }
     if (Object.keys(migrationPatch).length > 0) {
       await updateDesktopSettings(migrationPatch);

--- a/packages/ui/src/stores/DOCUMENTATION.md
+++ b/packages/ui/src/stores/DOCUMENTATION.md
@@ -15,7 +15,9 @@ Use a store only for state shared across distant component trees or for a cache 
 
 `useSessionFoldersStore.ts` keeps a runtime-scoped browser snapshot for immediate continuity and reconciles it with the active server's validated `/api/pi/session-folders` sidecar. Missing server state is not authoritative empty state, and in-flight hydration cannot replace newer local mutations.
 
-Model-picker preferences hydrate from the active runtime before autosave starts. Every later change is eligible for persistence, and pending changes flush to their captured runtime before app teardown or a runtime switch.
+Model-picker and appearance preferences hydrate from the active runtime before autosave starts. Every later change is eligible for persistence. Both subscriptions stop during app teardown or a runtime switch so the next runtime captures a fresh baseline, while pending writes drain against their captured runtime. When upgrading a local runtime whose older shared settings omit session-pruning fields, hydration migrates the existing local pruning values before authoritative defaults can replace them. This migration never copies those values into a remote runtime.
+
+Provider discovery also runs in the global config scope when no project exists. A fresh install can therefore choose models and save global session defaults before adding its first folder. Adding a folder activates a separate project scope and leaves the global selection intact.
 
 Caches and async work must be scoped to the active runtime. A failed authoritative request must preserve existing state and remain distinguishable from a successful empty result.
 

--- a/packages/ui/src/stores/useConfigStore.test.ts
+++ b/packages/ui/src/stores/useConfigStore.test.ts
@@ -18,6 +18,10 @@ let liveAgents: TestAgent[] = [];
 let listAgentsImpl: ((directory?: string | null) => Promise<TestAgent[]>) | null = null;
 let withDirectoryCalls: Array<string | null> = [];
 let currentFetchDirectory: string | null = DIRECTORY;
+let projects = [
+  { id: 'project', path: DIRECTORY, label: 'Project' },
+  { id: 'other', path: OTHER_DIRECTORY, label: 'Other' },
+];
 let configListener: ((event: { scopes: string[]; source?: string; timestamp: number }) => void | Promise<void>) | null = null;
 
 const makeStorage = (): Storage => ({
@@ -152,11 +156,8 @@ mock.module('@/stores/utils/safeStorage', () => ({
 mock.module('@/stores/useProjectsStore', () => ({
   useProjectsStore: {
     getState: () => ({
-      activeProjectId: 'project',
-      projects: [
-        { id: 'project', path: DIRECTORY, label: 'Project' },
-        { id: 'other', path: OTHER_DIRECTORY, label: 'Other' },
-      ],
+      activeProjectId: projects[0]?.id ?? null,
+      projects,
     }),
   },
 }));
@@ -305,6 +306,10 @@ describe('useConfigStore provider persistence', () => {
     listAgentsImpl = null;
     withDirectoryCalls = [];
     currentFetchDirectory = DIRECTORY;
+    projects = [
+      { id: 'project', path: DIRECTORY, label: 'Project' },
+      { id: 'other', path: OTHER_DIRECTORY, label: 'Other' },
+    ];
     // Note: syncConfigListeners intentionally persists across tests — the
     // store subscribes once at module load and must stay subscribed.
     setSyncRefs();
@@ -333,6 +338,26 @@ describe('useConfigStore provider persistence', () => {
       isConnected: true,
       isInitialized: false,
     });
+  });
+
+  test('loads providers into the global scope before the first project is added', async () => {
+    projects = [];
+    useConfigStore.setState({
+      activeDirectoryKey: '__global__',
+      isConnected: false,
+      hasEverConnected: false,
+      isInitialized: false,
+    });
+
+    await useConfigStore.getState().initializeApp();
+
+    const state = useConfigStore.getState();
+    expect(getProvidersCalls).toBe(1);
+    expect(state.isInitialized).toBe(true);
+    expect(state.providers.map((entry) => entry.id)).toEqual(['live']);
+    expect(state.currentProviderId).toBe('live');
+    expect(state.currentModelId).toBe('live-model');
+    expect(state.directoryScoped.__global__?.providers.map((entry) => entry.id)).toEqual(['live']);
   });
 
   test('hydrates persisted provider snapshots for instant paint, then refreshes to live data', async () => {

--- a/packages/ui/src/stores/useConfigStore.ts
+++ b/packages/ui/src/stores/useConfigStore.ts
@@ -96,7 +96,8 @@ export const useConfigStore = create<ConfigStore>()(
 
                 activateDirectory: async (directory) => {
                     const configDirectory = resolveConfigDirectory(directory);
-                    if (!configDirectory) {
+                    const hasRequestedDirectory = typeof directory === 'string' && directory.trim().length > 0;
+                    if (!configDirectory && hasRequestedDirectory) {
                         markStartupTrace('activateDirectory:skippedUnknownDirectory', { directory });
                         return;
                     }
@@ -223,11 +224,12 @@ export const useConfigStore = create<ConfigStore>()(
                 loadProviders: async (options) => {
                     const requestedDirectory = options?.directory ?? fromDirectoryKey(get().activeDirectoryKey);
                     const configDirectory = resolveConfigDirectory(requestedDirectory);
-                    if (!configDirectory) {
+                    const hasRequestedDirectory = typeof requestedDirectory === 'string' && requestedDirectory.trim().length > 0;
+                    if (!configDirectory && hasRequestedDirectory) {
                         markStartupTrace('loadProviders:skippedUnknownDirectory', { requestedDirectory, source: options?.source ?? 'unknown' });
                         return;
                     }
-                    const effectiveDirectory = configDirectory ?? useDirectoryStore.getState().currentDirectory ?? null;
+                    const effectiveDirectory = configDirectory ?? null;
                     const directoryKey = toDirectoryKey(configDirectory);
                     const source = options?.source ?? 'unknown';
                     markStartupTrace('loadProviders:called', { directoryKey, source, requestedDirectory, effectiveDirectory });
@@ -617,11 +619,12 @@ export const useConfigStore = create<ConfigStore>()(
                 loadAgents: async (options) => {
                     const requestedDirectory = options?.directory ?? fromDirectoryKey(get().activeDirectoryKey);
                     const configDirectory = resolveConfigDirectory(requestedDirectory);
-                    if (!configDirectory) {
+                    const hasRequestedDirectory = typeof requestedDirectory === 'string' && requestedDirectory.trim().length > 0;
+                    if (!configDirectory && hasRequestedDirectory) {
                         markStartupTrace('loadAgents:skippedUnknownDirectory', { requestedDirectory, source: options?.source ?? 'unknown' });
                         return false;
                     }
-                    const effectiveDirectory = configDirectory ?? useDirectoryStore.getState().currentDirectory ?? null;
+                    const effectiveDirectory = configDirectory ?? null;
                     const directoryKey = toDirectoryKey(configDirectory);
                     const source = options?.source ?? 'unknown';
                     markStartupTrace('loadAgents:called', { directoryKey, source, requestedDirectory, effectiveDirectory });
@@ -1367,11 +1370,9 @@ export const useConfigStore = create<ConfigStore>()(
                             const resolvedInitialDirectory = resolveConfigDirectory(resolvedProject?.path ?? initialDirectory ?? null);
                             const configDirectory = resolvedInitialDirectory ?? getFallbackProjectDirectory();
                             if (!configDirectory) {
-                                markStartupTrace('initializeApp:noProjectConfigDirectory');
-                                set({ isInitialized: true, isConnected: true, hasEverConnected: true, connectionPhase: "connected" });
-                                return;
+                                markStartupTrace('initializeApp:globalConfigScope');
                             }
-                            if (!resolvedInitialDirectory && initialDirectory !== configDirectory) {
+                            if (configDirectory && !resolvedInitialDirectory && initialDirectory !== configDirectory) {
                                 markStartupTrace('initializeApp:normalizedUnknownDirectoryToProject', {
                                     initialDirectory,
                                     configDirectory,


### PR DESCRIPTION
## Intent

Fresh installs could not load provider models until a folder existed because config bootstrap treated the null directory as an unknown directory instead of the existing global config scope. The full app also omitted the appearance/settings autosave lifecycle, so settings such as session pruning could appear changed without reaching shared settings.

This change:

- loads providers and defaults into the global config scope before the first folder is added;
- starts appearance autosave only after authoritative settings hydration;
- stops and restarts autosave across app teardown and runtime changes so each runtime gets a fresh baseline;
- migrates locally persisted pruning settings when an older local shared-settings file lacks those fields;
- keeps that migration local so values cannot leak into a remote runtime.

## Non-goals

- Changing project-specific model-default precedence after a folder is selected.
- Changing the server's schemaless merge format or `/api/pi/ui-settings` route.
- Synchronizing the internal pruning last-run timestamp across devices.
- Changing Settings layout, labels, or styling.

## Affected surfaces

- `packages/ui` config bootstrap and model availability on a fresh install.
- Shared web/desktop Settings persistence for appearance and retention preferences.
- Persisted local settings during upgrades from versions whose shared settings omit pruning fields.
- Runtime switching lifecycle. Remote runtimes retain authoritative missing-field behavior and do not receive local migration values.
- Hosted and Capacitor mobile continue using their existing startup paths; the reusable appearance autosave now also has an explicit stop contract, but those entrypoints do not otherwise change.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` and `CONTRIBUTING.md` | This changes shared UI startup and persisted settings behavior. | Kept Pi calls behind existing clients, preserved runtime boundaries, added focused and full validation, and documented the changed store contract. |
| `pichamber-change-discipline` | Executable source, persistence, and lifecycle behavior changed. | Added fresh-install, save/reload, migration, partial-runtime, and teardown tests; no dependencies or unrelated refactors. |
| `settings-ui-patterns` | Settings save behavior changed. | Reused the shared save-state and persistence paths; no new controls or one-off feedback UI. |
| `ui-api-decoupling` | Shared UI settings and Pi provider access cross runtime boundaries. | Continued using `updateDesktopSettings`, runtime settings APIs, and existing Pi provider loading. No hardcoded origin or auth behavior was added. |
| `sync-state-invariants` | Hydration, persisted values, runtime switching, and pending writes are involved. | Hydration precedes autosave, pending writes remain captured by runtime, subscriptions restart with fresh baselines, and local migration is explicitly excluded from remote runtimes. |
| `theme-system` and `locale-ui-patterns` | Settings UI can affect visible behavior. | No component styling, controls, icons, or user-facing copy changed. |
| `packages/ui/src/stores/DOCUMENTATION.md` | This module owns config and preference persistence contracts. | Updated it with global no-project discovery, autosave lifecycle, and local upgrade migration behavior. |

## Validation

| Check | Result |
|---|---|
| `bun run --cwd packages/ui test src/lib/persistence.test.ts src/App.settings-bootstrap.test.tsx src/stores/useConfigStore.test.ts` | Passed: 42 tests, 135 assertions. |
| `bun run type-check:ui` | Passed. |
| `bun run lint:ui` | Passed. |
| `bun run test` | Passed: web, 2,095 UI tests, and Electron architecture/updater suites. |
| `bun run docs:validate` | Passed. |
| `bun run dead-code` | Completed; only the repository's existing non-blocking findings were reported. |
| `git diff --check` | Passed. |
| Independent standards/spec review | No blocking issues after the appearance-autosave lifecycle fix. |

No packaged desktop, browser, or mobile runtime was launched manually. Automated tests cover the changed startup, persistence, migration, teardown, and runtime-isolation behavior.

## Visual evidence

Not applicable. The diff changes bootstrap and persistence behavior only. It does not change rendered markup, text, layout, styling, animation, or visual states, so screenshots would be identical.

## Risks and failure behavior

- Provider discovery still rejects unknown non-empty directories; only the intentional null/global scope is newly accepted.
- A failed provider request follows the existing retry and prior-state preservation behavior.
- Pruning migration runs only when the active runtime key is `local` and a field is absent or invalid. Existing authoritative values win.
- If migration persistence fails, the hydrated local values remain in the UI store and the normal save-state path reports failure; a later startup can retry because the shared fields remain absent.
- Runtime switches stop both autosave subscriptions. The existing settings persistence lifecycle drains already queued writes against their captured runtime before switching.
- Rollback is limited to reverting this commit; no destructive data conversion or server schema migration is introduced.
