### PR TITLE
fix(electron): ship safe Linux packages and AppImage updates

### DIFF
--- a/.github/workflows/release-desktop-smoke.yml
+++ b/.github/workflows/release-desktop-smoke.yml
@@ -24,7 +24,7 @@ on:
         default: true
         type: boolean
       build_linux:
-        description: Build Linux Electron AppImage artifacts
+        description: Build Linux Electron installable artifacts
         required: false
         default: true
         type: boolean
@@ -289,7 +289,10 @@ jobs:
           bun run test:architecture
           bun run test:updater
 
-      - name: Build and package Linux AppImage
+      - name: Install Linux packaging tools
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y rpm
+
+      - name: Build and package Linux desktop artifacts
         working-directory: packages/electron
         env:
           PICHAMBER_TARGET_ARCH: ${{ matrix.arch }}
@@ -311,6 +314,9 @@ jobs:
           set -euo pipefail
           APPIMAGE="dist/PiChamber-${VERSION}-linux-${ARTIFACT_ARCH}.AppImage"
           node ./scripts/verify-update-manifest.mjs "dist/${MANIFEST}" "$APPIMAGE" "$VERSION"
+          for artifact in dist/PiChamber-${VERSION}-linux-*.deb dist/PiChamber-${VERSION}-linux-*.rpm; do
+            node ./scripts/verify-update-manifest.mjs "dist/${MANIFEST}" "$artifact" "$VERSION"
+          done
 
       - name: Upload Linux installable artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -318,6 +324,8 @@ jobs:
           name: desktop-release-smoke-linux-${{ matrix.arch }}
           path: |
             packages/electron/dist/PiChamber-${{ steps.versions.outputs.app }}-linux-${{ matrix.artifact_arch }}.AppImage
+            packages/electron/dist/*.deb
+            packages/electron/dist/*.rpm
             packages/electron/dist/${{ matrix.manifest }}
           if-no-files-found: error
           retention-days: ${{ fromJSON(inputs.retention_days) }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -480,7 +480,10 @@ jobs:
           bun run test:architecture
           bun run test:updater
 
-      - name: Build and package Linux AppImage
+      - name: Install Linux packaging tools
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y rpm
+
+      - name: Build and package Linux desktop artifacts
         working-directory: packages/electron
         env:
           PICHAMBER_TARGET_ARCH: ${{ matrix.arch }}
@@ -502,6 +505,9 @@ jobs:
           set -euo pipefail
           APPIMAGE="dist/PiChamber-${VERSION}-linux-${ARTIFACT_ARCH}.AppImage"
           node ./scripts/verify-update-manifest.mjs "dist/${MANIFEST}" "$APPIMAGE" "$VERSION"
+          for artifact in dist/PiChamber-${VERSION}-linux-*.deb dist/PiChamber-${VERSION}-linux-*.rpm; do
+            node ./scripts/verify-update-manifest.mjs "dist/${MANIFEST}" "$artifact" "$VERSION"
+          done
 
       - name: Upload validated Linux release files
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -509,6 +515,8 @@ jobs:
           name: linux-release-${{ matrix.arch }}
           path: |
             packages/electron/dist/PiChamber-${{ needs.create-release.outputs.version }}-linux-${{ matrix.artifact_arch }}.AppImage
+            packages/electron/dist/*.deb
+            packages/electron/dist/*.rpm
             packages/electron/dist/${{ matrix.manifest }}
           if-no-files-found: error
           retention-days: 1
@@ -545,15 +553,19 @@ jobs:
             "artifacts/arm64/PiChamber-${VERSION}-linux-arm64.AppImage" \
             "$VERSION"
 
-      - name: Upload Linux AppImages and manifests to release
+      - name: Upload Linux desktop artifacts and manifests to release
         if: ${{ github.event.inputs.dry_run != 'true' }}
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: v${{ needs.create-release.outputs.version }}
           files: |
             artifacts/x64/PiChamber-${{ needs.create-release.outputs.version }}-linux-x86_64.AppImage
+            artifacts/x64/*.deb
+            artifacts/x64/*.rpm
             artifacts/x64/latest-linux.yml
             artifacts/arm64/PiChamber-${{ needs.create-release.outputs.version }}-linux-arm64.AppImage
+            artifacts/arm64/*.deb
+            artifacts/arm64/*.rpm
             artifacts/arm64/latest-linux-arm64.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -649,7 +661,16 @@ jobs:
               throw new Error(`Release asset ${name} has invalid size ${matches[0].size}`);
             }
           }
-          console.log(`Verified ${expected.length} Linux release assets and both architecture manifests.`);
+          for (const extension of ['.deb', '.rpm']) {
+            const matches = release.assets.filter((asset) => asset.name.startsWith(`PiChamber-${version}-linux-`) && asset.name.endsWith(extension));
+            if (matches.length !== 2) throw new Error(`Expected one ${extension} package per Linux architecture, found ${matches.length}`);
+            for (const asset of matches) {
+              if (!Number.isSafeInteger(asset.size) || asset.size <= 0) {
+                throw new Error(`Linux package ${asset.name} has invalid size ${asset.size}`);
+              }
+            }
+          }
+          console.log(`Verified ${expected.length} Linux release assets, both architecture manifests, and .deb/.rpm packages.`);
           })().catch((error) => {
             console.error(error);
             process.exit(1);

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,9 +70,9 @@ bun run electron:build
 `packages/electron/dist`.
 
 Desktop targets are macOS, Windows, and Linux. macOS produces DMG and ZIP
-artifacts, Windows produces an NSIS installer, and Linux produces an AppImage
-for the native x64 or arm64 host. Unsigned local installers are expected when
-signing credentials are not configured.
+artifacts, Windows produces an NSIS installer, and Linux produces AppImage,
+`.deb`, and `.rpm` artifacts for the native x64 or arm64 host. Unsigned local
+installers are expected when signing credentials are not configured.
 
 ### Shared UI
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ PiChamber stays focused on the parts around the agent:
 
 ## Quick start
 
-**Desktop:** Download the latest app from [GitHub Releases](https://github.com/RyderAsKing/PiChamber/releases/latest). The desktop app starts the PiChamber server and Pi session daemon in-process, so it does not need a separate Pi CLI installation.
+**Desktop:** Download the latest app from [GitHub Releases](https://github.com/RyderAsKing/PiChamber/releases/latest). Linux users can choose a `.deb`, `.rpm`, or portable AppImage; the desktop app starts the PiChamber server and Pi session daemon in-process, so it does not need a separate Pi CLI installation.
 
 **Server:**
 

--- a/packages/docs/content/docs/install.mdx
+++ b/packages/docs/content/docs/install.mdx
@@ -7,6 +7,14 @@ description: Install the desktop application or the PiChamber server.
 
 Download PiChamber from the [GitHub Releases](https://github.com/RyderAsKing/PiChamber/releases/latest) page. The desktop application starts its PiChamber backend in-process.
 
+On Linux, choose the package for your distribution when possible:
+
+- **Ubuntu, Debian, Linux Mint, and other Debian-family distributions:** download the `.deb` package and install it with `sudo apt install ./PiChamber-...-linux-amd64.deb`.
+- **Fedora, RHEL, openSUSE, and other RPM-family distributions:** download the `.rpm` package and install it with `sudo dnf install ./PiChamber-...-linux-x86_64.rpm`.
+- **Other distributions or a portable install:** use the AppImage. Copy it to a writable Linux filesystem, make it executable with `chmod +x`, and launch it from that location. AppImages use Electron's compatibility `--no-sandbox` mode because a user-mounted AppImage cannot provide the root-owned Chromium sandbox helper; use a `.deb` or `.rpm` package when the full Chromium sandbox is required.
+
+AppImage updates keep the existing file path so desktop shortcuts remain valid. The update is validated before replacement, and the previous image is retained until the new version starts successfully.
+
 ## Server
 
 PiChamber server requires Node.js 22 or newer, or Bun. Install the CLI package with a package manager.

--- a/packages/electron/README.md
+++ b/packages/electron/README.md
@@ -37,6 +37,14 @@ Desktop PNG/ICO/ICNS brand assets, web favicons, and mobile launcher/splash PNGs
 
 GitHub Releases for this package are produced by `.github/workflows/release.yml`. Desktop artifacts are built on every release. Android artifacts are built for version tags and can be enabled on a manual dispatch; npm publication is opt-in, and iOS TestFlight uses the separate Mobile Release workflow. See `CONTRIBUTING.md` for the version and tag steps.
 
+### Linux distribution
+
+Linux releases include `.deb`, `.rpm`, and AppImage artifacts for x64 and arm64. The `.deb` package is the recommended choice for Debian-family distributions and `.rpm` is recommended for Fedora-family distributions. Package-manager installations retain Electron's normal Chromium sandbox and use the package-specific updater.
+
+AppImages are portable and do not require installation, but the AppImage format cannot provide Electron's root-owned `chrome-sandbox` helper from a user-mounted filesystem. PiChamber therefore launches AppImages with Chromium's `--no-sandbox` compatibility mode; installed `.deb`/`.rpm` packages should be preferred when the full Chromium sandbox is required. AppImages should be copied to a writable Linux filesystem, such as `~/.local/opt/pichamber`, and kept at a stable filename if a desktop shortcut is created.
+
+Linux AppImage updates are staged and validated before the existing file is replaced. The previous image is retained until the restarted packaged UI confirms a successful launch; a failed restart is recovered on the next launch. The updater preserves the current AppImage path so existing desktop shortcuts do not become stale.
+
 macOS notarized builds need `APPLE_CERTIFICATE` as base64 of a Developer ID Application `.p12`. Missing or unreadable certificates produce unsigned `.dmg`/`.zip` files instead of failing the job.
 
 ## Platform rules

--- a/packages/electron/linux-appimage-update.mjs
+++ b/packages/electron/linux-appimage-update.mjs
@@ -1,0 +1,275 @@
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const TRANSACTION_FILE_NAME = 'linux-appimage-update.json';
+const BACKUP_SUFFIX = '.previous';
+const TEMP_SUFFIX = '.update.tmp';
+const MAX_EXTRACT_MS = 120_000;
+
+const isMissing = (error) => error?.code === 'ENOENT';
+
+const assertAbsolutePath = (value, label) => {
+  if (typeof value !== 'string' || !path.isAbsolute(value)) {
+    throw new Error(`${label} must be an absolute path`);
+  }
+  return path.normalize(value);
+};
+
+const defaultExtract = async (appImagePath) => {
+  const temporaryDirectory = await fsp.mkdtemp(path.join(os.tmpdir(), 'pichamber-appimage-'));
+  try {
+    const result = spawnSync(appImagePath, ['--appimage-extract'], {
+      cwd: temporaryDirectory,
+      stdio: 'ignore',
+      timeout: MAX_EXTRACT_MS,
+    });
+    if (result.error || result.status !== 0) {
+      throw new Error(`The downloaded AppImage could not be extracted${result.error ? `: ${result.error.message}` : ''}`);
+    }
+
+    const extractedRoot = path.join(temporaryDirectory, 'squashfs-root');
+    const indexPath = path.join(extractedRoot, 'resources', 'web-dist', 'index.html');
+    const indexInfo = await fsp.stat(indexPath);
+    if (!indexInfo.isFile() || indexInfo.size === 0) {
+      throw new Error('The downloaded AppImage is missing its packaged UI assets');
+    }
+    const launcherPath = path.join(extractedRoot, 'pichamber');
+    const bundledBinaryPath = path.join(extractedRoot, 'pichamber-bin');
+    const launcher = await fsp.readFile(launcherPath, 'utf8');
+    const binaryInfo = await fsp.stat(bundledBinaryPath);
+    if (!binaryInfo.isFile() || (binaryInfo.mode & 0o111) === 0 || !launcher.includes('--no-sandbox') || !launcher.includes('pichamber-bin')) {
+      throw new Error('The downloaded AppImage does not contain the compatible Linux launcher');
+    }
+  } finally {
+    await fsp.rm(temporaryDirectory, { recursive: true, force: true }).catch(() => {});
+  }
+};
+
+export const validateLinuxAppImage = async ({
+  appImagePath,
+  stat = fsp.stat,
+  extract = defaultExtract,
+} = {}) => {
+  const candidate = assertAbsolutePath(appImagePath, 'AppImage path');
+  let info;
+  try {
+    info = await stat(candidate);
+  } catch {
+    throw new Error(`The downloaded AppImage cannot be found at ${candidate}`);
+  }
+  if (!info.isFile() || info.size <= 0) {
+    throw new Error(`The downloaded AppImage is not a valid file at ${candidate}`);
+  }
+  if ((info.mode & 0o111) === 0) {
+    throw new Error(`The downloaded AppImage is not executable at ${candidate}`);
+  }
+
+  await extract(candidate);
+  return { path: candidate, size: info.size };
+};
+
+const readJson = async (filePath, readFile = fsp.readFile) => {
+  try {
+    return JSON.parse(await readFile(filePath, 'utf8'));
+  } catch (error) {
+    if (isMissing(error)) return null;
+    throw new Error(`The Linux update recovery record is invalid at ${filePath}`);
+  }
+};
+
+const writeJsonAtomically = async (filePath, value, {
+  writeFile = fsp.writeFile,
+  rename = fsp.rename,
+} = {}) => {
+  const temporaryPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  await writeFile(temporaryPath, `${JSON.stringify(value)}\n`, { mode: 0o600 });
+  await rename(temporaryPath, filePath);
+};
+
+const resolveTransactionPath = (appDataDirectory) => (
+  path.join(assertAbsolutePath(appDataDirectory, 'App data directory'), TRANSACTION_FILE_NAME)
+);
+
+const chooseBackupPath = async (currentPath, stat = fsp.stat, now = Date.now) => {
+  const base = `${currentPath}${BACKUP_SUFFIX}`;
+  try {
+    await stat(base);
+  } catch (error) {
+    if (isMissing(error)) return base;
+    throw error;
+  }
+  return `${base}.${now()}`;
+};
+
+const removeIfPresent = async (filePath, rm = fsp.rm) => {
+  await rm(filePath, { force: true }).catch((error) => {
+    if (!isMissing(error)) throw error;
+  });
+};
+
+export const installLinuxAppImageUpdate = async ({
+  currentPath,
+  downloadedPath,
+  appDataDirectory,
+  version = '',
+  validate = validateLinuxAppImage,
+  stat = fsp.stat,
+  copyFile = fsp.copyFile,
+  chmod = fsp.chmod,
+  rename = fsp.rename,
+  rm = fsp.rm,
+  mkdir = fsp.mkdir,
+  writeFile = fsp.writeFile,
+  now = Date.now,
+} = {}) => {
+  const current = assertAbsolutePath(currentPath, 'Current AppImage path');
+  const downloaded = assertAbsolutePath(downloadedPath, 'Downloaded AppImage path');
+  if (current === downloaded) {
+    throw new Error('The downloaded update must not be the running AppImage');
+  }
+
+  await validate({ appImagePath: downloaded });
+
+  let currentInfo;
+  try {
+    currentInfo = await stat(current);
+  } catch {
+    throw new Error(`The running AppImage cannot be found at ${current}`);
+  }
+  if (!currentInfo.isFile()) {
+    throw new Error(`The running AppImage is not a regular file at ${current}`);
+  }
+
+  const directory = path.dirname(current);
+  const temporaryPath = path.join(
+    directory,
+    `.${path.basename(current)}-${process.pid}-${now()}${TEMP_SUFFIX}`,
+  );
+  const backupPath = await chooseBackupPath(current, stat, now);
+  const transactionPath = resolveTransactionPath(appDataDirectory);
+
+  await mkdir(directory, { recursive: true });
+  await mkdir(path.dirname(transactionPath), { recursive: true });
+  await copyFile(downloaded, temporaryPath);
+  await chmod(temporaryPath, 0o755);
+
+  const transaction = {
+    currentPath: current,
+    backupPath,
+    version: typeof version === 'string' ? version : '',
+    phase: 'staged',
+    attempts: 0,
+  };
+  await writeJsonAtomically(transactionPath, transaction, { writeFile, rename });
+
+  try {
+    // Keep the last known-good image until the replacement has started
+    // successfully. The final rename below is atomic on the same filesystem,
+    // so desktop shortcuts keep pointing at the same path.
+    await copyFile(current, backupPath);
+    await chmod(backupPath, currentInfo.mode & 0o7777);
+    await rename(temporaryPath, current);
+
+    await writeJsonAtomically(transactionPath, {
+      ...transaction,
+      phase: 'installed',
+    }, { writeFile, rename });
+  } catch (error) {
+    await removeIfPresent(temporaryPath, rm);
+    await removeIfPresent(transactionPath, rm);
+    throw new Error(`Could not install the downloaded AppImage: ${error instanceof Error ? error.message : error}`);
+  }
+
+  return { currentPath: current, backupPath, transactionPath, version: transaction.version };
+};
+
+const restoreBackup = async ({
+  currentPath,
+  backupPath,
+  copyFile = fsp.copyFile,
+  chmod = fsp.chmod,
+  rename = fsp.rename,
+  rm = fsp.rm,
+  stat = fsp.stat,
+  now = Date.now,
+} = {}) => {
+  const restoreTempPath = `${currentPath}.${process.pid}.${now()}.restore.tmp`;
+  const backupInfo = await stat(backupPath);
+  await copyFile(backupPath, restoreTempPath);
+  await chmod(restoreTempPath, backupInfo.mode & 0o7777);
+  await rename(restoreTempPath, currentPath);
+  await removeIfPresent(backupPath, rm);
+};
+
+export const recoverLinuxAppImageUpdate = async ({
+  appImagePath,
+  appDataDirectory,
+  readFile = fsp.readFile,
+  writeFile = fsp.writeFile,
+  rename = fsp.rename,
+  rm = fsp.rm,
+  copyFile = fsp.copyFile,
+  chmod = fsp.chmod,
+  stat = fsp.stat,
+  now = Date.now,
+} = {}) => {
+  const current = assertAbsolutePath(appImagePath, 'AppImage path');
+  const transactionPath = resolveTransactionPath(appDataDirectory);
+  const transaction = await readJson(transactionPath, readFile);
+  if (!transaction || transaction.currentPath !== current) return { pending: false, recovered: false };
+
+  const backupPath = typeof transaction.backupPath === 'string'
+    ? transaction.backupPath
+    : `${current}${BACKUP_SUFFIX}`;
+  const backupExists = await stat(backupPath).then(() => true).catch((error) => {
+    if (isMissing(error)) return false;
+    throw error;
+  });
+
+  if (!backupExists) {
+    await removeIfPresent(transactionPath, rm);
+    return { pending: false, recovered: false };
+  }
+
+  if (transaction.phase !== 'installed') {
+    await restoreBackup({ currentPath: current, backupPath, copyFile, chmod, rename, rm, stat, now });
+    await removeIfPresent(transactionPath, rm);
+    return { pending: false, recovered: true };
+  }
+
+  if (Number(transaction.attempts) > 0) {
+    await restoreBackup({ currentPath: current, backupPath, copyFile, chmod, rename, rm, stat, now });
+    await removeIfPresent(transactionPath, rm);
+    return { pending: false, recovered: true };
+  }
+
+  await writeJsonAtomically(transactionPath, {
+    ...transaction,
+    attempts: 1,
+  }, { writeFile, rename });
+  return {
+    pending: true,
+    recovered: false,
+    version: typeof transaction.version === 'string' ? transaction.version : '',
+  };
+};
+
+export const confirmLinuxAppImageUpdate = async ({
+  appImagePath,
+  appDataDirectory,
+  readFile = fsp.readFile,
+  rm = fsp.rm,
+} = {}) => {
+  const current = assertAbsolutePath(appImagePath, 'AppImage path');
+  const transactionPath = resolveTransactionPath(appDataDirectory);
+  const transaction = await readJson(transactionPath, readFile);
+  if (!transaction || transaction.currentPath !== current) return false;
+
+  if (typeof transaction.backupPath === 'string') {
+    await removeIfPresent(transaction.backupPath, rm);
+  }
+  await removeIfPresent(transactionPath, rm);
+  return true;
+};

--- a/packages/electron/linux-appimage-update.test.mjs
+++ b/packages/electron/linux-appimage-update.test.mjs
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  confirmLinuxAppImageUpdate,
+  installLinuxAppImageUpdate,
+  recoverLinuxAppImageUpdate,
+} from './linux-appimage-update.mjs';
+
+const createFixture = async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'pichamber-appimage-update-test-'));
+  const currentPath = path.join(root, 'PiChamber.AppImage');
+  const downloadedPath = path.join(root, 'download', 'PiChamber-next.AppImage');
+  const appDataDirectory = path.join(root, 'data');
+  await fs.mkdir(path.dirname(downloadedPath), { recursive: true });
+  await fs.writeFile(currentPath, 'old-version');
+  await fs.chmod(currentPath, 0o755);
+  await fs.writeFile(downloadedPath, 'new-version');
+  await fs.chmod(downloadedPath, 0o755);
+  return { root, currentPath, downloadedPath, appDataDirectory };
+};
+
+const validateFixtureAppImage = async ({ appImagePath }) => {
+  const info = await fs.stat(appImagePath);
+  assert.equal(info.isFile(), true);
+};
+
+test('installs an AppImage over the existing path and preserves a backup', async () => {
+  const fixture = await createFixture();
+  try {
+    const result = await installLinuxAppImageUpdate({
+      ...fixture,
+      validate: validateFixtureAppImage,
+      now: () => 123,
+    });
+
+    assert.equal(result.currentPath, fixture.currentPath);
+    assert.equal(await fs.readFile(fixture.currentPath, 'utf8'), 'new-version');
+    assert.equal(await fs.readFile(result.backupPath, 'utf8'), 'old-version');
+    assert.equal((await fs.stat(result.transactionPath)).isFile(), true);
+  } finally {
+    await fs.rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test('confirms a successful update by removing recovery state', async () => {
+  const fixture = await createFixture();
+  try {
+    const result = await installLinuxAppImageUpdate({
+      ...fixture,
+      validate: validateFixtureAppImage,
+    });
+    assert.equal(await confirmLinuxAppImageUpdate({
+      appImagePath: fixture.currentPath,
+      appDataDirectory: fixture.appDataDirectory,
+    }), true);
+    await assert.rejects(() => fs.stat(result.backupPath), { code: 'ENOENT' });
+    await assert.rejects(() => fs.stat(result.transactionPath), { code: 'ENOENT' });
+  } finally {
+    await fs.rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test('recovers the previous AppImage after an unsuccessful restart', async () => {
+  const fixture = await createFixture();
+  try {
+    await installLinuxAppImageUpdate({
+      ...fixture,
+      validate: validateFixtureAppImage,
+    });
+
+    const firstStart = await recoverLinuxAppImageUpdate({
+      appImagePath: fixture.currentPath,
+      appDataDirectory: fixture.appDataDirectory,
+    });
+    assert.equal(firstStart.pending, true);
+    assert.equal(await fs.readFile(fixture.currentPath, 'utf8'), 'new-version');
+
+    const failedRestart = await recoverLinuxAppImageUpdate({
+      appImagePath: fixture.currentPath,
+      appDataDirectory: fixture.appDataDirectory,
+    });
+    assert.equal(failedRestart.recovered, true);
+    assert.equal(await fs.readFile(fixture.currentPath, 'utf8'), 'old-version');
+  } finally {
+    await fs.rm(fixture.root, { recursive: true, force: true });
+  }
+});

--- a/packages/electron/main.mjs
+++ b/packages/electron/main.mjs
@@ -19,7 +19,12 @@ import {
 import { sanitizeRuntimeRequestHeaders } from './runtime-request-headers.mjs';
 import { resolveElectronUpdaterVersion } from './app-version.mjs';
 import { createProcessPerformanceRecorder } from './process-performance-recorder.mjs';
-import { assertUpdaterCapability } from './updater-capability.mjs';
+import { assertUpdaterCapability, resolveLinuxPackageType } from './updater-capability.mjs';
+import {
+  confirmLinuxAppImageUpdate,
+  installLinuxAppImageUpdate,
+  recoverLinuxAppImageUpdate,
+} from './linux-appimage-update.mjs';
 import { checkForDesktopUpdate } from './updater-check.mjs';
 import { resolveUpdaterChannel } from './updater-channel.mjs';
 import { resolveUpdaterFeed } from './updater-feed.mjs';
@@ -93,6 +98,9 @@ if (isDev) {
   app.setPath('userData', path.join(app.getPath('appData'), 'PiChamber Dev'));
 }
 app.setAppUserModelId(APP_USER_MODEL_ID);
+// The Linux AppImage AppRun wrapper adds --no-sandbox before launching
+// Electron. Installed .deb/.rpm packages use the native executable directly,
+// so their package managers can retain Electron's normal sandbox setup.
 app.commandLine.appendSwitch('proxy-bypass-list', '<-loopback>');
 // Lift Chromium's per-host cap only for bundled UI. Applying this to Vite HMR
 // lets the renderer request most of the module graph at once, overwhelming the
@@ -1076,6 +1084,12 @@ const detectLanIPv4Address = async () => {
 const buildLocalUrl = (port) => `http://127.0.0.1:${port}`;
 
 const resourceRoot = () => isDev ? path.join(__dirname, 'resources') : process.resourcesPath;
+const currentLinuxPackageType = () => resolveLinuxPackageType({
+  platform: process.platform,
+  packaged: app.isPackaged,
+  appImagePath: process.env.APPIMAGE,
+  resourcesPath: resourceRoot(),
+});
 const resolveWebDistDir = () => path.join(resourceRoot(), 'web-dist');
 const shouldUsePackagedUi = () => {
   if (process.env.PICHAMBER_ELECTRON_LOAD_SERVER_UI === '1') return false;
@@ -1092,6 +1106,42 @@ const injectRuntimeConfigIntoHtml = (html) => {
   if (html.includes('<head>')) return html.replace('<head>', `<head>${initScript}`);
   if (html.includes('</head>')) return html.replace('</head>', `${initScript}</head>`);
   return `${initScript}${html}`;
+};
+
+const escapeHtml = (value) => String(value ?? '')
+  .replaceAll('&', '&amp;')
+  .replaceAll('<', '&lt;')
+  .replaceAll('>', '&gt;')
+  .replaceAll('"', '&quot;')
+  .replaceAll("'", '&#39;');
+
+const buildPackagedUiFailureHtml = ({ reason = 'The packaged UI files could not be loaded.' } = {}) => {
+  const logPath = (() => {
+    try {
+      return log.transports.file.getFile().path;
+    } catch {
+      return 'the PiChamber log directory';
+    }
+  })();
+  const packageType = currentLinuxPackageType() || process.platform;
+  const appImagePath = process.env.APPIMAGE || 'not running from an AppImage';
+  const recovery = packageType === 'AppImage'
+    ? 'Move the AppImage to a writable location, make it executable with chmod +x, and try again. If it still fails, install the .deb or .rpm package instead.'
+    : 'Reinstall PiChamber from the current release and include the log path below when reporting the issue.';
+  return `<!doctype html><html><head><meta charset="utf-8"><title>PiChamber could not start</title><style>body{font-family:system-ui,sans-serif;background:#151313;color:#f5f5f4;margin:0;padding:48px;line-height:1.5}main{max-width:720px;margin:auto}h1{font-size:24px}p{color:#d6d3d1}code{display:block;white-space:pre-wrap;overflow-wrap:anywhere;background:#292524;border-radius:8px;padding:12px;color:#fafaf9}</style></head><body><main><h1>PiChamber could not load its desktop UI</h1><p>${escapeHtml(reason)}</p><p>${escapeHtml(recovery)}</p><p>Include these diagnostics when reporting the issue:</p><code>Version: ${escapeHtml(APP_VERSION)}\nPackage: ${escapeHtml(packageType)}\nAppImage: ${escapeHtml(appImagePath)}\nLog: ${escapeHtml(logPath)}</code></main></body></html>`;
+};
+
+const inspectPackagedUi = () => {
+  const indexPath = path.join(resolveWebDistDir(), 'index.html');
+  try {
+    const info = fs.statSync(indexPath);
+    if (!info.isFile() || info.size === 0) {
+      return { ok: false, indexPath, reason: 'The packaged index.html file is empty.' };
+    }
+    return { ok: true, indexPath };
+  } catch {
+    return { ok: false, indexPath, reason: `The packaged UI is missing: ${indexPath}` };
+  }
 };
 
 const registerPackagedUiProtocol = () => {
@@ -1123,9 +1173,18 @@ const registerPackagedUiProtocol = () => {
     } catch {
     }
     const indexPath = path.join(distPath, 'index.html');
-    const html = await fsp.readFile(indexPath, 'utf8');
-    const body = injectRuntimeConfigIntoHtml(html);
-    return new Response(body, { headers: { 'Content-Type': 'text/html; charset=utf-8' } });
+    try {
+      const html = await fsp.readFile(indexPath, 'utf8');
+      const body = injectRuntimeConfigIntoHtml(html);
+      return new Response(body, { headers: { 'Content-Type': 'text/html; charset=utf-8' } });
+    } catch (error) {
+      const reason = `The packaged UI could not be read from ${indexPath}. ${error instanceof Error ? error.message : ''}`.trim();
+      log.error('[electron] packaged UI request failed', { reason, distPath });
+      return new Response(buildPackagedUiFailureHtml({ reason }), {
+        status: 503,
+        headers: { 'Content-Type': 'text/html; charset=utf-8' },
+      });
+    }
   });
 };
 
@@ -2436,12 +2495,42 @@ const createBrowserWindow = ({ label, restoreGeometry, url, runtimeConfig = {} }
       recordElectronStartupPerformance('electron.renderer.loaded', {
         documentClass: classifyStartupDocument(browserWindow.webContents.getURL()),
       });
+      if (process.platform === 'linux' && currentLinuxPackageType() === 'AppImage' && shouldUsePackagedUi() && inspectPackagedUi().ok && browserWindow.webContents.getURL().startsWith(`${UI_PROTOCOL}:`)) {
+        void confirmLinuxAppImageUpdate({
+          appImagePath: process.env.APPIMAGE,
+          appDataDirectory: app.getPath('userData'),
+        }).catch((error) => {
+          log.warn('[electron] failed to confirm Linux AppImage update', error);
+        });
+      }
     }
     browserWindow.webContents.setZoomFactor(1);
     if (state.mainWindow && browserWindow.id === state.mainWindow.id && pendingDeepLinks.length > 0) {
       const timer = setTimeout(flushPendingDeepLinks, 400);
       if (typeof timer?.unref === 'function') timer.unref();
     }
+  });
+
+  browserWindow.webContents.on('did-fail-load', (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
+    if (!isMainFrame || errorCode === -3) return;
+    log.error('[electron] renderer failed to load', {
+      label: browserWindow.__ocLabel,
+      errorCode,
+      errorDescription,
+      validatedURL,
+      packagedUi: shouldUsePackagedUi(),
+      packagedUiDiagnostics: shouldUsePackagedUi() ? inspectPackagedUi() : null,
+    });
+  });
+
+  browserWindow.webContents.on('render-process-gone', (_event, details) => {
+    log.error('[electron] renderer process exited', {
+      label: browserWindow.__ocLabel,
+      reason: details?.reason,
+      exitCode: details?.exitCode,
+      packagedUi: shouldUsePackagedUi(),
+      packagedUiDiagnostics: shouldUsePackagedUi() ? inspectPackagedUi() : null,
+    });
   });
 
   browserWindow.once('ready-to-show', () => {
@@ -4029,7 +4118,8 @@ const handleInvoke = async (browserWindow, command, args = {}) => {
     }
 
     case 'desktop_check_for_updates': {
-      assertUpdaterCapability({ packaged: app.isPackaged });
+      const packageType = currentLinuxPackageType();
+      assertUpdaterCapability({ packaged: app.isPackaged, packageType });
       const currentVersion = APP_VERSION;
       const { available, updateInfo, updateResult, nextVersion, pendingUpdate } = await checkForDesktopUpdate({
         autoUpdater,
@@ -4053,7 +4143,7 @@ const handleInvoke = async (browserWindow, command, args = {}) => {
     }
 
     case 'desktop_download_and_install_update':
-      assertUpdaterCapability({ packaged: app.isPackaged });
+      assertUpdaterCapability({ packaged: app.isPackaged, packageType: currentLinuxPackageType() });
       if (!state.pendingUpdate) {
         throw new Error('No pending update');
       }
@@ -4099,7 +4189,8 @@ const handleInvoke = async (browserWindow, command, args = {}) => {
 
     case 'desktop_restart': {
       const applyUpdate = Boolean(state.pendingUpdate?.downloaded && app.isPackaged);
-      if (applyUpdate) assertUpdaterCapability({ packaged: app.isPackaged });
+      const packageType = currentLinuxPackageType();
+      if (applyUpdate) assertUpdaterCapability({ packaged: app.isPackaged, packageType });
       log.info(`[electron] desktop_restart applyUpdate=${applyUpdate} packaged=${app.isPackaged}`);
       if (applyUpdate && process.platform === 'darwin' && typeof app.isInApplicationsFolder === 'function') {
         try {
@@ -4128,9 +4219,32 @@ const handleInvoke = async (browserWindow, command, args = {}) => {
       // Defer so the IPC reply flushes before the app starts shutting down.
       // Without this, quitAndInstall() can race with the renderer's pending
       // invoke and the restart appears to do nothing from the UI side.
-      setImmediate(() => {
+      setImmediate(async () => {
         try {
           if (applyUpdate) {
+            if (process.platform === 'linux' && packageType === 'AppImage') {
+              const currentPath = process.env.APPIMAGE;
+              const downloadedPath = autoUpdater.installerPath;
+              if (typeof currentPath !== 'string' || typeof downloadedPath !== 'string') {
+                throw new Error('The downloaded Linux update file is no longer available. Download it again.');
+              }
+
+              const installed = await installLinuxAppImageUpdate({
+                currentPath,
+                downloadedPath,
+                appDataDirectory: app.getPath('userData'),
+                version: state.pendingUpdate?.version || '',
+              });
+              log.info('[electron] staged Linux AppImage update', {
+                version: installed.version,
+                currentPath: installed.currentPath,
+              });
+              killSidecar();
+              app.relaunch({ execPath: installed.currentPath, args: [] });
+              app.exit(0);
+              return;
+            }
+
             killSidecar();
             autoUpdater.quitAndInstall();
           } else {
@@ -4139,7 +4253,16 @@ const handleInvoke = async (browserWindow, command, args = {}) => {
             app.exit(0);
           }
         } catch (err) {
+          state.installingUpdate = false;
+          state.quitRequested = false;
+          state.quitConfirmed = false;
           log.error('[electron] desktop_restart failed', err);
+          void dialog.showMessageBox({
+            type: 'error',
+            title: 'Update failed',
+            message: 'PiChamber kept the current version.',
+            detail: err instanceof Error ? err.message : String(err),
+          }).catch(() => {});
         }
       });
       return null;
@@ -4986,7 +5109,24 @@ app.whenReady().then(async () => {
     argv: process.argv,
     isBackgroundStart,
     loginItemSettings,
+    linuxPackageType: currentLinuxPackageType(),
+    packagedUi: app.isPackaged ? inspectPackagedUi() : null,
   });
+
+  if (process.platform === 'linux' && currentLinuxPackageType() === 'AppImage') {
+    try {
+      const recovery = await recoverLinuxAppImageUpdate({
+        appImagePath: process.env.APPIMAGE,
+        appDataDirectory: app.getPath('userData'),
+      });
+      if (recovery.pending || recovery.recovered) {
+        log.info('[electron] Linux AppImage update recovery state', recovery);
+      }
+    } catch (error) {
+      log.warn('[electron] failed to inspect Linux AppImage update recovery state', error);
+    }
+  }
+
   if (readSettingsRoot().desktopProcessPerformanceRecordingEnabled === true) {
     await processPerformanceRecorder.start();
   }
@@ -5027,6 +5167,12 @@ app.whenReady().then(async () => {
 
   if (isBackgroundStart) {
     const { localOrigin, bootOutcome, apiBaseUrl, clientToken, requestHeaders } = await resolveInitialUrl();
+    if (process.platform === 'linux' && currentLinuxPackageType() === 'AppImage' && inspectPackagedUi().ok) {
+      await confirmLinuxAppImageUpdate({
+        appImagePath: process.env.APPIMAGE,
+        appDataDirectory: app.getPath('userData'),
+      }).catch((error) => log.warn('[electron] failed to confirm background Linux AppImage update', error));
+    }
     state.localOrigin = localOrigin;
     state.apiBaseUrl = apiBaseUrl;
     state.clientToken = clientToken;

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -3,7 +3,11 @@
   "version": "0.9.1",
   "private": true,
   "description": "Electron desktop runtime for PiChamber",
-  "author": "PiChamber",
+  "author": {
+    "name": "PiChamber",
+    "email": "RyderAsKing@users.noreply.github.com"
+  },
+  "homepage": "https://github.com/RyderAsKing/PiChamber",
   "type": "module",
   "main": "./dist-bundle/main.mjs",
   "dependencies": {
@@ -25,7 +29,7 @@
     "Bun available for sidecar compilation",
     "macOS: Xcode + build tools for notarized packaging",
     "Windows: NSIS installed for installer creation",
-    "Linux: native x64 or arm64 host (no cross-arch packaging); FUSE/libfuse2 to run AppImages, or APPIMAGE_EXTRACT_AND_RUN=1"
+    "Linux: native x64 or arm64 host (no cross-arch packaging); AppImages need FUSE/libfuse2 or APPIMAGE_EXTRACT_AND_RUN=1, while .deb/.rpm packages are recommended for installed desktop use"
   ],
   "scripts": {
     "dev": "node ./scripts/electron-dev.mjs",
@@ -37,7 +41,7 @@
     "generate:macos-icon": "node ./scripts/generate-macos-icon-assets.cjs",
     "rebuild:native": "node ./scripts/rebuild-native.mjs",
     "test:architecture": "node --test ./startup-url-selection.test.mjs ./scripts/target-architecture.test.mjs ./scripts/verify-update-manifest.test.mjs ./scripts/ensure-electron.test.mjs ./path-open-utils.test.mjs ./process-performance-recorder.test.mjs",
-    "test:updater": "node --test ./app-version.test.mjs ./updater-capability.test.mjs ./updater-channel.test.mjs ./updater-check.test.mjs ./updater-feed.test.mjs ./scripts/finalize-latest-yml.test.mjs ./scripts/updater-e2e-fixture.test.mjs",
+    "test:updater": "node --test ./app-version.test.mjs ./linux-appimage-update.test.mjs ./updater-capability.test.mjs ./updater-channel.test.mjs ./updater-check.test.mjs ./updater-feed.test.mjs ./scripts/finalize-latest-yml.test.mjs ./scripts/updater-e2e-fixture.test.mjs",
     "test:linux-desktop": "node --test ./linux-autostart.test.mjs && node ./scripts/smoke-linux-app-discovery.mjs && node ./scripts/smoke-path-open-utils.mjs",
     "updater:e2e:fixture": "node ./scripts/updater-e2e-fixture.mjs",
     "verify:update-manifest": "node ./scripts/verify-update-manifest.mjs",
@@ -112,7 +116,9 @@
     },
     "linux": {
       "target": [
-        "AppImage"
+        "AppImage",
+        "deb",
+        "rpm"
       ],
       "category": "Development",
       "icon": "resources/icons/icon.png",

--- a/packages/electron/scripts/after-pack.cjs
+++ b/packages/electron/scripts/after-pack.cjs
@@ -1,12 +1,48 @@
 const fs = require('node:fs');
 const path = require('node:path');
 
+const linuxAppImageLauncher = `#!/bin/sh
+set -e
+
+BIN_DIR=$(CDPATH= cd -- "$(dirname -- "$(readlink -f -- "$0")")" && pwd)
+if [ -n "\${APPDIR:-}" ] || [ -n "\${APPIMAGE:-}" ]; then
+  exec "$BIN_DIR/pichamber-bin" --no-sandbox "$@"
+fi
+case "$BIN_DIR" in
+  */.mount_*|*/.mount_*/*|*/squashfs-root|*/squashfs-root/*)
+    exec "$BIN_DIR/pichamber-bin" --no-sandbox "$@"
+    ;;
+esac
+exec "$BIN_DIR/pichamber-bin" "$@"
+`;
+
 module.exports = (context) => {
-  const resourcesPath = context.electronPlatformName === 'darwin'
-    ? path.join(context.appOutDir, `${context.packager.appInfo.productFilename}.app`, 'Contents', 'Resources')
-    : path.join(context.appOutDir, 'resources');
+  if (context.electronPlatformName === 'linux') {
+    const executablePath = path.join(context.appOutDir, context.packager.executableName);
+    const bundledBinaryPath = `${executablePath}-bin`;
+    if (!fs.existsSync(executablePath)) {
+      throw new Error(`Missing packaged Electron executable at ${executablePath}`);
+    }
+    if (fs.existsSync(bundledBinaryPath)) {
+      const existingLauncher = fs.readFileSync(executablePath, 'utf8');
+      if (existingLauncher.includes('pichamber-bin')) return;
+      throw new Error(`Unexpected duplicate packaged Electron executable at ${bundledBinaryPath}`);
+    }
+    fs.renameSync(executablePath, bundledBinaryPath);
+    fs.writeFileSync(executablePath, linuxAppImageLauncher, { mode: 0o755 });
+    fs.chmodSync(executablePath, 0o755);
+    fs.chmodSync(bundledBinaryPath, 0o755);
+    return;
+  }
+
   if (context.electronPlatformName !== 'darwin') return;
 
+  const resourcesPath = path.join(
+    context.appOutDir,
+    `${context.packager.appInfo.productFilename}.app`,
+    'Contents',
+    'Resources',
+  );
   const sourceAssetsPath = path.join(__dirname, '..', 'resources', 'icons', 'Assets.car');
 
   if (!fs.existsSync(sourceAssetsPath)) {

--- a/packages/electron/scripts/updater-e2e-fixture.md
+++ b/packages/electron/scripts/updater-e2e-fixture.md
@@ -1,6 +1,6 @@
 # Linux Updater E2E Fixture
 
-This local-only harness verifies AppImage N-to-N+1 replacement without changing the
+This local-only harness verifies safe AppImage N-to-N+1 replacement without changing the
 production GitHub updater provider. It supports native x64 and arm64 hosts.
 
 1. Build both versions on the native target architecture. For N and N+1, set the
@@ -26,8 +26,14 @@ production GitHub updater provider. It supports native x64 and arm64 hosts.
    ```
 
 3. In N, check for updates, download/install, and restart. Verify the restarted app
-   reports N+1 and that the file at `APPIMAGE` was replaced. Repeat with `--arch arm64`
-   and the arm64 AppImages on the arm64 host.
+   reports N+1, the existing `APPIMAGE` path is still present, and the old image is
+   removed only after the new packaged UI loads. Existing desktop shortcuts must still
+   launch N+1. Repeat with `--arch arm64` and the arm64 AppImages on the arm64 host.
+
+The production installer stages the downloaded image beside the current one, validates
+its packaged `resources/web-dist/index.html`, preserves a recovery copy, and replaces
+the current path atomically. A restart that does not reach the packaged UI is rolled
+back on the next launch.
 
 The harness binds only `127.0.0.1`. Runtime override activation additionally requires
 `PICHAMBER_E2E=1`, the loopback URL set by the harness, and the build-time marker.

--- a/packages/electron/scripts/verify-linux-appimage.mjs
+++ b/packages/electron/scripts/verify-linux-appimage.mjs
@@ -72,7 +72,20 @@ export const verifyExtractedPayload = ({ root, targetArchitecture }) => {
     if (!desktop.split(/\r?\n/).includes(entry)) throw new Error(`Desktop identity mismatch: missing ${entry}`);
   }
   if (!/^Exec=AppRun(?:\s|$)/m.test(desktop)) throw new Error('Desktop identity mismatch: expected AppImage AppRun entrypoint');
-  assertElfArchitecture(path.join(root, 'pichamber'), targetArchitecture, 'Electron executable');
+  if (!/^Exec=AppRun\s+--no-sandbox(?:\s|$)/m.test(desktop)) {
+    throw new Error('Desktop identity mismatch: expected the AppImage launcher to pass --no-sandbox');
+  }
+  const packagedIndex = path.join(root, 'resources', 'web-dist', 'index.html');
+  if (!fs.existsSync(packagedIndex) || !fs.statSync(packagedIndex).isFile()) {
+    throw new Error(`Missing packaged UI entrypoint: ${packagedIndex}`);
+  }
+  const executablePath = path.join(root, 'pichamber');
+  if (!fs.statSync(executablePath).isFile()) throw new Error(`Missing AppImage launcher: ${executablePath}`);
+  const launcher = fs.readFileSync(executablePath, 'utf8');
+  if (!launcher.includes('--no-sandbox') || !launcher.includes('pichamber-bin')) {
+    throw new Error('AppImage launcher must pass --no-sandbox to the bundled Electron binary');
+  }
+  assertElfArchitecture(path.join(root, 'pichamber-bin'), targetArchitecture, 'Electron executable');
   const unpackedModules = path.join(root, 'resources', 'app.asar.unpacked', 'node_modules');
   if (!fs.existsSync(unpackedModules)) throw new Error(`Missing unpacked native modules: ${unpackedModules}`);
   const nativeModules = collectFiles(unpackedModules, (name, fullPath) => {

--- a/packages/electron/updater-capability.mjs
+++ b/packages/electron/updater-capability.mjs
@@ -1,18 +1,53 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+const SUPPORTED_LINUX_PACKAGE_TYPES = new Set(['AppImage', 'deb', 'rpm', 'pacman']);
+
+export const resolveLinuxPackageType = ({
+  platform = process.platform,
+  packaged,
+  appImagePath = process.env.APPIMAGE,
+  resourcesPath = process.resourcesPath,
+  readFile = fs.readFileSync,
+} = {}) => {
+  if (platform !== 'linux' || !packaged) return null;
+
+  if (typeof resourcesPath === 'string' && resourcesPath) {
+    try {
+      const packageType = String(readFile(path.join(resourcesPath, 'package-type'), 'utf8')).trim().toLowerCase();
+      const normalized = packageType === 'appimage' ? 'AppImage' : packageType;
+      if (SUPPORTED_LINUX_PACKAGE_TYPES.has(normalized)) return normalized;
+    } catch {
+    }
+  }
+
+  if (typeof appImagePath === 'string' && appImagePath.trim()) return 'AppImage';
+  return null;
+};
+
 export const assertUpdaterCapability = ({
   platform = process.platform,
   packaged,
+  packageType,
   appImagePath = process.env.APPIMAGE,
   access = fs.accessSync,
   stat = fs.statSync,
 } = {}) => {
   if (platform !== 'linux' || !packaged) return;
 
+  const resolvedPackageType = packageType || (
+    typeof appImagePath === 'string' && appImagePath.trim() ? 'AppImage' : null
+  );
+  if (resolvedPackageType && resolvedPackageType !== 'AppImage') {
+    if (!SUPPORTED_LINUX_PACKAGE_TYPES.has(resolvedPackageType)) {
+      throw new Error(`Unsupported Linux package type: ${resolvedPackageType}`);
+    }
+    return;
+  }
+
   if (!appImagePath) {
     throw new Error(
-      'Updates require the packaged Linux AppImage. Start PiChamber from its .AppImage file, not an extracted or repackaged copy.',
+      'Updates require a packaged Linux installation. Start PiChamber from its AppImage or install the .deb/.rpm package from GitHub Releases.',
     );
   }
   if (!path.isAbsolute(appImagePath)) {
@@ -27,9 +62,10 @@ export const assertUpdaterCapability = ({
 
   try {
     access(appImagePath, fs.constants.W_OK);
+    access(path.dirname(appImagePath), fs.constants.W_OK);
   } catch {
     throw new Error(
-      `The AppImage is not writable at ${appImagePath}. Move it to a writable location or grant write permission before updating.`,
+      `The AppImage location is not writable at ${appImagePath}. Move it to a writable Linux filesystem location or grant write permission before updating.`,
     );
   }
 };

--- a/packages/electron/updater-capability.test.mjs
+++ b/packages/electron/updater-capability.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { assertUpdaterCapability } from './updater-capability.mjs';
+import { assertUpdaterCapability, resolveLinuxPackageType } from './updater-capability.mjs';
 
 test('preserves updater behavior outside packaged Linux', () => {
   assert.doesNotThrow(() => assertUpdaterCapability({ platform: 'darwin', packaged: true }));
@@ -9,11 +9,24 @@ test('preserves updater behavior outside packaged Linux', () => {
   assert.doesNotThrow(() => assertUpdaterCapability({ platform: 'linux', packaged: false }));
 });
 
-test('rejects packaged Linux execution outside an AppImage', () => {
+test('rejects packaged Linux execution without a recognized package', () => {
   assert.throws(
     () => assertUpdaterCapability({ platform: 'linux', packaged: true, appImagePath: '' }),
-    /Start PiChamber from its \.AppImage file/,
+    /packaged Linux installation.*\.deb\/\.rpm package/,
   );
+});
+
+test('accepts package-manager installations without an AppImage path', () => {
+  assert.doesNotThrow(() => assertUpdaterCapability({
+    platform: 'linux',
+    packaged: true,
+    packageType: 'deb',
+  }));
+  assert.doesNotThrow(() => assertUpdaterCapability({
+    platform: 'linux',
+    packaged: true,
+    packageType: 'rpm',
+  }));
 });
 
 test('rejects missing and non-writable AppImages with actionable errors', () => {
@@ -46,4 +59,33 @@ test('accepts a writable packaged AppImage', () => {
     stat: () => ({ isFile: () => true }),
     access: () => {},
   }));
+});
+
+test('resolves AppImage and package-manager identities', () => {
+  assert.equal(resolveLinuxPackageType({
+    platform: 'linux',
+    packaged: true,
+    appImagePath: '/home/user/PiChamber.AppImage',
+  }), 'AppImage');
+  assert.equal(resolveLinuxPackageType({
+    platform: 'linux',
+    packaged: true,
+    appImagePath: '',
+    resourcesPath: '/resources',
+    readFile: () => 'deb\n',
+  }), 'deb');
+  assert.equal(resolveLinuxPackageType({
+    platform: 'linux',
+    packaged: true,
+    appImagePath: '',
+    resourcesPath: '/resources',
+    readFile: () => 'unknown\n',
+  }), null);
+  assert.equal(resolveLinuxPackageType({
+    platform: 'linux',
+    packaged: true,
+    appImagePath: '/home/user/PiChamber.AppImage',
+    resourcesPath: '/resources',
+    readFile: () => 'deb\n',
+  }), 'deb');
 });


### PR DESCRIPTION
## Intent

Improve Linux desktop distribution and update reliability. Linux releases now publish native `.deb` and `.rpm` packages alongside the AppImage, package-manager installs retain Electron's normal Chromium sandbox, and AppImages launch through a compatibility wrapper that passes `--no-sandbox` before Electron starts. AppImage updates are validated and replaced at the existing path with a backup and startup rollback marker, so desktop shortcuts remain valid.

Packaged UI failures now produce a diagnostic page with version, package, AppImage path, log path, and recovery guidance.

## Non-goals

- No Flatpak or distro-repository publication.
- No changes to Windows or macOS updater behavior.
- No changes to the separate `../opencode` repository.

## Affected surfaces

- `packages/electron`: Linux targets, launcher packaging, package detection, AppImage update staging/recovery, and startup diagnostics.
- `.github/workflows/release.yml` and `release-desktop-smoke.yml`: build, validate, upload, and inventory-check `.deb`/`.rpm` artifacts.
- README, install docs, contributing guidance, and the AppImage updater fixture instructions.
- Persisted AppImage recovery state in Electron `userData` (`linux-appimage-update.json`) and a temporary `.previous` sibling beside the current AppImage. The state is removed after a successful packaged-UI launch.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` | Required repository process and runtime-boundary guidance | Keeps Linux packaging/update logic in Electron, preserves unrelated worktree changes, and documents the persisted recovery contract. |
| `pichamber-change-discipline` | Source, package metadata, release workflow, and documentation changes | Uses focused edits, package scripts as validation sources, and updates owning docs. |
| `desktop-shell` | Electron main process, packaging, sandbox, and updater behavior | Keeps privileged file replacement and restart logic in the main process; native package installs retain the sandbox. |
| `locale-ui-patterns` | New startup and update error copy | Uses explicit recovery-oriented user-facing messages and avoids renderer-only hiding of failures. |
| `packages/electron/README.md`, `CONTRIBUTING.md`, and `packages/docs/content/docs/install.mdx` | Package and installation ownership documentation | Documents package choice, AppImage limitations, stable paths, and update behavior. |

## Validation

| Check | Result |
|---|---|
| `bun run test` | Passed: 2,095 tests, 0 failures. |
| `bun run type-check` | Passed for all workspaces. |
| `bun run lint` | Passed for all workspaces. |
| `bun run docs:validate` | Passed: 9 pages, 9 sidebar links. |
| `bun run --cwd packages/electron test:architecture` | Passed: 43 tests. |
| `bun run --cwd packages/electron test:updater` | Passed: 25 tests. |
| `bun run dead-code` | Completed non-blocking; reports the repository's existing unused-export inventory. |
| Linux AppImage build, `verify-linux-appimage`, and direct launch | Passed on native x64. Direct launch stayed alive under the 8-second smoke timeout (expected) and emitted no SUID sandbox abort. |
| Linux `.deb` build and package inspection | Passed on native x64; launcher and bundled binary were executable and the launcher resolved through symlinks. |
| `node validateLinuxAppImage(...)` on the built AppImage | Passed, including packaged UI and launcher validation. |
| Workflow YAML parse and Node syntax checks | Passed. |

The full all-target Linux build and native arm64 packaging are left to the release matrix because this host does not have `rpmbuild` or an arm64 architecture. A real N-to-N+1 updater UI run was not performed locally; transaction behavior is covered by unit tests and the documented fixture harness.

## Visual evidence

No React layout or theme changed. This is a packaging/main-process/docs change, so screenshots are not applicable. The built AppImage was launched directly on Linux as a runtime smoke check; no startup error page was needed.

## Risks and failure behavior

- AppImages run with `--no-sandbox` because a user-mounted AppImage cannot provide the root-owned Chromium helper. This policy is limited to the AppImage launcher; `.deb`/`.rpm` installations keep the normal sandbox setup.
- AppImage updates keep the current path, copy the current image to a recovery backup, atomically rename the validated candidate, and retain recovery state until the new packaged UI loads. A failed subsequent start restores the backup; cleanup removes the backup only after confirmation.
- Update capability checks reject missing, non-absolute, non-file, or non-writable AppImage paths and also require a writable containing directory.
- Package-manager updates use electron-updater's native Debian/RPM flows and may request administrator authorization.
- Candidate validation extracts the downloaded AppImage with a bounded timeout and checks both `resources/web-dist/index.html` and the compatibility launcher before replacement.
