### PR TITLE
chore(release): v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-09-06
+
+Linux distribution and desktop update reliability release.
+
+- **Native Linux packages.** Releases now include `.deb` and `.rpm` packages alongside portable AppImages for x64 and arm64. Package-manager installs retain Electron's normal Chromium sandbox and use the native package updater.
+- **AppImage startup compatibility.** AppImages launch through a compatibility wrapper that passes `--no-sandbox` before Electron starts, avoiding the SUID sandbox failure on user-mounted filesystems. Installed `.deb` and `.rpm` packages keep the normal sandbox setup.
+- **Safe AppImage updates.** Downloads are validated before replacement, the current image path is preserved for desktop shortcuts, and the previous image remains available until the restarted packaged UI confirms a successful launch. Failed restarts roll back on the next launch.
+- **Startup diagnostics.** Missing packaged UI assets now show version, package, AppImage, and log diagnostics with recovery guidance instead of leaving a blank desktop window.
+
 ## [0.9.1] - 2026-09-06
 
 Server-profile daemon isolation, first-run settings persistence, and public-launch cleanup release.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pichamber-monorepo",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "PiChamber monorepo workspace for web, ui, and desktop runtimes",
   "private": true,
   "type": "module",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pichamber/electron",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "private": true,
   "description": "Electron desktop runtime for PiChamber",
   "author": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pichamber/ui",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "private": true,
   "type": "module",
   "main": "src/main.tsx",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-chamber/web",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "private": false,
   "type": "module",
   "repository": {


### PR DESCRIPTION
## Intent

Prepare the v0.9.2 release for the Linux distribution and updater improvements merged in #107. This updates the root, UI, web, and Electron package versions and promotes the changelog entry to `0.9.2`.

## Non-goals

No source behavior changes; no npm or mobile release changes.

## Affected surfaces

- `package.json`
- `packages/ui/package.json`
- `packages/web/package.json`
- `packages/electron/package.json`
- `CHANGELOG.md`

## Validation

- Version bump reviewed across all four release manifests.
- Changelog retains the prior `0.9.1` section and contains the required `0.9.2` section for the release workflow.
- The merged Linux packaging/update implementation was validated by PR #107's checks and Linux x64 AppImage/`.deb` smoke tests.

## Visual evidence

Not applicable: this is release metadata only.

## Risks and failure behavior

The release workflow will build and validate the x64/arm64 Linux AppImage, `.deb`, and `.rpm` artifacts plus the existing desktop artifacts before publishing the draft release. No package lockfile changes are included, matching the repository's existing release process.
