### PR TITLE
Disable collapsed-by-default reasoning for fresh installs

### DIFF
--- a/packages/ui/src/lib/persistence.test.ts
+++ b/packages/ui/src/lib/persistence.test.ts
@@ -448,14 +448,14 @@ describe('updateDesktopSettings', () => {
     switchRuntimeEndpoint({ apiBaseUrl: 'https://thinking-collapse-a.example', runtimeKey: 'thinking-collapse-a' });
     registerSettingsApi(async () => ({}), async () => ({
       settings: {
-        collapseThinkingByDefault: false,
+        collapseThinkingByDefault: true,
         draftStartersScheduleTaskAdded: true,
       },
       source: 'web',
     }));
     await syncDesktopSettings();
 
-    expect(useUIStore.getState().collapseThinkingByDefault).toBe(false);
+    expect(useUIStore.getState().collapseThinkingByDefault).toBe(true);
 
     switchRuntimeEndpoint({ apiBaseUrl: 'https://thinking-collapse-b.example', runtimeKey: 'thinking-collapse-b' });
     registerSettingsApi(async () => ({}), async () => ({
@@ -464,7 +464,7 @@ describe('updateDesktopSettings', () => {
     }));
     await syncDesktopSettings();
 
-    expect(useUIStore.getState().collapseThinkingByDefault).toBe(true);
+    expect(useUIStore.getState().collapseThinkingByDefault).toBe(false);
   });
 
   test('drops removed session assistance settings from authoritative snapshots', async () => {

--- a/packages/ui/src/stores/useUIStore.ts
+++ b/packages/ui/src/stores/useUIStore.ts
@@ -432,7 +432,7 @@ export const useUIStore = create<UIStore>()(
         eventStreamHint: null,
         showReasoningTraces: true,
         collapsibleThinkingBlocks: true,
-        collapseThinkingByDefault: true,
+        collapseThinkingByDefault: false,
         showDeletionDialog: true,
         autoDeleteEnabled: false,
         autoSaveEnabled: true,


### PR DESCRIPTION
## Intent

Fresh installs collapse reasoning blocks by default. This flips the install default for `collapseThinkingByDefault` from `true` to `false`, so new installs keep a one-line reasoning trace unless the user explicitly enables collapse.

## Non-goals

- No change to existing users with a persisted `true` value; their choice is preserved.
- No change to `showReasoningTraces`, `collapsibleThinkingBlocks`, or the `ReasoningPart` component prop defaults.

## Affected surfaces

- `packages/ui` `useUIStore` initial state (`collapseThinkingByDefault: false`); flows through `materializeAuthoritativeUiSettings` for fresh server settings.
- Web, desktop, hosted mobile, and Capacitor mobile all consume the shared UI store — no runtime-specific branching.
- Persisted contract: missing value now means `false`; stored booleans still round-trip unchanged.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md instruction order + pichamber-change-discipline | Source default + persisted-contract change | Minimal one-line default flip; updated the reset-expectation test; preserved existing persisted values |
| packages/ui/src/stores/DOCUMENTATION.md | Store ownership/persistence | Default lives in owning store; server materialization reuses getInitialState |

## Validation

| Check | Result |
|---|---|
| `bun test --isolate src/lib/persistence.test.ts` (packages/ui) | 30 pass, 0 fail |
| `bun test --isolate src/components/chat/message/parts/ReasoningPart.test.tsx` | 11 pass, 0 fail |
| `bun run type-check` (packages/ui) | pass |
| `bun run lint` (packages/ui) | pass |

Not verified: full workspace `bun run test`.

## Visual evidence

No rendered-structure change; the Settings checkbox still renders. Only the fresh-install checked state changes from on to off, so no screenshot is attached.

## Risks and failure behavior

- Compatibility: existing `true` persists; downgrade keeps stored value.
- Rollback: revert the one-line default.
- Security/performance impact: none identified.