### PR TITLE
fix(ui): prevent duplicate terminal paste

### DIFF
--- a/packages/ui/src/components/terminal/TerminalViewport.tsx
+++ b/packages/ui/src/components/terminal/TerminalViewport.tsx
@@ -345,12 +345,6 @@ const TerminalViewport = React.forwardRef<TerminalController, Props>(
             void copyTerminalSelection(selection);
             return false;
           }
-          if (outcome === 'paste') {
-            void readClipboardText().then((text) => {
-              if (text && terminalRef.current === attachedTerminal) attachedTerminal.paste(text);
-            });
-            return false;
-          }
           if (outcome === 'ignore') return false;
           return true;
         });

--- a/packages/ui/src/components/terminal/__tests__/terminalContextMenu.test.ts
+++ b/packages/ui/src/components/terminal/__tests__/terminalContextMenu.test.ts
@@ -48,6 +48,16 @@ describe('terminal right-click copy/paste menu', () => {
     expect(viewportSource).toContain("{'Select All'}");
   });
 
+  test('leaves keyboard paste to the native xterm paste event', () => {
+    const start = viewportSource.indexOf('terminal.attachCustomKeyEventHandler(');
+    expect(start).toBeGreaterThan(-1);
+    const end = viewportSource.indexOf('// OSC 52 clipboard writes stay disabled', start);
+    expect(end).toBeGreaterThan(start);
+    const handler = viewportSource.slice(start, end);
+    expect(handler).not.toContain("outcome === 'paste'");
+    expect(handler).not.toContain('attachedTerminal.paste(text)');
+  });
+
   test('keeps Electron out of shared UI code', () => {
     expect(viewportSource).not.toContain("from 'electron'");
     expect(viewportSource).not.toContain('__PICHAMBER_DESKTOP__');

--- a/packages/ui/src/lib/terminalClipboard.test.ts
+++ b/packages/ui/src/lib/terminalClipboard.test.ts
@@ -49,7 +49,7 @@ describe('terminal clipboard shortcuts', () => {
     ).toBe('ignore');
   });
 
-  test('uses Ctrl+Shift+C and Ctrl+Shift+V on Windows and Linux', () => {
+  test('uses Ctrl+Shift+C and native paste on Windows and Linux', () => {
     expect(
       resolveTerminalClipboardShortcut(
         { ...base, key: 'C', ctrlKey: true, shiftKey: true, metaKey: false },
@@ -63,7 +63,7 @@ describe('terminal clipboard shortcuts', () => {
         'other',
         false,
       ),
-    ).toBe('paste');
+    ).toBeNull();
     expect(
       resolveTerminalClipboardShortcut(
         { ...base, key: 'c', ctrlKey: true, shiftKey: false, metaKey: false },
@@ -80,14 +80,14 @@ describe('terminal clipboard shortcuts', () => {
     ).toBeNull();
   });
 
-  test('supports Insert shortcuts and ignores Alt combinations', () => {
+  test('uses native Shift+Insert paste and ignores Alt combinations', () => {
     expect(
       resolveTerminalClipboardShortcut(
         { ...base, key: 'Insert', code: 'Insert', ctrlKey: false, shiftKey: true, metaKey: false },
         'other',
         false,
       ),
-    ).toBe('paste');
+    ).toBeNull();
     expect(
       resolveTerminalClipboardShortcut(
         { ...base, key: 'c', ctrlKey: true, shiftKey: true, metaKey: false, altKey: true },

--- a/packages/ui/src/lib/terminalClipboard.ts
+++ b/packages/ui/src/lib/terminalClipboard.ts
@@ -1,7 +1,7 @@
 import { copyTextToClipboard } from '@/lib/clipboard';
 
 export type TerminalClipboardPlatform = 'mac' | 'other';
-export type TerminalClipboardShortcut = 'copy' | 'paste' | 'ignore' | null;
+export type TerminalClipboardShortcut = 'copy' | 'ignore' | null;
 
 type ShortcutEvent = {
   key: string;
@@ -30,10 +30,11 @@ const normalizeKey = (event: ShortcutEvent): string => {
 
 /**
  * Decide whether a key event is a terminal clipboard shortcut.
- * Returns `copy`/`paste` when the terminal should handle it, `ignore` when the
- * event must be consumed without PTY input (for example copy with no
- * selection), and `null` when the event belongs to the terminal.
- * Ctrl+C is never a copy shortcut so SIGINT keeps working.
+ * Returns `copy` when the terminal should copy its selection, `ignore` when
+ * the event must be consumed without PTY input (for example copy with no
+ * selection), and `null` when the event belongs to xterm or the browser.
+ * Paste always uses xterm's native paste event so one gesture has one input
+ * path. Ctrl+C is never a copy shortcut so SIGINT keeps working.
  */
 export const resolveTerminalClipboardShortcut = (
   event: ShortcutEvent,
@@ -46,19 +47,15 @@ export const resolveTerminalClipboardShortcut = (
   if (platform === 'mac') {
     if (!event.metaKey || event.ctrlKey) return null;
     if (key === 'c' && !event.shiftKey) return hasSelection ? 'copy' : 'ignore';
-    // Cmd+V relies on the native paste event so xterm.js can apply
-    // bracketed paste and IME handling without a second manual paste.
     return null;
   }
 
   if (event.metaKey) return null;
-  if (event.shiftKey && !event.ctrlKey && key === 'insert') return 'paste';
   if (event.ctrlKey && !event.shiftKey && key === 'insert') {
     return hasSelection ? 'copy' : 'ignore';
   }
   if (!event.ctrlKey || !event.shiftKey) return null;
   if (key === 'c') return hasSelection ? 'copy' : 'ignore';
-  if (key === 'v') return 'paste';
   return null;
 };
 


### PR DESCRIPTION
## Intent

Pasting into the terminal inserted the text twice, so a pasted URL ran as a doubled command. Keyboard paste on Linux and Windows now uses only the native xterm paste event, matching the existing macOS path. One paste gesture produces one terminal input.

## Non-goals

- Context-menu paste behavior is unchanged. A click has no browser paste event, so it keeps the manual clipboard read.
- Copy shortcuts, Ctrl+C SIGINT behavior, and OSC 52 policy are unchanged.

## Affected surfaces

- packages/ui terminal viewport and clipboard shortcut helper.
- Runtimes: web, desktop, hosted mobile, and Capacitor mobile all use the shared viewport. Desktop gets no Electron-side change; the fix stays in shared UI code.
- No persisted data, routes, IDs, exports outside the narrowed shortcut union, or CLI output changes. The only consumer of the narrowed type is the terminal viewport.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md instruction order and runtime boundaries | Source change in shared UI used by every runtime | Read the owning files and tests first, kept Electron out of shared code, kept the viewport entrypoint thin |
| pichamber-change-discipline | Source, export, and contract change | Smallest deletion-only fix, traced the single consumer of the narrowed type, updated contract tests |
| desktop-shell | Fix affects the desktop terminal | Read packages/electron README, confirmed no Electron main/preload change was needed |

## Validation

| Check | Result |
|---|---|
| bun test --isolate packages/ui/src/lib/terminalClipboard.test.ts packages/ui/src/components/terminal/__tests__/terminalContextMenu.test.ts | 11 pass |
| bun run test (web, UI, Electron suites) | Pass: 2,086 UI tests, plus web and Electron architecture/updater suites |
| bun run --cwd packages/ui type-check | Pass |
| bun run --cwd packages/ui lint | Pass |
| bun run dead-code | Completed; only pre-existing findings |
| Manual browser or Electron paste check | Not run here; no runnable Electron/Chromium binary in this environment |

## Visual evidence

No layout or theme change. The visible difference is input count: one paste inserts once instead of twice. No screenshots attached because this environment cannot drive a real browser paste into xterm.

## Risks and failure behavior

If a runtime failed to deliver the native paste event for Ctrl+Shift+V or Shift+Insert, keyboard paste would do nothing there instead of doubling. xterm 6 listens for native paste on its textarea and element and leaves both shortcuts uncancelled, and macOS already relies on this path, so that outcome is unlikely. Rollback is a revert of the single commit; failed paste can be retried and does not strand state.