### PR TITLE
fix(electron): keep Linux updates responsive

### DIFF
--- a/packages/electron/README.md
+++ b/packages/electron/README.md
@@ -45,6 +45,8 @@ AppImages are portable and do not require installation, but the AppImage format 
 
 Linux AppImage updates are staged and validated before the existing file is replaced. The previous image is retained until the restarted packaged UI confirms a successful launch; a failed restart is recovered on the next launch. The updater preserves the current AppImage path so existing desktop shortcuts do not become stale.
 
+Native Linux package installs run their privileged package command asynchronously. Polkit or sudo authentication does not block the Electron window.
+
 macOS notarized builds need `APPLE_CERTIFICATE` as base64 of a Developer ID Application `.p12`. Missing or unreadable certificates produce unsigned `.dmg`/`.zip` files instead of failing the job.
 
 ## Platform rules

--- a/packages/electron/linux-appimage-update.mjs
+++ b/packages/electron/linux-appimage-update.mjs
@@ -1,7 +1,7 @@
 import fsp from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { spawnSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 
 const TRANSACTION_FILE_NAME = 'linux-appimage-update.json';
 const BACKUP_SUFFIX = '.previous';
@@ -17,17 +17,47 @@ const assertAbsolutePath = (value, label) => {
   return path.normalize(value);
 };
 
+const extractAppImage = (appImagePath, temporaryDirectory) => new Promise((resolve, reject) => {
+  let child;
+  try {
+    child = spawn(appImagePath, ['--appimage-extract'], {
+      cwd: temporaryDirectory,
+      stdio: 'ignore',
+    });
+  } catch (error) {
+    reject(error);
+    return;
+  }
+
+  let settled = false;
+  const timer = setTimeout(() => {
+    if (settled) return;
+    settled = true;
+    child.kill('SIGKILL');
+    reject(new Error(`The downloaded AppImage could not be extracted within ${MAX_EXTRACT_MS}ms`));
+  }, MAX_EXTRACT_MS);
+
+  const finish = (callback, value) => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(timer);
+    callback(value);
+  };
+  child.once('error', (error) => finish(reject, error));
+  child.once('exit', (code, signal) => {
+    if (code === 0) {
+      finish(resolve);
+      return;
+    }
+    const detail = signal ? ` (signal ${signal})` : '';
+    finish(reject, new Error(`The downloaded AppImage could not be extracted${detail}`));
+  });
+});
+
 const defaultExtract = async (appImagePath) => {
   const temporaryDirectory = await fsp.mkdtemp(path.join(os.tmpdir(), 'pichamber-appimage-'));
   try {
-    const result = spawnSync(appImagePath, ['--appimage-extract'], {
-      cwd: temporaryDirectory,
-      stdio: 'ignore',
-      timeout: MAX_EXTRACT_MS,
-    });
-    if (result.error || result.status !== 0) {
-      throw new Error(`The downloaded AppImage could not be extracted${result.error ? `: ${result.error.message}` : ''}`);
-    }
+    await extractAppImage(appImagePath, temporaryDirectory);
 
     const extractedRoot = path.join(temporaryDirectory, 'squashfs-root');
     const indexPath = path.join(extractedRoot, 'resources', 'web-dist', 'index.html');

--- a/packages/electron/linux-appimage-update.test.mjs
+++ b/packages/electron/linux-appimage-update.test.mjs
@@ -8,6 +8,7 @@ import {
   confirmLinuxAppImageUpdate,
   installLinuxAppImageUpdate,
   recoverLinuxAppImageUpdate,
+  validateLinuxAppImage,
 } from './linux-appimage-update.mjs';
 
 const createFixture = async () => {
@@ -27,6 +28,32 @@ const validateFixtureAppImage = async ({ appImagePath }) => {
   const info = await fs.stat(appImagePath);
   assert.equal(info.isFile(), true);
 };
+
+test('validates an AppImage without blocking the event loop during extraction', async () => {
+  const fixture = await createFixture();
+  await fs.writeFile(fixture.downloadedPath, `#!/bin/sh
+if [ "$1" = "--appimage-extract" ]; then
+  mkdir -p squashfs-root/resources/web-dist
+  printf '<!doctype html>' > squashfs-root/resources/web-dist/index.html
+  printf '#!/bin/sh\\nexec pichamber-bin --no-sandbox "$@"\\n' > squashfs-root/pichamber
+  printf 'binary' > squashfs-root/pichamber-bin
+  chmod +x squashfs-root/pichamber-bin
+  sleep 0.025
+fi
+`, { mode: 0o755 });
+
+  let heartbeat = false;
+  try {
+    const validation = validateLinuxAppImage({ appImagePath: fixture.downloadedPath });
+    setTimeout(() => {
+      heartbeat = true;
+    }, 5);
+    await validation;
+    assert.equal(heartbeat, true);
+  } finally {
+    await fs.rm(fixture.root, { recursive: true, force: true });
+  }
+});
 
 test('installs an AppImage over the existing path and preserves a backup', async () => {
   const fixture = await createFixture();

--- a/packages/electron/linux-package-update.mjs
+++ b/packages/electron/linux-package-update.mjs
@@ -1,0 +1,228 @@
+import { execFile, spawn } from 'node:child_process';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const PACKAGE_MANAGER_PRIORITIES = Object.freeze({
+  deb: ['dpkg', 'apt'],
+  rpm: ['zypper', 'dnf', 'yum', 'rpm'],
+  pacman: ['pacman'],
+});
+
+const ELEVATION_COMMANDS = ['gksudo', 'kdesudo', 'pkexec', 'beesu'];
+const SUPPORTED_PACKAGE_TYPES = new Set(Object.keys(PACKAGE_MANAGER_PRIORITIES));
+
+const normalizePackageType = (value) => {
+  const normalized = String(value || '').trim().toLowerCase();
+  if (!SUPPORTED_PACKAGE_TYPES.has(normalized)) {
+    throw new Error(`Unsupported Linux package type: ${value || '(missing)'}`);
+  }
+  return normalized;
+};
+
+const assertAbsolutePath = (value) => {
+  if (typeof value !== 'string' || !path.isAbsolute(value)) {
+    throw new Error('The downloaded Linux update path must be absolute');
+  }
+  return path.normalize(value);
+};
+
+/**
+ * electron-updater escapes Linux installer paths for its shell-based updater.
+ * The asynchronous runner below passes arguments directly, so restore the
+ * original path before spawning the package manager.
+ */
+export const unescapeUpdaterInstallerPath = (value) => {
+  let result = '';
+  let escaped = false;
+  for (const character of String(value || '')) {
+    if (escaped) {
+      result += character;
+      escaped = false;
+    } else if (character === '\\') {
+      escaped = true;
+    } else {
+      result += character;
+    }
+  }
+  return escaped ? `${result}\\` : result;
+};
+
+const defaultCommandExists = async (command) => {
+  try {
+    await execFileAsync('/bin/sh', [
+      '-c',
+      'command -v -- "$1"',
+      'pichamber-linux-update',
+      command,
+    ], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export const resolveLinuxPackageManager = async ({
+  packageType,
+  commandExists = defaultCommandExists,
+} = {}) => {
+  const normalizedType = normalizePackageType(packageType);
+  for (const command of PACKAGE_MANAGER_PRIORITIES[normalizedType]) {
+    if (await commandExists(command)) return command;
+  }
+  throw new Error(`No supported package manager was found for the Linux ${normalizedType} package`);
+};
+
+export const buildLinuxPackageManagerArgs = ({
+  packageType,
+  packageManager,
+  installerPath,
+} = {}) => {
+  const normalizedType = normalizePackageType(packageType);
+  const manager = String(packageManager || '').trim();
+  const installer = assertAbsolutePath(installerPath);
+
+  if (normalizedType === 'deb' && manager === 'dpkg') return ['-i', installer];
+  if (normalizedType === 'deb' && manager === 'apt') {
+    return [
+      'install',
+      '-y',
+      '--allow-unauthenticated',
+      '--allow-downgrades',
+      '--allow-change-held-packages',
+      installer,
+    ];
+  }
+  if (normalizedType === 'rpm' && manager === 'zypper') {
+    return ['--non-interactive', '--no-refresh', 'install', '--allow-unsigned-rpm', '-f', installer];
+  }
+  if (normalizedType === 'rpm' && manager === 'dnf') return ['install', '--nogpgcheck', '-y', installer];
+  if (normalizedType === 'rpm' && manager === 'yum') return ['install', '--nogpgcheck', '-y', installer];
+  if (normalizedType === 'rpm' && manager === 'rpm') {
+    return ['-Uvh', '--replacepkgs', '--replacefiles', '--nodeps', installer];
+  }
+  if (normalizedType === 'pacman' && manager === 'pacman') return ['-U', '--noconfirm', installer];
+
+  throw new Error(`Package manager ${manager || '(missing)'} cannot install a Linux ${normalizedType} package`);
+};
+
+const shellQuote = (value) => `'${String(value).replaceAll("'", "'\\''")}'`;
+
+const buildElevationCommand = ({
+  elevationCommand,
+  command,
+  args,
+} = {}) => {
+  if (!elevationCommand) return { command, args };
+
+  if (elevationCommand === 'pkexec' || elevationCommand === 'sudo' || elevationCommand === 'beesu') {
+    return {
+      command: elevationCommand,
+      args: elevationCommand === 'pkexec'
+        ? ['--disable-internal-agent', command, ...args]
+        : [command, ...args],
+    };
+  }
+
+  const commandLine = [command, ...args].map(shellQuote).join(' ');
+  if (elevationCommand === 'kdesudo') {
+    return { command: elevationCommand, args: ['--comment', 'PiChamber would like to update', '-c', commandLine] };
+  }
+  if (elevationCommand === 'gksudo') {
+    return { command: elevationCommand, args: ['--message', 'PiChamber would like to update', command, ...args] };
+  }
+  throw new Error(`Unsupported Linux elevation command: ${elevationCommand}`);
+};
+
+const defaultRunCommand = (command, args) => new Promise((resolve, reject) => {
+  let child;
+  try {
+    child = spawn(command, args, {
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+  } catch (error) {
+    reject(error);
+    return;
+  }
+
+  let settled = false;
+  const settle = (callback, value) => {
+    if (settled) return;
+    settled = true;
+    callback(value);
+  };
+  child.once('error', (error) => settle(reject, error));
+  child.once('exit', (code, signal) => settle(resolve, { code, signal }));
+});
+
+const resolveLinuxElevationCommand = async (commandExists) => {
+  for (const command of ELEVATION_COMMANDS) {
+    if (await commandExists(command)) return command;
+  }
+  return 'sudo';
+};
+
+const runElevatedCommand = async ({
+  elevationCommand,
+  command,
+  args,
+  runCommand,
+}) => {
+  const invocation = buildElevationCommand({ elevationCommand, command, args });
+  return runCommand(invocation.command, invocation.args);
+};
+
+const assertCommandSucceeded = (result, label) => {
+  if (result?.code === 0) return;
+  const signal = result?.signal ? ` (signal ${result.signal})` : '';
+  throw new Error(`${label} failed with exit code ${result?.code ?? 'unknown'}${signal}`);
+};
+
+export const installLinuxPackageUpdate = async ({
+  packageType,
+  installerPath,
+  isRoot = typeof process.getuid === 'function' && process.getuid() === 0,
+  commandExists = defaultCommandExists,
+  runCommand = defaultRunCommand,
+} = {}) => {
+  const normalizedType = normalizePackageType(packageType);
+  const installer = assertAbsolutePath(installerPath);
+  const packageManager = await resolveLinuxPackageManager({
+    packageType: normalizedType,
+    commandExists,
+  });
+  const elevationCommand = isRoot ? null : await resolveLinuxElevationCommand(commandExists);
+  const args = buildLinuxPackageManagerArgs({
+    packageType: normalizedType,
+    packageManager,
+    installerPath: installer,
+  });
+
+  const result = await runElevatedCommand({
+    elevationCommand,
+    command: packageManager,
+    args,
+    runCommand,
+  });
+
+  if (result?.code === 0) return { packageManager };
+
+  // Match electron-updater's .deb behavior: dpkg can unpack the package and
+  // then fail while configuring a dependency. apt-get -f completes that
+  // transaction without blocking Electron's event loop.
+  if (normalizedType === 'deb' && packageManager === 'dpkg') {
+    const repairResult = await runElevatedCommand({
+      elevationCommand,
+      command: 'apt-get',
+      args: ['install', '-f', '-y'],
+      runCommand,
+    });
+    assertCommandSucceeded(repairResult, 'Linux package dependency repair');
+    return { packageManager, repaired: true };
+  }
+
+  assertCommandSucceeded(result, 'Linux package installation');
+  return { packageManager };
+};

--- a/packages/electron/linux-package-update.test.mjs
+++ b/packages/electron/linux-package-update.test.mjs
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { installLinuxPackageUpdate } from './linux-package-update.mjs';
+
+test('keeps the Electron event loop available during a privileged Linux package install', async () => {
+  const commands = [];
+  let heartbeat = false;
+
+  const installation = installLinuxPackageUpdate({
+    packageType: 'deb',
+    installerPath: '/tmp/PiChamber-update.deb',
+    isRoot: false,
+    commandExists: async (command) => command === 'dpkg' || command === 'pkexec',
+    runCommand: async (command, args) => {
+      commands.push({ command, args });
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      return { code: 0, signal: null };
+    },
+  });
+
+  setTimeout(() => {
+    heartbeat = true;
+  }, 5);
+
+  await installation;
+
+  assert.equal(heartbeat, true);
+  assert.deepEqual(commands, [
+    {
+      command: 'pkexec',
+      args: ['--disable-internal-agent', 'dpkg', '-i', '/tmp/PiChamber-update.deb'],
+    },
+  ]);
+});
+
+test('repairs a failed dpkg configuration asynchronously', async () => {
+  const commands = [];
+  const result = await installLinuxPackageUpdate({
+    packageType: 'deb',
+    installerPath: '/tmp/PiChamber update.deb',
+    isRoot: true,
+    commandExists: async (command) => command === 'dpkg',
+    runCommand: async (command, args) => {
+      commands.push({ command, args });
+      return commands.length === 1 ? { code: 1, signal: null } : { code: 0, signal: null };
+    },
+  });
+
+  assert.deepEqual(result, { packageManager: 'dpkg', repaired: true });
+  assert.deepEqual(commands, [
+    { command: 'dpkg', args: ['-i', '/tmp/PiChamber update.deb'] },
+    { command: 'apt-get', args: ['install', '-f', '-y'] },
+  ]);
+});
+
+test('restores paths escaped by electron-updater', async () => {
+  const { unescapeUpdaterInstallerPath } = await import('./linux-package-update.mjs');
+  assert.equal(
+    unescapeUpdaterInstallerPath('/home/ryder/My\\ App/updates/PiChamber\\ 0.9.3.deb'),
+    '/home/ryder/My App/updates/PiChamber 0.9.3.deb',
+  );
+});

--- a/packages/electron/main.mjs
+++ b/packages/electron/main.mjs
@@ -25,6 +25,7 @@ import {
   installLinuxAppImageUpdate,
   recoverLinuxAppImageUpdate,
 } from './linux-appimage-update.mjs';
+import { installLinuxPackageUpdate, unescapeUpdaterInstallerPath } from './linux-package-update.mjs';
 import { checkForDesktopUpdate } from './updater-check.mjs';
 import { resolveUpdaterChannel } from './updater-channel.mjs';
 import { resolveUpdaterFeed } from './updater-feed.mjs';
@@ -271,6 +272,7 @@ const state = {
   quitConfirmationPending: false,
   backgroundShutdownComplete: false,
   installingUpdate: false,
+  linuxUpdateInProgress: false,
   pendingUpdate: null,
   unreachableHosts: new Set(),
   windowCounter: 1,
@@ -4188,6 +4190,7 @@ const handleInvoke = async (browserWindow, command, args = {}) => {
       }
 
     case 'desktop_restart': {
+      if (state.installingUpdate) return null;
       const applyUpdate = Boolean(state.pendingUpdate?.downloaded && app.isPackaged);
       const packageType = currentLinuxPackageType();
       if (applyUpdate) assertUpdaterCapability({ packaged: app.isPackaged, packageType });
@@ -4203,11 +4206,11 @@ const handleInvoke = async (browserWindow, command, args = {}) => {
         }
       }
       if (applyUpdate) {
-        // Match the working updater pattern closely: only bypass the macOS
-        // hide-on-close / quit-confirmation guards, leave the rest of the
-        // updater-driven quit/install sequence alone.
+        // Bypass the macOS hide-on-close and quit-confirmation guards while
+        // the update installer owns the shutdown sequence.
         state.quitRequested = true;
         state.installingUpdate = true;
+        state.linuxUpdateInProgress = process.platform === 'linux';
         state.quitConfirmationPending = false;
         if (state.mainWindow && !state.mainWindow.isDestroyed()) {
           try {
@@ -4239,8 +4242,26 @@ const handleInvoke = async (browserWindow, command, args = {}) => {
                 version: installed.version,
                 currentPath: installed.currentPath,
               });
+              state.linuxUpdateInProgress = false;
               killSidecar();
               app.relaunch({ execPath: installed.currentPath, args: [] });
+              app.exit(0);
+              return;
+            }
+
+            if (process.platform === 'linux' && packageType) {
+              const downloadedPath = autoUpdater.installerPath;
+              if (typeof downloadedPath !== 'string') {
+                throw new Error('The downloaded Linux update file is no longer available. Download it again.');
+              }
+
+              await installLinuxPackageUpdate({
+                packageType,
+                installerPath: unescapeUpdaterInstallerPath(downloadedPath),
+              });
+              state.linuxUpdateInProgress = false;
+              killSidecar();
+              app.relaunch();
               app.exit(0);
               return;
             }
@@ -4254,6 +4275,7 @@ const handleInvoke = async (browserWindow, command, args = {}) => {
           }
         } catch (err) {
           state.installingUpdate = false;
+          state.linuxUpdateInProgress = false;
           state.quitRequested = false;
           state.quitConfirmed = false;
           log.error('[electron] desktop_restart failed', err);
@@ -5029,6 +5051,9 @@ app.on('window-all-closed', () => {
   }
 
   if (process.platform !== 'darwin') {
+    if (state.linuxUpdateInProgress) {
+      return;
+    }
     if (state.installingUpdate) {
       app.quit();
     } else {
@@ -5039,6 +5064,11 @@ app.on('window-all-closed', () => {
 
 app.on('before-quit', (event) => {
   state.quitRequested = true;
+
+  if (state.linuxUpdateInProgress) {
+    event.preventDefault();
+    return;
+  }
 
   if (state.installingUpdate) {
     return;

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -41,7 +41,7 @@
     "generate:macos-icon": "node ./scripts/generate-macos-icon-assets.cjs",
     "rebuild:native": "node ./scripts/rebuild-native.mjs",
     "test:architecture": "node --test ./startup-url-selection.test.mjs ./scripts/target-architecture.test.mjs ./scripts/verify-update-manifest.test.mjs ./scripts/ensure-electron.test.mjs ./path-open-utils.test.mjs ./process-performance-recorder.test.mjs",
-    "test:updater": "node --test ./app-version.test.mjs ./linux-appimage-update.test.mjs ./updater-capability.test.mjs ./updater-channel.test.mjs ./updater-check.test.mjs ./updater-feed.test.mjs ./scripts/finalize-latest-yml.test.mjs ./scripts/updater-e2e-fixture.test.mjs",
+    "test:updater": "node --test ./app-version.test.mjs ./linux-appimage-update.test.mjs ./linux-package-update.test.mjs ./updater-capability.test.mjs ./updater-channel.test.mjs ./updater-check.test.mjs ./updater-feed.test.mjs ./scripts/finalize-latest-yml.test.mjs ./scripts/updater-e2e-fixture.test.mjs",
     "test:linux-desktop": "node --test ./linux-autostart.test.mjs && node ./scripts/smoke-linux-app-discovery.mjs && node ./scripts/smoke-path-open-utils.mjs",
     "updater:e2e:fixture": "node ./scripts/updater-e2e-fixture.mjs",
     "verify:update-manifest": "node ./scripts/verify-update-manifest.mjs",


### PR DESCRIPTION
## Intent

Keep Linux desktop updates responsive while Polkit/sudo authentication and native package installation run. The Electron main process now uses asynchronous child processes for `.deb`, `.rpm`, and pacman installs, including the existing `dpkg` dependency-repair fallback. AppImage extraction is asynchronous as well.

## Non-goals

- No changes to Windows or macOS update behavior.
- No changes to release artifacts, updater feeds, package formats, or renderer layout/copy.
- No changes to persisted session data or API contracts.

## Affected surfaces

- `packages/electron`: Linux updater orchestration, AppImage extraction, package installation helpers, tests, and updater documentation.
- Linux packaged desktop installs and AppImage updates. Windows and macOS continue through their existing updater paths.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` | Governs repository-wide change, security, runtime-boundary, and validation rules. | Keeps privileged update logic in Electron main, preserves unrelated worktree changes, and does not add dependencies or secrets. |
| `pichamber-change-discipline` | Applies to Electron source, tests, package scripts, and documentation changes. | Keeps the change focused, updates the owning README, and adds regression coverage. |
| `desktop-shell` | Applies to Electron main-process lifecycle and privileged child-process behavior. | Uses direct child-process arguments, keeps entrypoint behavior explicit, and guards shutdown/relaunch while installation is active. |
| `packages/electron/README.md` | Nearest package guidance for desktop packaging and updater behavior. | Documents the asynchronous privileged Linux install contract. |

## Validation

| Check | Result |
|---|---|
| `bun run test` | Passed, 2,095 tests. |
| `bun run type-check` | Passed. |
| `bun run lint` | Passed. |
| `bun run --cwd packages/electron test:updater` | Passed. |
| `bun run --cwd packages/electron test:architecture` | Passed. |
| `bun run --cwd packages/electron type-check` | Passed. |
| `bun run --cwd packages/electron bundle:main` | Passed. |
| Packaged Linux update with a real `.deb`/`.rpm` or AppImage release | Not run in this environment; distro/package-manager authentication was not available for an end-to-end GUI check. |

## Visual evidence

No renderer, layout, theme, or copy changes were made, so screenshots are not applicable. The behavior change is in the Electron main-process update lifecycle; regression tests cover that the event loop remains available during privileged installation and AppImage extraction.

## Risks and failure behavior

- Package-manager and elevation failures reject the update, clear the in-progress shutdown state, and leave the app running rather than relaunching prematurely.
- Downloaded installer paths are validated and passed as direct arguments instead of shell-interpolated strings.
- AppImage staging and rollback behavior remains unchanged apart from asynchronous extraction.
- The new flow relies on the existing native package managers and desktop authentication agents; unsupported package types or missing managers fail explicitly.
