### PR TITLE
fix(ui): keep extension mode status in sync

### DIFF
--- a/packages/ui/src/sync/pi-session-store-helpers.test.ts
+++ b/packages/ui/src/sync/pi-session-store-helpers.test.ts
@@ -168,4 +168,23 @@ describe('pi-session-store-helpers', () => {
     expect(merged.lifecycle).toBe('busy');
     expect(merged.lastSequence).toBe(7);
   });
+
+  test('keeps a live mode status when stale hydration catches the first prompt', () => {
+    const existing = hydrateSessionFromDetail({
+      session: { id: 'session-1', directory: '/dir' },
+      lastSequence: 7,
+      lifecycle: 'busy',
+      extensionStatuses: [{ key: 'mode', text: 'mode:balance/max' }],
+      messages: [],
+    }).session;
+    const fetched = hydrateSessionFromDetail({
+      session: { id: 'session-1', directory: '/dir' },
+      lastSequence: 5,
+      messages: [],
+    }).session;
+
+    const merged = mergeHydratedSession(fetched, existing);
+
+    expect(merged.extensionStatuses.get('mode')).toBe('mode:balance/max');
+  });
 });

--- a/packages/ui/src/sync/pi-session-store-helpers.ts
+++ b/packages/ui/src/sync/pi-session-store-helpers.ts
@@ -144,6 +144,10 @@ export const mergeHydratedSession = (
     existing.lifecycle === 'busy' || existing.lifecycle === 'retry';
   const preserveExisting =
     liveTurn || existing.lastSequence > fetched.lastSequence;
+  // A fetch can finish behind an already accepted live extension event. The
+  // detail response has no way to represent that newer event, so do not let
+  // stale hydration erase the status that the user is looking at.
+  const preserveExistingExtensionState = existing.lastSequence > fetched.lastSequence;
   const preservePagedHistory = fetched.hasMoreBefore === true && existing.messages.size > 0;
   if (existing.messages.size === 0 && !preserveExisting) return fetched;
 
@@ -174,6 +178,23 @@ export const mergeHydratedSession = (
     ...(existing.thinking && (preserveExisting || !fetched.thinking)
       ? { thinking: existing.thinking }
       : {}),
+    ...(preserveExistingExtensionState
+      ? {
+          extensionStatuses: existing.extensionStatuses,
+          extensionWidgets: existing.extensionWidgets,
+          extensionDialogs: existing.extensionDialogs,
+          extensionPanels: existing.extensionPanels,
+          extensionApps: existing.extensionApps,
+          extensionTitle: existing.extensionTitle,
+        }
+      : {}),
+    // These fields are local live state rather than part of the session detail
+    // response. Hydration must not reset them, regardless of fetched sequence.
+    extensionNotices: existing.extensionNotices,
+    extensionErrors: existing.extensionErrors,
+    extensionCatalogRevision: existing.extensionCatalogRevision,
+    sessionTreeRevision: existing.sessionTreeRevision,
+    extensionEditor: existing.extensionEditor,
   };
   if (preserveExisting || preservePagedHistory) {
     for (const [id, message] of existing.messages) {

--- a/packages/ui/src/sync/session-ui-message-routing.ts
+++ b/packages/ui/src/sync/session-ui-message-routing.ts
@@ -52,6 +52,10 @@ export async function routeMessage(params: {
       ? params.delivery
       : 'prompt';
   const sessionStore = getPiSessionStore();
+  // Pi resets thinking to the model default during setModel. The reducer may
+  // still report the old level when the model request resolves, so a model
+  // change always invalidates the cached thinking value for this send.
+  let modelChanged = false;
   if (params.sessionId && params.providerID && params.modelID) {
     const currentModel = committedSessionSelection(params.sessionId).model;
     if (
@@ -64,11 +68,12 @@ export async function routeMessage(params: {
         params.providerID,
         params.modelID
       );
+      modelChanged = true;
     }
   }
   if (params.sessionId && isPiThinkingLevel(params.variant)) {
     const currentThinking = committedSessionSelection(params.sessionId).thinking;
-    if (currentThinking !== params.variant) {
+    if (modelChanged || currentThinking !== params.variant) {
       await sessionStore.setThinking(params.sessionId, params.variant);
     }
   }

--- a/packages/ui/src/sync/session-ui-store.test.ts
+++ b/packages/ui/src/sync/session-ui-store.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 
 import { getPiSessionStore } from '@/apps/pi-session-store';
+import { hydrateSessionFromDetail } from '@/lib/pi/event-reducer';
 import {
   draftBranchCheckoutReceiptMatches,
   materializeOpenDraftSession,
@@ -183,6 +184,50 @@ describe('routeMessage', () => {
     });
 
     expect(calls).toEqual(['setModel', 'setThinking', 'prompt']);
+  });
+
+  test('reapplies the selected thinking level after changing models', async () => {
+    const sessionId = 'session-direct-mode';
+    const originalState = store.getState();
+    const existing = hydrateSessionFromDetail({
+      session: {
+        id: sessionId,
+        directory: '/workspace',
+        model: { providerId: 'opencode-go', modelId: 'previous-model' },
+        thinking: 'max',
+      },
+      lastSequence: 1,
+      messages: [],
+    }).session;
+    (store as unknown as { state: typeof originalState }).state = {
+      ...originalState,
+      reducer: {
+        ...originalState.reducer,
+        bySession: new Map([[sessionId, existing]]),
+      },
+    };
+
+    const calls: string[] = [];
+    store.setModel = async () => { calls.push('setModel'); };
+    store.setThinking = async () => { calls.push('setThinking'); };
+    store.prompt = async () => {
+      calls.push('prompt');
+      return { accepted: true, messageId: 'message-direct-mode' };
+    };
+
+    try {
+      await routeMessage({
+        sessionId,
+        directory: '/workspace',
+        content: 'hello',
+        providerID: 'openai-codex',
+        modelID: 'gpt-5.6-luna',
+        variant: 'max',
+      });
+      expect(calls).toEqual(['setModel', 'setThinking', 'prompt']);
+    } finally {
+      (store as unknown as { state: typeof originalState }).state = originalState;
+    }
   });
 
   test('does not prompt when setThinking fails', async () => {


### PR DESCRIPTION
## Intent

Pi clears the thinking level while changing models. The UI can still hold the previous `max` value, skip the follow-up `setThinking` call, and leave the modes extension without its expected `mode:balance/max` status. A stale session-detail response could also overwrite a newer live extension status.

This change preserves newer live extension state during hydration and reapplies the selected thinking level after a model change. Provider and model matching stays exact, so `openai-codex/gpt-5.6-luna` is not treated as the OpenCode equivalent.

## Non-goals

- No changes to the Pi extension or its mode configuration.
- No daemon request while the composer is edited. Model and thinking updates still happen when a message is sent.
- No changes to persisted data, routes, or package dependencies.

## Affected surfaces

- `packages/ui` session hydration and send-time model/thinking routing.
- Web, Electron, hosted mobile, and Capacitor mobile clients through the shared UI store.
- The existing extension status strip receives the authoritative live mode status. Its rendering and styling are unchanged.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` | Repository-wide runtime and validation rules apply to shared UI changes. | Keeps Pi authoritative, preserves runtime parity, avoids secrets and dependencies, and keeps the change focused. |
| `.agents/skills/pichamber-change-discipline/SKILL.md` | This changes shared UI source and synchronization behavior. | Preserves existing callers, adds regression coverage, and validates the owning package. |
| `.agents/skills/sync-state-invariants/SKILL.md` | The fix covers stale hydration and send-time state reconciliation. | Newer live state wins over older detail responses, and model changes invalidate the cached thinking level. |
| `.agents/skills/ui-api-decoupling/SKILL.md` | The send path invokes Pi session operations through the existing store facade. | No direct transport or runtime-specific API was added. |
| `packages/ui/src/sync/DOCUMENTATION.md` and `packages/ui/src/lib/pi/DOCUMENTATION.md` | These modules own session synchronization and Pi state contracts. | The implementation stays in the existing sync and Pi-store paths. |

## Validation

| Check | Result |
|---|---|
| `bun run --cwd packages/ui test` | Passed, 2,103 tests. |
| `bun run type-check:ui` | Passed. |
| `bun run lint:ui` | Passed. |
| `bun run test:electron` | Passed, 72 tests. |
| `PATH=/home/ryder/.nvm/versions/node/v22.19.0/bin:/home/ryder/.bun/bin:$PATH bun run test` | Web suite reached 72/73 passing. The only failure was the existing `supervisor.test.js` per-profile daemon test reporting `The Pi session daemon is unavailable`; the root command stopped before its UI and Electron phases. UI and Electron suites were run separately above. |

No browser screenshot was captured. The status strip component and styling did not change; this patch changes which live status value reaches that existing renderer.

## Risks and failure behavior

The change only preserves existing live extension fields when the fetched sequence is older, and it retries the selected thinking level after a successful model change. If either Pi operation fails, the existing error path prevents prompt dispatch. No persisted state or external contract changes.
