### PR TITLE
fix(ui): navigate to new-session draft after deleting the current session

### DIFF
--- a/packages/ui/src/components/session/SessionDialogs.tsx
+++ b/packages/ui/src/components/session/SessionDialogs.tsx
@@ -16,7 +16,6 @@ import { DirectoryExplorerDialog } from './DirectoryExplorerDialog';
 import type { Session } from '@/lib/chat/types';
 import { getSessionDisplayTitle } from '@/lib/chat/sessionTitle';
 import { useSessionUIStore } from '@/sync/session-ui-store';
-import * as sessionActions from '@/sync/session-actions';
 import { useUIStore } from '@/stores/useUIStore';
 import { useDeviceInfo } from '@/lib/device';
 import { sessionEvents } from '@/lib/sessionEvents';
@@ -35,7 +34,7 @@ export const SessionDialogs: React.FC = () => {
     const [deleteDialog, setDeleteDialog] = React.useState<DeleteDialogState | null>(null);
     const [isProcessingDelete, setIsProcessingDelete] = React.useState(false);
 
-    const deleteSession = sessionActions.deleteSession;
+    const deleteSession = useSessionUIStore((s) => s.deleteSession);
     const deleteSessions = useSessionUIStore((s) => s.deleteSessions);
     const showDeletionDialog = useUIStore((state) => state.showDeletionDialog);
     const setShowDeletionDialog = useUIStore((state) => state.setShowDeletionDialog);

--- a/packages/ui/src/sync/session-ui-delete-navigation.test.ts
+++ b/packages/ui/src/sync/session-ui-delete-navigation.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { getPiSessionStore } from '@/apps/pi-session-store';
+import { useSessionUIStore } from './session-ui-store';
+
+const piStore = getPiSessionStore();
+const originalRemove = piStore.remove;
+
+const resetUi = () => {
+  useSessionUIStore.setState({
+    currentSessionId: null,
+    currentSessionDirectory: null,
+    newSessionDraft: {
+      id: null,
+      open: false,
+      selectedProjectId: null,
+      directoryOverride: null,
+      branchIntent: null,
+      worktreeIntent: null,
+      preserveDirectoryOverride: false,
+      parentID: null,
+      title: undefined,
+      initialPrompt: undefined,
+      syntheticParts: undefined,
+      targetFolderId: undefined,
+    },
+  });
+};
+
+afterEach(() => {
+  piStore.remove = originalRemove;
+  resetUi();
+});
+
+describe('delete navigates away from the visible session', () => {
+  test('deleteSession opens a new draft when the current session is deleted', async () => {
+    piStore.remove = (async () => undefined) as typeof piStore.remove;
+    useSessionUIStore.setState({ currentSessionId: 'sess-current', currentSessionDirectory: '/workspace' });
+
+    const result = await useSessionUIStore.getState().deleteSession('sess-current');
+
+    expect(result).toBe(true);
+    expect(useSessionUIStore.getState().currentSessionId).toBeNull();
+    expect(useSessionUIStore.getState().newSessionDraft.open).toBe(true);
+  });
+
+  test('deleteSession keeps the current session when another session is deleted', async () => {
+    piStore.remove = (async () => undefined) as typeof piStore.remove;
+    useSessionUIStore.setState({ currentSessionId: 'sess-other', currentSessionDirectory: '/workspace' });
+
+    const result = await useSessionUIStore.getState().deleteSession('sess-current');
+
+    expect(result).toBe(true);
+    expect(useSessionUIStore.getState().currentSessionId).toBe('sess-other');
+    expect(useSessionUIStore.getState().newSessionDraft.open).toBe(false);
+  });
+
+  test('deleteSession does not navigate when the delete fails', async () => {
+    piStore.remove = (async () => {
+      throw new Error('delete failed');
+    }) as typeof piStore.remove;
+    useSessionUIStore.setState({ currentSessionId: 'sess-current', currentSessionDirectory: '/workspace' });
+
+    await expect(useSessionUIStore.getState().deleteSession('sess-current')).rejects.toThrow('delete failed');
+    expect(useSessionUIStore.getState().currentSessionId).toBe('sess-current');
+    expect(useSessionUIStore.getState().newSessionDraft.open).toBe(false);
+  });
+
+  test('deleteSession does not steal a session selected during the delete RPC', async () => {
+    piStore.remove = (async () => {
+      useSessionUIStore.setState({ currentSessionId: 'sess-new', currentSessionDirectory: '/workspace' });
+    }) as typeof piStore.remove;
+    useSessionUIStore.setState({ currentSessionId: 'sess-current', currentSessionDirectory: '/workspace' });
+
+    const result = await useSessionUIStore.getState().deleteSession('sess-current');
+
+    expect(result).toBe(true);
+    expect(useSessionUIStore.getState().currentSessionId).toBe('sess-new');
+    expect(useSessionUIStore.getState().newSessionDraft.open).toBe(false);
+  });
+
+  test('deleteSessions opens a new draft when the current session is among the deleted ids', async () => {
+    piStore.remove = (async () => undefined) as typeof piStore.remove;
+    useSessionUIStore.setState({ currentSessionId: 'sess-a', currentSessionDirectory: '/workspace' });
+
+    const result = await useSessionUIStore.getState().deleteSessions(['sess-a', 'sess-b']);
+
+    expect(result.deletedIds).toEqual(['sess-a', 'sess-b']);
+    expect(useSessionUIStore.getState().currentSessionId).toBeNull();
+    expect(useSessionUIStore.getState().newSessionDraft.open).toBe(true);
+  });
+
+  test('deleteSessions keeps the current session when it was not deleted', async () => {
+    piStore.remove = (async (id: string) => {
+      if (id === 'sess-current') throw new Error('delete failed');
+    }) as typeof piStore.remove;
+    useSessionUIStore.setState({ currentSessionId: 'sess-current', currentSessionDirectory: '/workspace' });
+
+    const result = await useSessionUIStore.getState().deleteSessions(['sess-current', 'sess-b']);
+
+    expect(result.deletedIds).toEqual(['sess-b']);
+    expect(result.failedIds).toEqual(['sess-current']);
+    expect(useSessionUIStore.getState().currentSessionId).toBe('sess-current');
+    expect(useSessionUIStore.getState().newSessionDraft.open).toBe(false);
+  });
+});

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -693,11 +693,28 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
   },
 
   // ---------------------------------------------------------------------------
-  // deleteSession — calls the Pi API, SSE event updates child store
+  // deleteSession — calls the Pi API, SSE event updates child store.
+  // Deleting the visible session navigates to the new-session draft so the
+  // chat does not stay pinned to a deleted id and error on load. The Pi
+  // cluster may still hold a sibling selection for background continuity;
+  // the open draft wins the visible route via the draft guard.
   // ---------------------------------------------------------------------------
-  deleteSession: (id, options) => deleteSessionAction(id, options as any),
+  deleteSession: async (id, options) => {
+    const result = await deleteSessionAction(id, options as any)
+    if (result && get().currentSessionId === id) {
+      get().openNewSessionDraft()
+    }
+    return result
+  },
 
-  deleteSessions: (ids, options) => deleteSessionsAction(ids, options as any),
+  deleteSessions: async (ids, options) => {
+    const result = await deleteSessionsAction(ids, options as any)
+    const current = get().currentSessionId
+    if (current && result.deletedIds.includes(current)) {
+      get().openNewSessionDraft()
+    }
+    return result
+  },
 
   archiveSession: (id) => archiveSessionAction(id),
 


### PR DESCRIPTION
## Intent

Deleting the session you are currently in deleted the row but left `currentSessionId` pinned to the deleted id, so the chat tried to hydrate it and landed on "Session could not be loaded" instead of the new-session page.

This change makes `session-ui-store.deleteSession`/`deleteSessions` open a new-session draft when the visible session was among the successfully deleted ids (checked at commit time, so a session selected mid-RPC is not stolen). The Pi cluster may still hold a sibling selection for background continuity; the open draft wins the visible route via the existing draft guard, and the URL clears to `/`. Single-delete in `SessionDialogs` now goes through the UI store instead of bypassing it via `session-actions`, so all delete entry points share the navigation.

## Non-goals

- Archive/restore behavior is unchanged (archiving the current session still leaves it visible; only hard delete navigates).
- `PiSessionStore.remove()` sibling reselection is unchanged; the draft overlays it for the visible route.
- No retention-cleanup changes (auto-cleanup already excludes the current session).

## Affected surfaces

- Packages: `packages/ui` only (`sync/session-ui-store.ts`, `components/session/SessionDialogs.tsx`, new test).
- Runtimes: shared UI behavior, identical on web, desktop, hosted-mobile, and Capacitor mobile — `openNewSessionDraft` is runtime-agnostic, no runtime-specific branching added.
- User-visible: deleting the open session now lands on the new-session draft (composer-first surface) instead of a load error.
- Persisted/external contracts: none changed. Opening the draft via the default (non-automatic) path clears the persisted last-session pointer so a reload does not try to restore the deleted id.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root AGENTS.md + `pichamber-change-discipline` | Source change with cross-surface observable behavior | Smallest complete fix at the owning layer (UI selection/draft owns navigation; Pi store keeps domain mutation); no new deps; focused tests + package type-check/lint |
| `sync-state-invariants` | Session delete touches sync selection, hydration, and draft lifecycle | Re-verifies `currentSessionId` at commit time (no redirect of a session selected during the RPC); failure (throw / missing from `deletedIds`) never navigates; follows draft-wins-route contract in `sync/DOCUMENTATION.md` |
| `ui-api-decoupling` | Shared UI data access / Pi API boundary | Pi calls stay in `piClient`/`PiSessionStore.remove`; navigation lives in `session-ui-store`; `SessionDialogs` now consumes the UI store instead of bypassing it |
| `sync/DOCUMENTATION.md` (Archive, restore, and delete contract; draft intent) | Governs delete + draft navigation | Pi remove semantics untouched; open draft is the blank-chat intent that outranks resident Pi selection and stale URLs per docs |

## Validation

| Check | Result |
|---|---|
| New `src/sync/session-ui-delete-navigation.test.ts` (6 tests) | 6 pass |
| Existing `src/sync/session-ui-store.test.ts` | 23 pass |
| Full UI suite (`bun run test:ui`) | 2257 pass, 0 fail |
| `packages/ui` type-check (`bun run type-check`) | pass |
| `packages/ui` lint | pass |
| `bun run dead-code` | non-blocking; inspected, no new dead exports from this change |
| `bun run test` (all suites) | web fails with 3 pre-existing `sdk-upgrade.test.js` newline-delimiter failures — reproduced on `main` without this change, unrelated |

## Visual evidence

Navigation-only change with no static visual delta: after deleting the open session the app renders the existing new-session draft surface (same component as the New Chat button) instead of the "Session could not be loaded" error. No screenshots captured in this headless environment; covered by the unit tests above asserting `currentSessionId` → null + draft open.

## Risks and failure behavior

- Delete RPC failure: no navigation (single-delete rethrows, bulk checks `deletedIds`), user stays on the current session and existing error toasts apply.
- Mid-delete session switch: commit-time check prevents stealing the newly selected session.
- Bulk delete including current + others: navigates once to a single draft; deleting only background sessions leaves the current session untouched.
- Reload after delete: persisted last-session pointer is cleared by the user-initiated draft open, so cold launch does not restore the deleted id.
- Security/perf: no new data handling, credentials, or hot-path changes; one synchronous store update after the RPC resolves.