### PR TITLE
fix(web): restore @ file tagging via /api/fs/find

### DIFF
--- a/packages/web/server/lib/fs/DOCUMENTATION.md
+++ b/packages/web/server/lib/fs/DOCUMENTATION.md
@@ -5,7 +5,7 @@ Own filesystem API behavior for the web server runtime, including workspace-boun
 
 ## Entrypoints and structure
 - `packages/web/server/lib/fs/routes.js`: route registration and runtime-owned state for `/api/fs/*` endpoints.
-- `packages/web/server/lib/fs/search.js`: fuzzy filesystem search runtime used by non-FS routes (for example project icon discovery).
+- `packages/web/server/lib/fs/search.js`: bounded-concurrency fuzzy filesystem search runtime used by `GET /api/fs/find`.
 
 ## Public exports
 - `registerFsRoutes(app, dependencies)` from `routes.js`
@@ -23,11 +23,14 @@ Own filesystem API behavior for the web server runtime, including workspace-boun
     - `POST /api/fs/exec`
     - `GET /api/fs/exec/:jobId`
     - `GET /api/fs/list`
+    - `GET /api/fs/find`
   - Owns exec job queue state (`execJobs`) and lifecycle/TTL pruning.
   - Enforces workspace boundary checks with active project + worktree fallback support. An explicit `directory` query is authoritative over a stale runtime directory header, which lets user-confirmed directory-browser operations and project-local optional configuration probes scope themselves to the selected directory. `optional=true` converts only a missing file to an empty success; it never bypasses workspace policy.
-- `createFsSearchRuntime({ fsPromises, path, spawn, resolveGitBinaryForSpawn })` from `search.js`
+- `createFsSearchRuntime({ fsPromises, path, spawn, resolveGitBinaryForSpawn, gitCheckIgnoreTimeoutMs })` from `search.js`
   - Returns `{ searchFilesystemFiles(rootPath, options) }`.
-  - Supports fuzzy matching, hidden-file handling, and optional `git check-ignore` filtering.
+  - Supports fuzzy file and directory matching, hidden-file handling, fixed build-output exclusions, and optional `git check-ignore` filtering.
+  - Git-ignore checks use bounded directory concurrency and a positive configurable timeout (`PICHAMBER_GIT_CHECK_IGNORE_TIMEOUT_MS`, default 2500 ms). Concurrent searches share identical in-flight checks. A failed or timed-out check fails the search instead of returning files that may be ignored.
+  - Search reads through canonical paths for boundary enforcement, but result paths stay in the caller's requested path space so symlinked workspaces remain navigable.
 
 ## Composition contract with `index.js`
 - `index.js` provides composition-time dependencies only (platform primitives + callbacks such as `resolveProjectDirectory`, `normalizeDirectoryPath`, and `buildAugmentedPath`).

--- a/packages/web/server/lib/fs/routes.js
+++ b/packages/web/server/lib/fs/routes.js
@@ -433,6 +433,13 @@ export const registerFsRoutes = (app, dependencies) => {
   const commandTimeoutMs = createCommandTimeoutMs();
   const gitReadCacheTtlMs = createGitReadCacheTtlMs();
   const gitCheckIgnoreTimeoutMs = createGitCheckIgnoreTimeoutMs();
+  const fsSearchRuntime = createFsSearchRuntime({
+    fsPromises,
+    path,
+    spawn,
+    resolveGitBinaryForSpawn,
+    gitCheckIgnoreTimeoutMs,
+  });
   const gitReadCache = new Map();
   const inFlightGitReadCache = new Map();
 
@@ -1475,46 +1482,64 @@ export const registerFsRoutes = (app, dependencies) => {
     if (!rawPath.trim()) return res.status(400).json({ error: 'Directory path is required' });
 
     try {
-      const { canonicalPath } = await resolveWorkspacePath(rawPath, { scope: 'read' });
+      const resolved = await resolveWorkspacePathFromContext({
+        req,
+        targetPath: rawPath,
+        resolveProjectDirectory,
+        path,
+        os,
+        normalizeDirectoryPath,
+        pichamberUserConfigRoot,
+      });
+      if (!resolved.ok) {
+        return res.status(400).json({ error: resolved.error });
+      }
+
+      const [canonicalPath, canonicalBase] = await Promise.all([
+        realpathCache.resolve(resolved.resolved),
+        realpathCache.resolve(resolved.base).catch(() => path.resolve(resolved.base)),
+      ]);
+      if (!isPathWithinRoot(canonicalPath, canonicalBase, path, os)) {
+        return res.status(403).json({ error: 'Access to directory denied' });
+      }
+
+      const stats = await fsPromises.stat(canonicalPath);
+      if (!stats.isDirectory()) {
+        return res.status(400).json({ error: 'Specified path is not a directory', reason: 'not-directory' });
+      }
+
       const query = typeof req.query.query === 'string' ? req.query.query : '';
-      const limit = Number.isSafeInteger(Number(req.query.limit)) ? Math.min(Number(req.query.limit), 500) : 60;
+      const requestedLimit = Number(req.query.limit);
+      const limit = Number.isSafeInteger(requestedLimit) ? Math.max(1, Math.min(requestedLimit, 500)) : 60;
       const includeHidden = req.query.includeHidden === 'true';
       const respectGitignore = req.query.respectGitignore !== 'false';
       const type = req.query.type === 'directory' ? 'directory' : req.query.type === 'file' ? 'file' : undefined;
 
-      const fsSearchRuntime = createFsSearchRuntime({ fsPromises, path, spawn, resolveGitBinaryForSpawn });
       const rawHits = await fsSearchRuntime.searchFilesystemFiles(canonicalPath, {
         query,
         limit,
         includeHidden,
         respectGitignore,
+        type,
       });
 
-      const files = rawHits
-        .filter((hit) => {
-          if (type === 'file' && hit.isDir) return false;
-          if (type === 'directory' && !hit.isDir) return false;
-          return true;
-        })
-        .map((hit) => {
-          const hitPath = hit.path.replace(/\\/g, '/');
-          const rootNorm = canonicalPath.replace(/\\/g, '/');
-          const relativePath = hitPath.startsWith(rootNorm)
-            ? hitPath.slice(rootNorm.length).replace(/^\//, '')
-            : path.basename(hitPath);
-          const name = path.basename(hitPath);
-          return {
-            name,
-            path: hitPath,
-            relativePath,
-            ...(name.includes('.') ? { extension: name.split('.').pop().toLowerCase() } : {}),
-          };
-        });
+      const logicalRoot = path.resolve(resolved.resolved);
+      const files = rawHits.map((hit) => {
+        const relativePath = hit.relativePath.replace(/\\/g, '/');
+        const hitPath = path.join(logicalRoot, hit.relativePath).replace(/\\/g, '/');
+        const name = hit.name;
+        return {
+          name,
+          path: hitPath,
+          relativePath,
+          ...(hit.extension ? { extension: hit.extension } : {}),
+        };
+      });
 
       return res.json({ files });
     } catch (error) {
-      if (error && error.code === 'WORKSPACE_ACCESS_DENIED') {
-        return sendWorkspaceAccessDenied(res, 'Access to directory denied');
+      if (isOsPermissionError(error)) {
+        return sendOsPermissionDenied(res, 'Access to directory denied');
       }
       return res.status(500).json({ error: (error && error.message) || 'Failed to search files' });
     }

--- a/packages/web/server/lib/fs/routes.test.js
+++ b/packages/web/server/lib/fs/routes.test.js
@@ -220,6 +220,27 @@ const registerClone = ({ fsPromises, spawn }) => {
   return getRoute('POST', '/api/fs/clone');
 };
 
+const registerFind = ({ fsPromises, spawn, resolveProjectDirectory = async () => ({ directory: '/repo' }) }) => {
+  const { app, getRoute } = createRouteRegistry();
+  registerFsRoutes(app, {
+    os: { homedir: () => '/home/user' },
+    path: path.posix,
+    fsPromises: {
+      realpath: async (targetPath) => targetPath,
+      stat: async () => ({ isDirectory: () => true }),
+      ...fsPromises,
+    },
+    spawn,
+    crypto: { randomUUID: () => 'job-0' },
+    normalizeDirectoryPath: (p) => p,
+    resolveProjectDirectory,
+    buildAugmentedPath: () => '/usr/bin',
+    resolveGitBinaryForSpawn: () => 'git',
+    pichamberUserConfigRoot: '/home/user/.config',
+  });
+  return getRoute('GET', '/api/fs/find');
+};
+
 const registerReveal = ({ fsPromises, spawn, platform = 'linux' }) => {
   const { app, getRoute } = createRouteRegistry();
   registerFsRoutes(app, {
@@ -896,6 +917,210 @@ describe('fs list symlink path space (issue 2627)', () => {
       expect(res.body).toEqual({ error: 'Access to directory denied', reason: 'os-permission' });
     });
   }
+});
+
+describe('/api/fs/find', () => {
+  it('searches the active workspace instead of failing during path resolution', async () => {
+    const handler = registerFind({
+      fsPromises: {
+        readdir: vi.fn(async (directory) => directory === '/repo'
+          ? [{ name: 'src', isDirectory: () => true, isFile: () => false }]
+          : [{ name: 'app.ts', isDirectory: () => false, isFile: () => true }]),
+      },
+      spawn: createSpawn().spawn,
+    });
+    const res = createMockResponse();
+
+    await handler({
+      query: {
+        directory: '/repo',
+        query: 'app',
+        limit: '80',
+        includeHidden: 'true',
+        respectGitignore: 'true',
+        type: 'file',
+      },
+    }, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      files: [{
+        name: 'app.ts',
+        path: '/repo/src/app.ts',
+        relativePath: 'src/app.ts',
+        extension: 'ts',
+      }],
+    });
+  });
+
+  it('returns matching directories', async () => {
+    const handler = registerFind({
+      fsPromises: {
+        readdir: vi.fn(async (directory) => directory === '/repo'
+          ? [{ name: 'src', isDirectory: () => true, isFile: () => false }]
+          : []),
+      },
+      spawn: createSpawn().spawn,
+    });
+    const res = createMockResponse();
+
+    await handler({
+      query: {
+        directory: '/repo',
+        query: 'src',
+        type: 'directory',
+        respectGitignore: 'true',
+      },
+    }, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.files).toEqual([{
+      name: 'src',
+      path: '/repo/src',
+      relativePath: 'src',
+    }]);
+  });
+
+  it('does not return gitignored files', async () => {
+    const spawn = vi.fn((_command, _args, options) => {
+      const child = new EventEmitter();
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.kill = () => {};
+      queueMicrotask(() => {
+        if (options.cwd === '/repo') {
+          child.stdout.emit('data', Buffer.from('ignored.ts\n'));
+        }
+        child.emit('close', 0, null);
+      });
+      return child;
+    });
+    const handler = registerFind({
+      fsPromises: {
+        readdir: vi.fn(async () => [
+          { name: 'ignored.ts', isDirectory: () => false, isFile: () => true },
+          { name: 'visible.ts', isDirectory: () => false, isFile: () => true },
+        ]),
+      },
+      spawn,
+    });
+    const res = createMockResponse();
+
+    await handler({
+      query: {
+        directory: '/repo',
+        query: 'i',
+        type: 'file',
+        respectGitignore: 'true',
+      },
+    }, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.files.map((file) => file.name)).toEqual(['visible.ts']);
+    expect(spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps result paths in the requested symlink path space', async () => {
+    const handler = registerFind({
+      fsPromises: {
+        realpath: vi.fn(async (targetPath) => targetPath === '/repo-link' ? '/repo' : targetPath),
+        readdir: vi.fn(async () => [
+          { name: 'app.ts', isDirectory: () => false, isFile: () => true },
+        ]),
+      },
+      spawn: createSpawn().spawn,
+      resolveProjectDirectory: async () => ({ directory: '/repo-link' }),
+    });
+    const res = createMockResponse();
+
+    await handler({
+      query: {
+        directory: '/repo-link',
+        query: 'app',
+        type: 'file',
+        respectGitignore: 'true',
+      },
+    }, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.files[0]).toMatchObject({
+      path: '/repo-link/app.ts',
+      relativePath: 'app.ts',
+    });
+  });
+
+  it('shares gitignore checks across concurrent file and directory searches', async () => {
+    const deferred = createDeferredSpawn();
+    const handler = registerFind({
+      fsPromises: {
+        readdir: vi.fn(async () => [
+          { name: 'app.ts', isDirectory: () => false, isFile: () => true },
+        ]),
+      },
+      spawn: deferred.spawn,
+    });
+    const fileResponse = createMockResponse();
+    const directoryResponse = createMockResponse();
+
+    const fileSearch = handler({
+      query: { directory: '/repo', query: 'app', type: 'file', respectGitignore: 'true' },
+    }, fileResponse);
+    const directorySearch = handler({
+      query: { directory: '/repo', query: 'app', type: 'directory', respectGitignore: 'true' },
+    }, directoryResponse);
+
+    await vi.waitFor(() => expect(deferred.spawn).toHaveBeenCalledTimes(1));
+    deferred.closeNext();
+    await Promise.all([fileSearch, directorySearch]);
+
+    expect(fileResponse.statusCode).toBe(200);
+    expect(directoryResponse.statusCode).toBe(200);
+    expect(deferred.spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('bounds a stalled gitignore check instead of returning unfiltered files', async () => {
+    const previousTimeout = process.env.PICHAMBER_GIT_CHECK_IGNORE_TIMEOUT_MS;
+    process.env.PICHAMBER_GIT_CHECK_IGNORE_TIMEOUT_MS = '5';
+    let killed = false;
+    const spawn = vi.fn(() => {
+      const child = new EventEmitter();
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.kill = () => { killed = true; };
+      return child;
+    });
+
+    try {
+      const handler = registerFind({
+        fsPromises: {
+          readdir: vi.fn(async () => [
+            { name: 'possibly-ignored.ts', isDirectory: () => false, isFile: () => true },
+          ]),
+        },
+        spawn,
+      });
+      const res = createMockResponse();
+
+      await handler({
+        query: {
+          directory: '/repo',
+          query: 'ignored',
+          type: 'file',
+          respectGitignore: 'true',
+        },
+      }, res);
+
+      expect(killed).toBe(true);
+      expect(res.statusCode).toBe(500);
+      expect(res.body.files).toBeUndefined();
+    } finally {
+      if (previousTimeout === undefined) {
+        delete process.env.PICHAMBER_GIT_CHECK_IGNORE_TIMEOUT_MS;
+      } else {
+        process.env.PICHAMBER_GIT_CHECK_IGNORE_TIMEOUT_MS = previousTimeout;
+      }
+    }
+  });
 });
 
 describe('/api/fs/home', () => {

--- a/packages/web/server/lib/fs/search.js
+++ b/packages/web/server/lib/fs/search.js
@@ -95,9 +95,20 @@ const fuzzyMatchScoreNormalized = (normalizedQuery, candidate) => {
   return score;
 };
 
-export const createFsSearchRuntime = ({ fsPromises, path, spawn, resolveGitBinaryForSpawn }) => {
+export const createFsSearchRuntime = ({
+  fsPromises,
+  path,
+  spawn,
+  resolveGitBinaryForSpawn,
+  gitCheckIgnoreTimeoutMs = 2500,
+}) => {
+  const effectiveGitCheckIgnoreTimeoutMs = Number.isFinite(gitCheckIgnoreTimeoutMs) && gitCheckIgnoreTimeoutMs > 0
+    ? gitCheckIgnoreTimeoutMs
+    : 2500;
+  const inFlightGitignoreChecks = new Map();
+
   const searchFilesystemFiles = async (rootPath, options) => {
-    const { limit, query, includeHidden, respectGitignore } = options;
+    const { limit, query, includeHidden, respectGitignore, type } = options;
     const includeHiddenEntries = Boolean(includeHidden);
     const normalizedQuery = query.trim().toLowerCase();
     const matchAll = normalizedQuery.length === 0;
@@ -123,18 +134,47 @@ export const createFsSearchRuntime = ({ fsPromises, path, spawn, resolveGitBinar
               return { dir, dirents, ignoredPaths: new Set() };
             }
 
-            const result = await new Promise((resolve) => {
-              const child = spawn(resolveGitBinaryForSpawn(), ['check-ignore', '--', ...pathsToCheck], {
-                cwd: dir,
-                windowsHide: true,
-                stdio: ['ignore', 'pipe', 'pipe'],
-              });
+            const checkKey = `${dir}\0${pathsToCheck.join('\0')}`;
+            let check = inFlightGitignoreChecks.get(checkKey);
+            if (!check) {
+              check = new Promise((resolve, reject) => {
+                const child = spawn(resolveGitBinaryForSpawn(), ['check-ignore', '--', ...pathsToCheck], {
+                  cwd: dir,
+                  windowsHide: true,
+                  stdio: ['ignore', 'pipe', 'pipe'],
+                });
 
-              let stdout = '';
-              child.stdout.on('data', (data) => { stdout += data.toString(); });
-              child.on('close', () => resolve(stdout));
-              child.on('error', () => resolve(''));
-            });
+                let stdout = '';
+                let settled = false;
+                let timeout = null;
+                const finish = (callback) => {
+                  if (settled) return;
+                  settled = true;
+                  if (timeout) clearTimeout(timeout);
+                  callback();
+                };
+
+                timeout = setTimeout(() => {
+                  try {
+                    child.kill('SIGKILL');
+                  } catch {
+                  }
+                  finish(() => reject(new Error('Timed out while checking gitignore rules')));
+                }, effectiveGitCheckIgnoreTimeoutMs);
+
+                child.stdout?.on('data', (data) => { stdout += data.toString(); });
+                child.on('close', () => finish(() => resolve(stdout)));
+                child.on('error', (error) => finish(() => reject(error)));
+              });
+              inFlightGitignoreChecks.set(checkKey, check);
+              const clearCheck = () => {
+                if (inFlightGitignoreChecks.get(checkKey) === check) {
+                  inFlightGitignoreChecks.delete(checkKey);
+                }
+              };
+              check.then(clearCheck, clearCheck);
+            }
+            const result = await check;
 
             const ignoredNames = new Set(
               String(result)
@@ -144,8 +184,8 @@ export const createFsSearchRuntime = ({ fsPromises, path, spawn, resolveGitBinar
             );
 
             return { dir, dirents, ignoredPaths: ignoredNames };
-          } catch {
-            return { dir, dirents: await listDirectoryEntries(dir, fsPromises), ignoredPaths: new Set() };
+          } catch (error) {
+            throw new Error(`Failed to apply gitignore rules in ${dir}`, { cause: error });
           }
         })
       );
@@ -167,6 +207,21 @@ export const createFsSearchRuntime = ({ fsPromises, path, spawn, resolveGitBinar
             if (shouldSkipSearchDirectory(entryName, includeHiddenEntries)) {
               continue;
             }
+
+            if (type === 'directory') {
+              const relativePath = normalizeRelativeSearchPath(rootPath, entryPath, path);
+              const score = matchAll ? 0 : fuzzyMatchScoreNormalized(normalizedQuery, relativePath);
+              if (score !== null) {
+                candidates.push({
+                  name: entryName,
+                  path: entryPath,
+                  relativePath,
+                  extension: undefined,
+                  score,
+                });
+              }
+            }
+
             if (!visited.has(entryPath)) {
               visited.add(entryPath);
               queue.push(entryPath);
@@ -174,32 +229,22 @@ export const createFsSearchRuntime = ({ fsPromises, path, spawn, resolveGitBinar
             continue;
           }
 
-          if (!dirent.isFile()) {
+          if (!dirent.isFile() || type === 'directory') {
             continue;
           }
 
           const relativePath = normalizeRelativeSearchPath(rootPath, entryPath, path);
           const extension = entryName.includes('.') ? entryName.split('.').pop()?.toLowerCase() : undefined;
+          const score = matchAll ? 0 : fuzzyMatchScoreNormalized(normalizedQuery, relativePath);
 
-          if (matchAll) {
+          if (score !== null) {
             candidates.push({
               name: entryName,
               path: entryPath,
               relativePath,
               extension,
-              score: 0,
+              score,
             });
-          } else {
-            const score = fuzzyMatchScoreNormalized(normalizedQuery, relativePath);
-            if (score !== null) {
-              candidates.push({
-                name: entryName,
-                path: entryPath,
-                relativePath,
-                extension,
-                score,
-              });
-            }
           }
 
           if (candidates.length >= collectLimit) {


### PR DESCRIPTION
## Intent

Fixes `@` file tagging in the composer. Every `GET /api/fs/find` request returned 500 with `normalizeDirectoryPath is not a function`, so the picker showed no files or directories.

Result after this change:
- `type=file` returns matching workspace files.
- `type=directory` returns matching directories.
- Gitignored names stay hidden by default and a failed gitignore check fails closed instead of leaking names.

## Non-goals

- No change to `/api/fs/list` filtering behavior.
- No change to the fixed build-output exclusion set (`node_modules`, `.git`, `dist`, etc.).
- No client-side autocomplete or debounce changes.

## Affected surfaces

- `packages/web/server/lib/fs/routes.js`: `GET /api/fs/find` only. Same response shape `{ files: [{ name, path, relativePath, extension? }] }`.
- `packages/web/server/lib/fs/search.js`: search runtime used only by `/api/fs/find`.
- Runtimes: web server behavior. Desktop, hosted mobile, and Capacitor mobile use the same server route, so they inherit the fix with no client changes.
- No persisted data, CLI output, or public export changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md instruction order and docs discovery | FS module change requires owning docs and skill checks | Read `packages/web/server/lib/fs/DOCUMENTATION.md` and `packages/web/README.md`, traced route, runtime, caller, and tests before editing |
| pichamber-change-discipline | Source, contract, and docs change | Kept the API shape, preserved existing callers, updated owning docs, validated narrowest then broad |
| ui-api-decoupling implementation map | Server route behind shared UI `searchFiles` | Confirmed only `FileMentionAutocomplete`, command palette, and files view consume `/api/fs/find`; no transport or auth changes needed |
| performance-engineering | Per-keystroke search with per-directory git subprocess | Kept bounded concurrency, added timeout, shared identical in-flight gitignore checks, kept candidate caps |
| diagnosing-bugs feedback loop | Reported 500 with no existing route test | Reproduced with a minimal route harness before fixing, then pinned with regression tests |

## Validation

| Check | Result |
|---|---|
| `bun run --cwd packages/web test -- server/lib/fs/routes.test.js` | 42 passed, including 6 new `/api/fs/find` tests |
| `bun run --cwd packages/web test` | 77 files, 726 tests passed |
| `bun run --cwd packages/web type-check` | Passed |
| `bun run --cwd packages/web lint` | Passed |
| `bun run test` | Passed: web 726, UI 2257, Electron architecture 43 and updater 29 |
| `node --check` on `routes.js` and `search.js` | Passed |

Not verified: live LAN reproduction against the reporter's `192.168.0.203:10000` host. The route harness covers the same code path with mocked fs and spawn.

## Visual evidence

No rendered change. This is a server-only fix that restores data for the existing `@` autocomplete. The UI already handled the empty and populated states, so there is no new visual state to screenshot.

## Risks and failure behavior

- Outside-workspace directory returns 400, canonical escape returns 403, non-directory returns 400 with `not-directory`.
- OS permission failure returns 403 with `reason: os-permission`.
- Gitignore subprocess timeout (default 2500ms, floor enforced) or spawn error returns 500 fail-closed, so ignored files are never served unfiltered from find.
- Result paths stay in the requested workspace path space, so symlinked roots remain navigable.
- Rollback is safe: reverting restores the prior 500 behavior with no migration or stored state.
