### PR TITLE
fix(files): guard editor saves with revisions and explicit conflict recovery

### DIFF
--- a/packages/ui/src/apps/DOCUMENTATION.md
+++ b/packages/ui/src/apps/DOCUMENTATION.md
@@ -75,6 +75,18 @@
 - Mobile commit/sync behavior stays visually scoped to the mobile surface: desktop commit-and-push fireworks are not triggered by `chrome="mobile"`.
 - The Files consolidation is not a startup-performance claim. Opening the mobile Files tab currently loads the full `FilesView` module, including editor/preview dependencies. A later split should move editor-heavy implementation behind an on-demand boundary so browsing a directory does not pay that cost before a file is opened.
 
+## Standalone diagram saves
+
+`components/views/DiagramView.tsx` uses the same guarded-write contract and
+`FileSaveConflictDialog` as the Files view. A conflict preserves the editor
+buffer and offers explicit reload, overwrite, and comparison. Reload discards
+edits only after a successful read, including when the disk bytes match the
+original editor prop. Overwrite captures the latest buffer at the click, and
+neither save path resets edits made while the write is pending. File/runtime
+switches invalidate pending completions and reset action ownership; a failed
+initial read offers no editable, unguarded fallback. Failed conflict reloads
+leave the dirty editor intact.
+
 ## Runtime Git Ownership
 
 - UI feature code consumes the injected `RuntimeAPIs.git` contract directly. The old `lib/gitApi.ts` forwarding layer was removed because it duplicated the runtime-vs-HTTP decision for every method. React surfaces resolve Git through `useRuntimeAPIs()`; non-React callers that can run before a provider exists keep a narrow `gitApiHttp` fallback at the call site.

--- a/packages/ui/src/apps/DOCUMENTATION.md
+++ b/packages/ui/src/apps/DOCUMENTATION.md
@@ -90,7 +90,7 @@ leave the dirty editor intact.
 ## Runtime Git Ownership
 
 - UI feature code consumes the injected `RuntimeAPIs.git` contract directly. The old `lib/gitApi.ts` forwarding layer was removed because it duplicated the runtime-vs-HTTP decision for every method. React surfaces resolve Git through `useRuntimeAPIs()`; non-React callers that can run before a provider exists keep a narrow `gitApiHttp` fallback at the call site.
-- `git/gitStatusPredicates.ts` and `git/gitChangeDescriptors.ts` define the shared staged, working, and new-file classification and change descriptors used across `GitView`, `ChangeRow`, and `DiffView`; untracked `?` entries remain working changes rather than staged changes.
+- `git/gitStatusPredicates.ts` and `git/gitChangeDescriptors.ts` define the shared staged, working, and new-file classification and change descriptors used across `GitView`, `ChangeRow`, and `DiffView`; untracked `?` entries remain working changes rather than staged changes. Branch-only history requests use the same resolvable-base gate as branch comparison controls, so a conventional `main` fallback that is absent locally and remotely never reaches the Git log API.
 - Diff presentation is modularized under `components/views/diff/`: scope filtering (`ChangeScopeSelector`), file list selection (`FileList`), diff presentation (`InlineDiffViewer`, `InlineImageDiffViewer`), per-file staging/revert controls (`FileDiffActions`), and stacked entry orchestration (`MultiFileDiffEntry`) isolate diff rendering concerns from `DiffView`.
 - Optional runtime capabilities such as commit-file diff and credential discovery fall back only for that capability; they do not reintroduce a broad compatibility adapter. Types come from `lib/api/types.ts`.
 

--- a/packages/ui/src/components/views/DiagramView.test.tsx
+++ b/packages/ui/src/components/views/DiagramView.test.tsx
@@ -1,0 +1,866 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+// --- Mutable test controls (read through mock closures) ------------------
+
+let editorXml = '<base/>';
+let currentRuntimeKey = 'local';
+let runtimeListeners: Array<(detail?: unknown) => void> = [];
+let readImpl: (path: string) => Promise<{ content: string; revision?: string | null; exists?: boolean }> = async () => ({
+  content: '<base/>',
+  revision: 'rev-1',
+});
+let writeImpl: (
+  path: string,
+  content: string,
+  options?: { expectedRevision?: string | null; overwrite?: boolean },
+) => Promise<{ success: boolean; path: string; revision?: string | null }> = async (path) => ({
+  success: true,
+  path,
+  revision: 'rev-2',
+});
+type DialogProps = {
+  open: boolean;
+  conflict: {
+    path: string;
+    displayPath: string;
+    exists: boolean;
+    currentRevision: string | null;
+    currentContent: string | null;
+    dirtyContent: string;
+  } | null;
+  isResolving: boolean;
+  showCompare: boolean;
+  onToggleCompare: () => void;
+  onReload: () => void;
+  onOverwrite: () => void;
+  onClose: () => void;
+};
+let lastDialogProps: DialogProps | null = null;
+let lastEditorProps: { xml: string } | null = null;
+const toastErrors: string[] = [];
+const writes: Array<{ path: string; content: string; options?: unknown }> = [];
+
+mock.module('@/components/ui', () => ({
+  toast: {
+    error: (message: string) => { toastErrors.push(message); },
+    success: () => undefined,
+  },
+}));
+
+mock.module('@/components/icon/Icon', () => ({
+  Icon: () => null,
+}));
+
+mock.module('@/components/diagram/DiagramEditor', () => ({
+  DiagramEditor: React.forwardRef(({ xml }: { xml: string }, ref: React.Ref<{ getXml: () => string }>) => {
+    lastEditorProps = { xml };
+    const prevRef = React.useRef<string | null>(null);
+    const mountedRef = React.useRef(false);
+    if (!mountedRef.current) {
+      mountedRef.current = true;
+      prevRef.current = xml;
+      editorXml = xml;
+    } else if (prevRef.current !== xml) {
+      prevRef.current = xml;
+      editorXml = xml;
+    }
+    React.useImperativeHandle(ref, () => ({ getXml: () => editorXml }));
+    return null;
+  }),
+}));
+
+mock.module('@/hooks/useRuntimeAPIs', () => ({
+  useRuntimeAPIs: () => ({
+    files: {
+      readFile: (path: string) => readImpl(path),
+      writeFile: (path: string, content: string, options?: { expectedRevision?: string | null; overwrite?: boolean }) => {
+        writes.push({ path, content, options });
+        return writeImpl(path, content, options);
+      },
+    },
+    runtime: { platform: 'web', isDesktop: false },
+  }),
+}));
+
+mock.module('@/lib/runtime-switch', () => ({
+  getRuntimeKey: () => currentRuntimeKey,
+  subscribeRuntimeEndpointChanged: (callback: (detail?: unknown) => void) => {
+    runtimeListeners.push(callback);
+    return () => {
+      runtimeListeners = runtimeListeners.filter((listener) => listener !== callback);
+    };
+  },
+}));
+
+mock.module('@/components/views/files/FileSaveConflictDialog', () => ({
+  FileSaveConflictDialog: (props: DialogProps) => {
+    lastDialogProps = props;
+    if (!props.open || !props.conflict) return null;
+    return React.createElement(
+      'div',
+      { 'data-testid': 'conflict-dialog' },
+      React.createElement('div', { 'data-testid': 'conflict-dirty' }, props.conflict.dirtyContent),
+      React.createElement('div', { 'data-testid': 'conflict-current' }, props.conflict.currentContent ?? ''),
+      props.showCompare
+        ? React.createElement('div', { 'data-testid': 'conflict-compare' }, 'compare-on')
+        : null,
+      React.createElement('button', { 'aria-label': 'Compare versions', onClick: props.onToggleCompare }, 'Compare'),
+      React.createElement('button', { 'aria-label': 'Reload current version', onClick: props.onReload }, 'Reload'),
+      React.createElement('button', { 'aria-label': 'Overwrite with my edits', onClick: props.onOverwrite }, 'Overwrite'),
+      React.createElement('button', { 'aria-label': 'Close conflict dialog', onClick: props.onClose }, 'Close'),
+    );
+  },
+}));
+
+const { DiagramView } = await import('./DiagramView');
+const { useUIStore } = await import('@/stores/useUIStore');
+
+// --- Minimal DOM stub (proven pattern from number-input.test.tsx) ---------
+
+interface FakeNode {
+  nodeType: number;
+  nodeName: string;
+  tagName: string;
+  ownerDocument: FakeDocument;
+  parentNode: FakeNode | null;
+  childNodes: FakeNode[];
+  style: Record<string, unknown>;
+  classList: { add(...c: string[]): void; remove(...c: string[]): void; contains(c: string): boolean };
+  [key: string]: unknown;
+}
+
+interface FakeDocument extends FakeNode {
+  defaultView: FakeWindow;
+  body: FakeNode;
+  documentElement: FakeNode;
+  createElement(tag: string): FakeNode;
+  createElementNS(_: string, tag: string): FakeNode;
+  createTextNode(text: string): FakeNode;
+  activeElement: FakeNode | null;
+}
+
+interface FakeWindow {
+  document: FakeDocument;
+  navigator: { userAgent: string; platform: string; maxTouchPoints: number };
+  matchMedia(query: string): { matches: boolean; addEventListener(): void; removeEventListener(): void };
+  addEventListener(): void;
+  removeEventListener(): void;
+  dispatchEvent(): boolean;
+}
+
+function makeNode(tag: string, owner: FakeDocument): FakeNode {
+  const node = {
+    nodeType: 1,
+    nodeName: tag.toUpperCase(),
+    tagName: tag.toUpperCase(),
+    ownerDocument: owner,
+    parentNode: null,
+    childNodes: [] as FakeNode[],
+    style: { setProperty() {}, getPropertyValue() { return ''; } },
+    classList: {
+      add() {},
+      remove() {},
+      contains() { return false; },
+    },
+    setAttribute() {},
+    removeAttribute() {},
+    hasAttribute() { return false; },
+    getAttribute() { return null; },
+    addEventListener() {},
+    removeEventListener() {},
+    appendChild(c: FakeNode) { (this as FakeNode).childNodes.push(c); c.parentNode = this as unknown as FakeNode; return c; },
+    insertBefore(c: FakeNode, ref: FakeNode) {
+      const list = (this as FakeNode).childNodes;
+      const i = list.indexOf(ref);
+      if (i < 0) list.push(c); else list.splice(i, 0, c);
+      c.parentNode = this as unknown as FakeNode;
+      return c;
+    },
+    removeChild(c: FakeNode) {
+      const list = (this as FakeNode).childNodes;
+      const i = list.indexOf(c);
+      if (i >= 0) list.splice(i, 1);
+      c.parentNode = null;
+      return c;
+    },
+    contains() { return false; },
+    focus() {},
+    blur() {},
+    click() {},
+    textContent: '',
+    innerHTML: '',
+  } as unknown as FakeNode;
+  return node;
+}
+
+function installDomStub(): { restore: () => void; container: FakeNode } {
+  const document = {
+    nodeType: 9,
+    nodeName: '#document',
+    parentNode: null,
+    childNodes: [] as FakeNode[],
+    style: {},
+    classList: { add() {}, remove() {}, contains() { return false; } },
+    setAttribute() {},
+    getAttribute() { return null; },
+    addEventListener() {},
+    removeEventListener() {},
+    getElementById() { return null; },
+    createTextNode(text: string) {
+      return { nodeType: 3, nodeName: '#text', textContent: text, parentNode: null } as unknown as FakeNode;
+    },
+    createElement(tag: string) { return makeNode(tag, document as unknown as FakeDocument); },
+    createElementNS(_: string, tag: string) { return makeNode(tag, document as unknown as FakeDocument); },
+    activeElement: null,
+  } as unknown as FakeDocument;
+  document.defaultView = {
+    document,
+    navigator: { userAgent: 'test', platform: 'test', maxTouchPoints: 0 },
+    matchMedia() { return { matches: false, addEventListener() {}, removeEventListener() {} }; },
+    addEventListener() {},
+    removeEventListener() {},
+    dispatchEvent() { return true; },
+    Element: class {},
+    HTMLElement: class {},
+    HTMLIFrameElement: class {},
+    HTMLInputElement: class {},
+    HTMLTextAreaElement: class {},
+  } as unknown as FakeWindow;
+  document.body = makeNode('body', document);
+  document.documentElement = makeNode('html', document);
+  (document as unknown as Record<string, unknown>)['HTMLIFrameElement'] = (
+    document.defaultView as unknown as Record<string, unknown>
+  )['HTMLIFrameElement'];
+
+  const g = globalThis as unknown as Record<string, unknown>;
+  const previous = {
+    document: g['document'],
+    window: g['window'],
+    navigator: g['navigator'],
+    Element: g['Element'],
+    HTMLElement: g['HTMLElement'],
+    HTMLIFrameElement: g['HTMLIFrameElement'],
+    IS_REACT_ACT_ENVIRONMENT: g['IS_REACT_ACT_ENVIRONMENT'],
+  };
+  g['IS_REACT_ACT_ENVIRONMENT'] = true;
+  g['document'] = document;
+  g['window'] = document.defaultView;
+  g['navigator'] = (document.defaultView as unknown as FakeWindow).navigator;
+  g['Element'] = (document.defaultView as unknown as Record<string, unknown>)['Element'];
+  g['HTMLElement'] = (document.defaultView as unknown as Record<string, unknown>)['HTMLElement'];
+  g['HTMLIFrameElement'] = (document.defaultView as unknown as Record<string, unknown>)['HTMLIFrameElement'];
+  const container = document.createElement('div');
+  return {
+    container,
+    restore() {
+      g['document'] = previous['document'];
+      g['window'] = previous['window'];
+      g['navigator'] = previous['navigator'];
+      g['Element'] = previous['Element'];
+      g['HTMLElement'] = previous['HTMLElement'];
+      g['HTMLIFrameElement'] = previous['HTMLIFrameElement'];
+      g['IS_REACT_ACT_ENVIRONMENT'] = previous['IS_REACT_ACT_ENVIRONMENT'];
+    },
+  };
+}
+
+const roots: Root[] = [];
+const restores: Array<() => void> = [];
+
+const flush = async () => {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await Promise.resolve();
+  });
+};
+
+const findByProp = (container: FakeNode, prop: string, value: string): FakeNode | null => {
+  const visit = (node: FakeNode): FakeNode | null => {
+    const key = Object.keys(node).find((k) => k.startsWith('__reactProps'));
+    if (key) {
+      const props = (node as unknown as Record<string, Record<string, unknown>>)[key];
+      if (props?.[prop] === value) return node;
+    }
+    for (const child of node.childNodes) {
+      const found = visit(child);
+      if (found) return found;
+    }
+    return null;
+  };
+  return visit(container);
+};
+
+const clickProp = (container: FakeNode, prop: string, value: string) => {
+  const node = findByProp(container, prop, value);
+  if (!node) throw new Error(`button ${prop}="${value}" not found`);
+  const key = Object.keys(node).find((k) => k.startsWith('__reactProps'))!;
+  const props = (node as unknown as Record<string, { onClick: (e: unknown) => void }>)[key]!;
+  act(() => {
+    props.onClick({ preventDefault() {}, stopPropagation() {} });
+  });
+};
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+};
+
+const conflictError = (overrides: { currentRevision?: string | null; exists?: boolean; path?: string } = {}) => Object.assign(
+  new Error('File has changed on disk'),
+  {
+    name: 'FileRevisionConflictError',
+    reason: 'file-revision-conflict',
+    currentRevision: overrides.currentRevision ?? 'rev-9',
+    exists: overrides.exists ?? true,
+    filePath: overrides.path ?? '/repo/a.drawio',
+  },
+);
+
+const resetState = () => {
+  editorXml = '<base/>';
+  currentRuntimeKey = 'local';
+  runtimeListeners = [];
+  writes.length = 0;
+  toastErrors.length = 0;
+  lastDialogProps = null;
+  lastEditorProps = null;
+  readImpl = async () => ({ content: '<base/>', revision: 'rev-1' });
+  writeImpl = async (path) => ({ success: true, path, revision: 'rev-2' });
+  useUIStore.getState().setPendingDiagramFile(null);
+  useUIStore.setState({ pendingDiagramFile: null });
+};
+
+afterEach(async () => {
+  for (const root of roots.splice(0)) {
+    await act(async () => root.unmount());
+  }
+  restores.splice(0).forEach((restore) => restore());
+  resetState();
+});
+
+const renderDiagram = async (path: string) => {
+  const stub = installDomStub();
+  restores.push(stub.restore);
+  useUIStore.getState().setPendingDiagramFile(path);
+  const root = createRoot(stub.container as unknown as Element);
+  roots.push(root);
+  await act(async () => {
+    root.render(React.createElement(DiagramView));
+  });
+  await flush();
+  await flush();
+  return stub.container;
+};
+
+describe('DiagramView stale-save conflict recovery', () => {
+  test('409 keeps dirty XML and opens reload/overwrite/compare', async () => {
+    readImpl = async () => ({ content: '<base/>', revision: 'rev-1' });
+    writeImpl = async () => { throw conflictError(); };
+    const container = await renderDiagram('/repo/a.drawio');
+    expect(lastEditorProps?.xml).toBe('<base/>');
+
+    editorXml = '<dirty/>';
+    // The conflict fetch observes the newer disk bytes.
+    readImpl = async () => ({ content: '<disk/>', revision: 'rev-9' });
+    clickProp(container, 'title', 'Save diagram');
+    await flush();
+    await flush();
+
+    expect(lastDialogProps?.open).toBe(true);
+    expect(lastDialogProps?.conflict?.dirtyContent).toBe('<dirty/>');
+    expect(lastDialogProps?.conflict?.currentContent).toBe('<disk/>');
+    expect(lastDialogProps?.conflict?.exists).toBe(true);
+    // Dirty editor content is preserved: the loaded base is untouched.
+    expect(lastEditorProps?.xml).toBe('<base/>');
+    expect(toastErrors).toEqual([]);
+
+    // Compare preview is available through the shared dialog workflow.
+    clickProp(container, 'aria-label', 'Compare versions');
+    await flush();
+    expect(lastDialogProps?.showCompare).toBe(true);
+  });
+
+  test('overwrite forces the preserved dirty XML and clears the dialog', async () => {
+    readImpl = async () => ({ content: '<base/>', revision: 'rev-1' });
+    writeImpl = async () => { throw conflictError(); };
+    const container = await renderDiagram('/repo/a.drawio');
+    editorXml = '<dirty/>';
+    readImpl = async () => ({ content: '<disk/>', revision: 'rev-9' });
+    clickProp(container, 'title', 'Save diagram');
+    await flush();
+    await flush();
+    expect(lastDialogProps?.open).toBe(true);
+
+    writeImpl = async (path) => ({ success: true, path, revision: 'rev-10' });
+    clickProp(container, 'aria-label', 'Overwrite with my edits');
+    await flush();
+    await flush();
+
+    const overwrite = writes[writes.length - 1];
+    expect(overwrite?.content).toBe('<dirty/>');
+    expect(overwrite?.options).toEqual({ expectedRevision: 'rev-1', overwrite: true });
+    expect(lastDialogProps?.open).toBe(false);
+    expect(lastEditorProps?.xml).toBe('<dirty/>');
+
+    // The new revision backs the next guarded save.
+    editorXml = '<dirty-2/>';
+    clickProp(container, 'title', 'Save diagram');
+    await flush();
+    await flush();
+    expect(writes[writes.length - 1]?.options).toEqual({ expectedRevision: 'rev-10' });
+  });
+
+  test('reload discards dirty only after a successful read', async () => {
+    readImpl = async () => ({ content: '<base/>', revision: 'rev-1' });
+    writeImpl = async () => { throw conflictError(); };
+    const container = await renderDiagram('/repo/a.drawio');
+    editorXml = '<dirty/>';
+    readImpl = async () => ({ content: '<disk/>', revision: 'rev-9' });
+    clickProp(container, 'title', 'Save diagram');
+    await flush();
+    await flush();
+    expect(lastDialogProps?.open).toBe(true);
+
+    readImpl = async () => ({ content: '<reloaded/>', revision: 'rev-11' });
+    clickProp(container, 'aria-label', 'Reload current version');
+    await flush();
+    await flush();
+    expect(lastEditorProps?.xml).toBe('<reloaded/>');
+    expect(editorXml).toBe('<reloaded/>');
+    expect(lastDialogProps?.open).toBe(false);
+  });
+
+  test('reload resets dirty buffer when disk matches the loaded base', async () => {
+    readImpl = async () => ({ content: '<base/>', revision: 'rev-1' });
+    writeImpl = async () => { throw conflictError(); };
+    const container = await renderDiagram('/repo/a.drawio');
+    expect(lastEditorProps?.xml).toBe('<base/>');
+    editorXml = '<dirty/>';
+    readImpl = async () => ({ content: '<base/>', revision: 'rev-1' });
+    clickProp(container, 'title', 'Save diagram');
+    await flush();
+    await flush();
+    expect(lastDialogProps?.open).toBe(true);
+    expect(lastEditorProps?.xml).toBe('<base/>');
+
+    readImpl = async () => ({ content: '<base/>', revision: 'rev-1' });
+    clickProp(container, 'aria-label', 'Reload current version');
+    await flush();
+    await flush();
+    expect(lastDialogProps?.open).toBe(false);
+    expect(lastEditorProps?.xml).toBe('<base/>');
+    expect(editorXml).toBe('<base/>');
+
+    writeImpl = async (path) => ({ success: true, path, revision: 'rev-2' });
+    editorXml = '<dirty-2/>';
+    clickProp(container, 'title', 'Save diagram');
+    await flush();
+    await flush();
+    expect(writes[writes.length - 1]?.options).toEqual({ expectedRevision: 'rev-1' });
+  });
+
+  test('failed reload keeps dirty XML and the open dialog', async () => {
+    readImpl = async () => ({ content: '<base/>', revision: 'rev-1' });
+    writeImpl = async () => { throw conflictError(); };
+    const container = await renderDiagram('/repo/a.drawio');
+    editorXml = '<dirty/>';
+    readImpl = async () => ({ content: '<disk/>', revision: 'rev-9' });
+    clickProp(container, 'title', 'Save diagram');
+    await flush();
+    await flush();
+    expect(lastDialogProps?.open).toBe(true);
+
+    readImpl = async () => { throw new Error('Disk unreachable'); };
+    clickProp(container, 'aria-label', 'Reload current version');
+    await flush();
+    await flush();
+    expect(lastDialogProps?.open).toBe(true);
+    expect(lastDialogProps?.conflict?.dirtyContent).toBe('<dirty/>');
+    expect(lastEditorProps?.xml).toBe('<base/>');
+    expect(editorXml).toBe('<dirty/>');
+    expect(toastErrors.length).toBeGreaterThan(0);
+  });
+
+  test('stale save completion after a file switch never clobbers the new file', async () => {
+    readImpl = async (path: string) => (
+      path === '/repo/b.drawio'
+        ? { content: '<base-b/>', revision: 'rev-b1' }
+        : { content: '<base-a/>', revision: 'rev-a1' }
+    );
+    const gate = deferred<void>();
+    writeImpl = async (path: string) => {
+      await gate.promise;
+      return { success: true, path, revision: 'rev-a2' };
+    };
+    const container = await renderDiagram('/repo/a.drawio');
+    expect(lastEditorProps?.xml).toBe('<base-a/>');
+
+    editorXml = '<dirty-a/>';
+    clickProp(container, 'title', 'Save diagram');
+    // Switch files while the A write is still in flight.
+    await act(async () => {
+      useUIStore.getState().setPendingDiagramFile('/repo/b.drawio');
+      await Promise.resolve();
+    });
+    await flush();
+    await flush();
+    expect(lastEditorProps?.xml).toBe('<base-b/>');
+
+    await act(async () => {
+      gate.resolve();
+      await gate.promise;
+    });
+    await flush();
+    await flush();
+
+    expect(lastEditorProps?.xml).toBe('<base-b/>');
+    expect(lastDialogProps?.open).toBe(false);
+  });
+
+  test('missing read for a new path offers no editor or Save and writes nothing', async () => {
+    readImpl = async (path: string) => (
+      path === '/repo/b.drawio'
+        ? undefined as unknown as { content: string; revision?: string | null }
+        : { content: '<base-a/>', revision: 'rev-a1' }
+    );
+    const container = await renderDiagram('/repo/a.drawio');
+    expect(lastEditorProps?.xml).toBe('<base-a/>');
+
+    await act(async () => {
+      useUIStore.getState().setPendingDiagramFile('/repo/b.drawio');
+      await Promise.resolve();
+    });
+    await flush();
+    await flush();
+    // Failure is explicit and offers no editing surface with an unknown revision.
+    expect(toastErrors.length).toBeGreaterThan(0);
+    expect(findByProp(container, 'title', 'Save diagram')).toBeNull();
+    expect(writes.length).toBe(0);
+    expect(lastDialogProps?.open).toBe(false);
+
+    // Old bytes/revision are not exposed: reopening the target captures a
+    // fresh authoritative revision instead of reusing rev-a1 or saving unguarded.
+    readImpl = async (path: string) => (
+      path === '/repo/b.drawio'
+        ? { content: '<base-b/>', revision: 'rev-b1' }
+        : { content: '<base-a/>', revision: 'rev-a1' }
+    );
+    await act(async () => {
+      useUIStore.getState().setPendingDiagramFile('/repo/b.drawio');
+      await Promise.resolve();
+    });
+    await flush();
+    await flush();
+    expect(findByProp(container, 'title', 'Save diagram')).not.toBeNull();
+    expect(lastEditorProps?.xml).toBe('<base-b/>');
+    editorXml = '<dirty-b/>';
+    clickProp(container, 'title', 'Save diagram');
+    await flush();
+    await flush();
+    const last = writes[writes.length - 1];
+    expect(last?.path).toBe('/repo/b.drawio');
+    expect(last?.content).toBe('<dirty-b/>');
+    expect(last?.options).toEqual({ expectedRevision: 'rev-b1' });
+  });
+
+  test('throw on new-scope load offers no editor or Save and writes nothing', async () => {
+    readImpl = async (path: string) => {
+      if (path === '/repo/b.drawio') throw new Error('Disk unreachable');
+      return { content: '<base-a/>', revision: 'rev-a1' };
+    };
+    const container = await renderDiagram('/repo/a.drawio');
+    expect(lastEditorProps?.xml).toBe('<base-a/>');
+
+    await act(async () => {
+      useUIStore.getState().setPendingDiagramFile('/repo/b.drawio');
+      await Promise.resolve();
+    });
+    await flush();
+    await flush();
+    expect(toastErrors.length).toBeGreaterThan(0);
+    expect(findByProp(container, 'title', 'Save diagram')).toBeNull();
+    expect(writes.length).toBe(0);
+    expect(lastDialogProps?.open).toBe(false);
+
+    readImpl = async (path: string) => (
+      path === '/repo/b.drawio'
+        ? { content: '<base-b/>', revision: 'rev-b1' }
+        : { content: '<base-a/>', revision: 'rev-a1' }
+    );
+    await act(async () => {
+      useUIStore.getState().setPendingDiagramFile('/repo/b.drawio');
+      await Promise.resolve();
+    });
+    await flush();
+    await flush();
+    expect(findByProp(container, 'title', 'Save diagram')).not.toBeNull();
+    expect(lastEditorProps?.xml).toBe('<base-b/>');
+    editorXml = '<dirty-b/>';
+    clickProp(container, 'title', 'Save diagram');
+    await flush();
+    await flush();
+    const last = writes[writes.length - 1];
+    expect(last?.path).toBe('/repo/b.drawio');
+    expect(last?.content).toBe('<dirty-b/>');
+    expect(last?.options).toEqual({ expectedRevision: 'rev-b1' });
+  });
+
+  test('stale conflict completion after a runtime switch never opens over the new runtime', async () => {
+    readImpl = async () => ({ content: '<base/>', revision: 'rev-1' });
+    const gate = deferred<void>();
+    writeImpl = async () => {
+      await gate.promise;
+      throw conflictError();
+    };
+    const container = await renderDiagram('/repo/a.drawio');
+    expect(lastEditorProps?.xml).toBe('<base/>');
+    editorXml = '<dirty/>';
+    readImpl = async () => {
+      await gate.promise;
+      return { content: '<disk/>', revision: 'rev-9' };
+    };
+    clickProp(container, 'title', 'Save diagram');
+    currentRuntimeKey = 'url:https://remote';
+    readImpl = async () => ({ content: '<remote/>', revision: 'rev-r1' });
+    await act(async () => {
+      for (const listener of [...runtimeListeners]) listener({});
+    });
+    await flush();
+    await act(async () => {
+      gate.resolve();
+      await gate.promise;
+    });
+    await flush();
+    await flush();
+
+    expect(lastDialogProps?.open).toBe(false);
+    expect(toastErrors).toEqual([]);
+    expect(lastEditorProps?.xml).toBe('<remote/>');
+    expect(editorXml).toBe('<remote/>');
+
+    writeImpl = async (path) => ({ success: true, path, revision: 'rev-r2' });
+    editorXml = '<dirty-remote/>';
+    clickProp(container, 'title', 'Save diagram');
+    await flush();
+    await flush();
+    const last = writes[writes.length - 1];
+    expect(last?.path).toBe('/repo/a.drawio');
+    expect(last?.content).toBe('<dirty-remote/>');
+    expect(last?.options).toEqual({ expectedRevision: 'rev-r1' });
+  });
+
+  test('interleaved edit during save is preserved', async () => {
+    readImpl = async () => ({ content: '<base/>', revision: 'rev-1' });
+    const gate = deferred<void>();
+    writeImpl = async (path: string) => {
+      await gate.promise;
+      return { success: true, path, revision: 'rev-2' };
+    };
+    const container = await renderDiagram('/repo/a.drawio');
+    expect(lastEditorProps?.xml).toBe('<base/>');
+
+    editorXml = '<dirty/>';
+    clickProp(container, 'title', 'Save diagram');
+    // Edit typed while the '<dirty/>' write is in flight.
+    editorXml = '<dirty+more/>';
+    await act(async () => {
+      gate.resolve();
+      await gate.promise;
+    });
+    await flush();
+    await flush();
+
+    // The stale submitted bytes must not reset the editor and discard edits.
+    expect(lastEditorProps?.xml).toBe('<base/>');
+    expect(lastDialogProps?.open).toBe(false);
+    expect(toastErrors).toEqual([]);
+
+    // The new revision still backs the next guarded save of the latest edits.
+    writeImpl = async (path) => ({ success: true, path, revision: 'rev-3' });
+    clickProp(container, 'title', 'Save diagram');
+    await flush();
+    await flush();
+    expect(writes[writes.length - 1]?.content).toBe('<dirty+more/>');
+    expect(writes[writes.length - 1]?.options).toEqual({ expectedRevision: 'rev-2' });
+  });
+
+  test('overwrite captures latest editor XML, not the stale dialog snapshot', async () => {
+    readImpl = async () => ({ content: '<base/>', revision: 'rev-1' });
+    writeImpl = async () => { throw conflictError(); };
+    const container = await renderDiagram('/repo/a.drawio');
+    editorXml = '<dirty/>';
+    readImpl = async () => ({ content: '<disk/>', revision: 'rev-9' });
+    clickProp(container, 'title', 'Save diagram');
+    await flush();
+    await flush();
+    expect(lastDialogProps?.open).toBe(true);
+    expect(lastDialogProps?.conflict?.dirtyContent).toBe('<dirty/>');
+
+    // Edits typed after the conflict must win over the dialog snapshot.
+    editorXml = '<dirty+latest/>';
+    writeImpl = async (path) => ({ success: true, path, revision: 'rev-10' });
+    clickProp(container, 'aria-label', 'Overwrite with my edits');
+    await flush();
+    await flush();
+
+    expect(writes[writes.length - 1]?.content).toBe('<dirty+latest/>');
+    expect(writes[writes.length - 1]?.options).toEqual({ expectedRevision: 'rev-1', overwrite: true });
+    expect(lastDialogProps?.open).toBe(false);
+    expect(lastEditorProps?.xml).toBe('<dirty+latest/>');
+  });
+
+  test('interleaved edit during overwrite is preserved', async () => {
+    readImpl = async () => ({ content: '<base/>', revision: 'rev-1' });
+    writeImpl = async () => { throw conflictError(); };
+    const container = await renderDiagram('/repo/a.drawio');
+    editorXml = '<dirty/>';
+    readImpl = async () => ({ content: '<disk/>', revision: 'rev-9' });
+    clickProp(container, 'title', 'Save diagram');
+    await flush();
+    await flush();
+    expect(lastDialogProps?.open).toBe(true);
+
+    const gate = deferred<void>();
+    writeImpl = async (path: string) => {
+      await gate.promise;
+      return { success: true, path, revision: 'rev-10' };
+    };
+    clickProp(container, 'aria-label', 'Overwrite with my edits');
+    // Edit typed while the overwrite write is in flight.
+    editorXml = '<dirty+more/>';
+    await act(async () => {
+      gate.resolve();
+      await gate.promise;
+    });
+    await flush();
+    await flush();
+
+    // Overwrite wrote the click-time bytes but must not reset later edits.
+    expect(writes[writes.length - 1]?.content).toBe('<dirty/>');
+    expect(lastEditorProps?.xml).toBe('<base/>');
+    expect(lastDialogProps?.open).toBe(false);
+
+    // Later edits remain saveable with the new revision.
+    writeImpl = async (path) => ({ success: true, path, revision: 'rev-11' });
+    clickProp(container, 'title', 'Save diagram');
+    await flush();
+    await flush();
+    expect(writes[writes.length - 1]?.content).toBe('<dirty+more/>');
+    expect(writes[writes.length - 1]?.options).toEqual({ expectedRevision: 'rev-10' });
+  });
+
+  test('new scope can save after a stale save completes', async () => {
+    readImpl = async (path: string) => (
+      path === '/repo/b.drawio'
+        ? { content: '<base-b/>', revision: 'rev-b1' }
+        : { content: '<base-a/>', revision: 'rev-a1' }
+    );
+    const gate = deferred<void>();
+    writeImpl = async (path: string) => {
+      await gate.promise;
+      return { success: true, path, revision: 'rev-a2' };
+    };
+    const container = await renderDiagram('/repo/a.drawio');
+    editorXml = '<dirty-a/>';
+    clickProp(container, 'title', 'Save diagram');
+    await act(async () => {
+      useUIStore.getState().setPendingDiagramFile('/repo/b.drawio');
+      await Promise.resolve();
+    });
+    await flush();
+    await flush();
+    expect(lastEditorProps?.xml).toBe('<base-b/>');
+
+    await act(async () => {
+      gate.resolve();
+      await gate.promise;
+    });
+    await flush();
+    await flush();
+    expect(lastEditorProps?.xml).toBe('<base-b/>');
+
+    // The new document must not be stuck saving after the stale completion.
+    writeImpl = async (path) => ({ success: true, path, revision: 'rev-b2' });
+    editorXml = '<dirty-b/>';
+    clickProp(container, 'title', 'Save diagram');
+    await flush();
+    await flush();
+    const last = writes[writes.length - 1];
+    expect(last?.path).toBe('/repo/b.drawio');
+    expect(last?.content).toBe('<dirty-b/>');
+  });
+
+  test('stale non-conflict error after a file switch is dropped', async () => {
+    readImpl = async (path: string) => (
+      path === '/repo/b.drawio'
+        ? { content: '<base-b/>', revision: 'rev-b1' }
+        : { content: '<base-a/>', revision: 'rev-a1' }
+    );
+    const gate = deferred<void>();
+    writeImpl = async () => {
+      await gate.promise;
+      throw new Error('Disk unreachable');
+    };
+    const container = await renderDiagram('/repo/a.drawio');
+    editorXml = '<dirty-a/>';
+    clickProp(container, 'title', 'Save diagram');
+    await act(async () => {
+      useUIStore.getState().setPendingDiagramFile('/repo/b.drawio');
+      await Promise.resolve();
+    });
+    await flush();
+    await flush();
+    expect(lastEditorProps?.xml).toBe('<base-b/>');
+
+    await act(async () => {
+      gate.resolve();
+      await gate.promise;
+    });
+    await flush();
+    await flush();
+
+    expect(lastEditorProps?.xml).toBe('<base-b/>');
+    expect(lastDialogProps?.open).toBe(false);
+    expect(toastErrors).toEqual([]);
+  });
+
+  test('Esc/close while resolving keeps the dialog open', async () => {
+    readImpl = async () => ({ content: '<base/>', revision: 'rev-1' });
+    writeImpl = async () => { throw conflictError(); };
+    const container = await renderDiagram('/repo/a.drawio');
+    editorXml = '<dirty/>';
+    readImpl = async () => ({ content: '<disk/>', revision: 'rev-9' });
+    clickProp(container, 'title', 'Save diagram');
+    await flush();
+    await flush();
+    expect(lastDialogProps?.open).toBe(true);
+
+    const gate = deferred<void>();
+    writeImpl = async (path: string) => {
+      await gate.promise;
+      return { success: true, path, revision: 'rev-10' };
+    };
+    clickProp(container, 'aria-label', 'Overwrite with my edits');
+    await flush();
+    expect(lastDialogProps?.isResolving).toBe(true);
+
+    await act(async () => {
+      lastDialogProps?.onClose();
+    });
+    await flush();
+    expect(lastDialogProps?.open).toBe(true);
+    expect(lastDialogProps?.conflict?.dirtyContent).toBe('<dirty/>');
+
+    await act(async () => {
+      gate.resolve();
+      await gate.promise;
+    });
+    await flush();
+    await flush();
+    expect(lastDialogProps?.open).toBe(false);
+  });
+});

--- a/packages/ui/src/components/views/DiagramView.tsx
+++ b/packages/ui/src/components/views/DiagramView.tsx
@@ -1,33 +1,125 @@
 import React from 'react';
+import { toast } from '@/components/ui';
 import { useUIStore } from '@/stores/useUIStore';
 import { useRuntimeAPIs } from '@/hooks/useRuntimeAPIs';
+import { buildGuardedWriteOptions } from '@/components/views/files/fileRevisionCache';
+import { isFileRevisionConflict } from '@/lib/api/files-errors';
+import { getRuntimeKey, subscribeRuntimeEndpointChanged } from '@/lib/runtime-switch';
 import { DiagramEditor, type DiagramEditorHandle } from '@/components/diagram/DiagramEditor';
+import {
+  FileSaveConflictDialog,
+  type FileSaveConflictDetails,
+} from '@/components/views/files/FileSaveConflictDialog';
 import { Icon } from '@/components/icon/Icon';
 
+type DiagramSaveConflict = FileSaveConflictDetails & {
+  /** Runtime that owned the failed save; reload/overwrite must not run against a new runtime. */
+  runtimeKey: string;
+};
+
+const toDisplayPath = (path: string): string => path.split('/').pop() || path;
+
 export function DiagramView() {
-  
   const { files } = useRuntimeAPIs();
 
   const [filePath, setFilePath] = React.useState<string | null>(null);
   const [xml, setXml] = React.useState('');
   const [loading, setLoading] = React.useState(true);
+  const [saveConflict, setSaveConflict] = React.useState<DiagramSaveConflict | null>(null);
+  const [isResolvingConflict, setIsResolvingConflict] = React.useState(false);
+  const [showConflictCompare, setShowConflictCompare] = React.useState(false);
+  const [isSaving, setIsSaving] = React.useState(false);
+  const [editorVersion, setEditorVersion] = React.useState(0);
+  const revisionRef = React.useRef<string | null | undefined>(undefined);
+  const savedXmlRef = React.useRef('');
+  const loadIdRef = React.useRef(0);
+  const saveOpRef = React.useRef(0);
+  const resolveOpRef = React.useRef(0);
   const editorRef = React.useRef<DiagramEditorHandle>(null);
+  const mountedRef = React.useRef(true);
+  const filePathRef = React.useRef<string | null>(null);
   const pendingDiagramFile = useUIStore((state) => state.pendingDiagramFile);
 
+  React.useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const isCurrent = React.useCallback((generation: number, runtimeKey: string, path: string): boolean => (
+    mountedRef.current
+    && loadIdRef.current === generation
+    && getRuntimeKey() === runtimeKey
+    && filePathRef.current === path
+  ), []);
+
   const loadFile = React.useCallback(async (path: string) => {
+    const loadId = loadIdRef.current + 1;
+    loadIdRef.current = loadId;
+    const loadRuntimeKey = getRuntimeKey();
+    const readFile = files?.readFile;
+    saveOpRef.current += 1;
+    resolveOpRef.current += 1;
     setLoading(true);
     setFilePath(path);
+    filePathRef.current = path;
+    setSaveConflict(null);
+    setShowConflictCompare(false);
+    setIsSaving(false);
+    setIsResolvingConflict(false);
     try {
-      const result = await files?.readFile?.(path);
-      if (result) {
-        setXml(result.content);
+      const result = await readFile?.(path);
+      if (!isCurrent(loadId, loadRuntimeKey, path)) return;
+      if (!result) {
+        // A missing/empty read leaves the on-disk revision unknown. Never
+        // offer an empty editor with an unguarded save that could overwrite
+        // a potentially existing target. Surface the failure and clear the
+        // active file so the user can reopen through the picker.
+        toast.error('Failed to read file');
+        setFilePath(null);
+        filePathRef.current = null;
+        savedXmlRef.current = '';
+        setXml('');
+        revisionRef.current = undefined;
+        setLoading(false);
+        return;
       }
-    } catch {
+      savedXmlRef.current = result.content;
+      setXml(result.content);
+      revisionRef.current = result.revision;
+    } catch (error) {
+      if (!isCurrent(loadId, loadRuntimeKey, path)) return;
+      toast.error(error instanceof Error ? error.message : 'Failed to read file');
+      setFilePath(null);
+      filePathRef.current = null;
+      savedXmlRef.current = '';
       setXml('');
-    } finally {
+      revisionRef.current = undefined;
       setLoading(false);
+      return;
+    } finally {
+      if (isCurrent(loadId, loadRuntimeKey, path)) {
+        setLoading(false);
+      }
     }
-  }, [files]);
+  }, [files, isCurrent]);
+
+  React.useEffect(() => subscribeRuntimeEndpointChanged(() => {
+    loadIdRef.current += 1;
+    revisionRef.current = undefined;
+    saveOpRef.current += 1;
+    resolveOpRef.current += 1;
+    if (!mountedRef.current) return;
+    setSaveConflict(null);
+    setShowConflictCompare(false);
+    setIsSaving(false);
+    setIsResolvingConflict(false);
+    const currentPath = filePathRef.current;
+    if (currentPath) {
+      void loadFile(currentPath);
+    }
+  }), [loadFile]);
 
   React.useEffect(() => {
     if (!pendingDiagramFile) {
@@ -39,13 +131,205 @@ export function DiagramView() {
     }
   }, [loadFile, pendingDiagramFile]);
 
-  const saveDiagram = React.useCallback(async () => {
-    const newXml = editorRef.current?.getXml();
-    if (filePath && files?.writeFile && newXml && newXml !== xml) {
-      await files.writeFile(filePath, newXml);
-      setXml(newXml);
+  const openConflict = React.useCallback(async (
+    path: string,
+    dirtyXml: string,
+    currentRevision: string | null,
+    exists: boolean,
+    saveGeneration: number,
+    saveRuntimeKey: string,
+  ) => {
+    let currentContent: string | null = null;
+    let resolvedRevision: string | null = currentRevision;
+    let resolvedExists = exists;
+    try {
+      if (resolvedExists) {
+        const entry = await files?.readFile?.(path);
+        if (!isCurrent(saveGeneration, saveRuntimeKey, path)) return;
+        if (entry) {
+          currentContent = entry.content ?? null;
+          if (typeof entry.revision === 'string') resolvedRevision = entry.revision;
+          resolvedExists = entry.exists !== false;
+        }
+      }
+    } catch {
+      if (!isCurrent(saveGeneration, saveRuntimeKey, path)) return;
     }
-  }, [filePath, files, xml]);
+    if (!isCurrent(saveGeneration, saveRuntimeKey, path)) return;
+    setSaveConflict({
+      path,
+      displayPath: toDisplayPath(path),
+      exists: resolvedExists,
+      currentRevision: resolvedRevision,
+      currentContent,
+      dirtyContent: dirtyXml,
+      runtimeKey: saveRuntimeKey,
+    });
+    setShowConflictCompare(false);
+  }, [files, isCurrent]);
+
+  const persistBytes = React.useCallback(async (
+    path: string,
+    content: string,
+    overwrite: boolean,
+    generation: number,
+    runtimeKey: string,
+  ): Promise<{ stale: true } | { stale: false; success: boolean; revision?: string | null }> => {
+    const result = await files?.writeFile?.(
+      path,
+      content,
+      buildGuardedWriteOptions(revisionRef.current, overwrite ? true : undefined),
+    );
+    if (!isCurrent(generation, runtimeKey, path)) return { stale: true };
+    return { stale: false, success: Boolean(result?.success), revision: result?.revision };
+  }, [files, isCurrent]);
+
+  const commitWritten = React.useCallback((written: string, revision?: string | null) => {
+    savedXmlRef.current = written;
+    if (typeof revision !== 'undefined') revisionRef.current = revision;
+    if (editorRef.current?.getXml() === written) {
+      setXml(written);
+    }
+  }, []);
+
+  const saveDiagram = React.useCallback(async () => {
+    const latest = editorRef.current?.getXml();
+    if (!filePath || !files?.writeFile || !latest || latest === savedXmlRef.current) return;
+    if (isSaving || isResolvingConflict) return;
+    const saveGeneration = loadIdRef.current;
+    const saveRuntimeKey = getRuntimeKey();
+    const savePath = filePath;
+    const dirtyXml = latest;
+    const op = saveOpRef.current + 1;
+    saveOpRef.current = op;
+    setIsSaving(true);
+    try {
+      const outcome = await persistBytes(savePath, dirtyXml, false, saveGeneration, saveRuntimeKey);
+      if (outcome.stale) return;
+      if (!outcome.success) {
+        toast.error('Failed to write file');
+        return;
+      }
+      commitWritten(dirtyXml, outcome.revision);
+    } catch (error) {
+      if (!isCurrent(saveGeneration, saveRuntimeKey, savePath)) return;
+      if (isFileRevisionConflict(error)) {
+        await openConflict(
+          savePath,
+          dirtyXml,
+          error.currentRevision ?? null,
+          error.exists,
+          saveGeneration,
+          saveRuntimeKey,
+        );
+        return;
+      }
+      toast.error(error instanceof Error ? error.message : 'Save failed');
+    } finally {
+      if (saveOpRef.current === op) {
+        setIsSaving(false);
+      }
+    }
+  }, [commitWritten, filePath, files, isCurrent, isResolvingConflict, isSaving, openConflict, persistBytes]);
+
+  const handleConflictReload = React.useCallback(async () => {
+    const details = saveConflict;
+    if (!details || isResolvingConflict) return;
+    if (!isCurrent(loadIdRef.current, details.runtimeKey, details.path)) return;
+    const reloadGeneration = loadIdRef.current;
+    const reloadRuntimeKey = details.runtimeKey;
+    if (!details.exists) {
+      setFilePath(null);
+      filePathRef.current = null;
+      savedXmlRef.current = '';
+      setXml('');
+      revisionRef.current = undefined;
+      setSaveConflict(null);
+      setShowConflictCompare(false);
+      return;
+    }
+    const op = resolveOpRef.current + 1;
+    resolveOpRef.current = op;
+    setIsResolvingConflict(true);
+    try {
+      const entry = await files?.readFile?.(details.path);
+      if (!isCurrent(reloadGeneration, reloadRuntimeKey, details.path)) return;
+      if (!entry) {
+        toast.error('Failed to read file');
+        return;
+      }
+      savedXmlRef.current = entry.content ?? '';
+      setXml(entry.content ?? '');
+      revisionRef.current = entry.revision;
+      setEditorVersion((value) => value + 1);
+      setSaveConflict(null);
+      setShowConflictCompare(false);
+    } catch (error) {
+      if (!isCurrent(reloadGeneration, reloadRuntimeKey, details.path)) return;
+      toast.error(error instanceof Error ? error.message : 'Failed to read file');
+    } finally {
+      if (resolveOpRef.current === op) {
+        setIsResolvingConflict(false);
+      }
+    }
+  }, [files, isCurrent, isResolvingConflict, saveConflict]);
+
+  const handleConflictOverwrite = React.useCallback(async () => {
+    const details = saveConflict;
+    if (!details || isResolvingConflict) return;
+    if (!isCurrent(loadIdRef.current, details.runtimeKey, details.path)) return;
+    const overwriteGeneration = loadIdRef.current;
+    const overwriteRuntimeKey = details.runtimeKey;
+    const writeFile = files?.writeFile;
+    if (!writeFile) {
+      toast.error('Saving not supported');
+      return;
+    }
+    const latest = editorRef.current?.getXml();
+    const content = latest ?? details.dirtyContent;
+    if (!content) {
+      toast.error('Failed to write file');
+      return;
+    }
+    const op = resolveOpRef.current + 1;
+    resolveOpRef.current = op;
+    setIsResolvingConflict(true);
+    try {
+      const outcome = await persistBytes(details.path, content, true, overwriteGeneration, overwriteRuntimeKey);
+      if (outcome.stale) return;
+      if (!outcome.success) {
+        toast.error('Failed to write file');
+        return;
+      }
+      commitWritten(content, outcome.revision);
+      setSaveConflict(null);
+      setShowConflictCompare(false);
+    } catch (error) {
+      if (!isCurrent(overwriteGeneration, overwriteRuntimeKey, details.path)) return;
+      if (isFileRevisionConflict(error)) {
+        await openConflict(
+          details.path,
+          content,
+          error.currentRevision ?? details.currentRevision,
+          error.exists,
+          overwriteGeneration,
+          overwriteRuntimeKey,
+        );
+        return;
+      }
+      toast.error(error instanceof Error ? error.message : 'Save failed');
+    } finally {
+      if (resolveOpRef.current === op) {
+        setIsResolvingConflict(false);
+      }
+    }
+  }, [commitWritten, files, isCurrent, isResolvingConflict, openConflict, persistBytes, saveConflict]);
+
+  const handleConflictClose = React.useCallback(() => {
+    if (isResolvingConflict || isSaving) return;
+    setSaveConflict(null);
+    setShowConflictCompare(false);
+  }, [isResolvingConflict, isSaving]);
 
   const fileName = filePath ? filePath.split('/').pop() || filePath : '';
 
@@ -91,11 +375,22 @@ export function DiagramView() {
       </div>
       <div className="flex-1 min-h-0">
         <DiagramEditor
+          key={editorVersion}
           ref={editorRef}
           xml={xml}
           className="h-full"
         />
       </div>
+      <FileSaveConflictDialog
+        open={Boolean(saveConflict)}
+        conflict={saveConflict}
+        isResolving={isResolvingConflict || isSaving}
+        showCompare={showConflictCompare}
+        onToggleCompare={() => setShowConflictCompare((value) => !value)}
+        onReload={() => { void handleConflictReload(); }}
+        onOverwrite={() => { void handleConflictOverwrite(); }}
+        onClose={handleConflictClose}
+      />
     </div>
   );
 }

--- a/packages/ui/src/components/views/FilesView.tsx
+++ b/packages/ui/src/components/views/FilesView.tsx
@@ -57,8 +57,10 @@ import { useFileOperations } from './files/useFileOperations';
 import { loadFileDocument } from './files/loadFileDocument';
 import { useDirtyFileNavigation, type DirtyFileNavigationIntent } from './files/useDirtyFileNavigation';
 import { useFileEditorNavigation } from './files/useFileEditorNavigation';
-import { useFileEditorSave } from './files/useFileEditorSave';
+import { useFileEditorSave, type FileEditorConflict } from './files/useFileEditorSave';
 import { useFileStatReconciliation } from './files/useFileStatReconciliation';
+import { shouldInvalidateLoadedRevision, type FileRevisionScope } from './files/fileRevisionCache';
+import { FileSaveConflictDialog } from './files/FileSaveConflictDialog';
 import { useFileViewerModes } from './files/useFileViewerModes';
 import { useFilesTree, shouldEnableFilesTree } from './files/useFilesTree';
 import { useFilesViewSearch } from './files/useFilesViewSearch';
@@ -272,6 +274,23 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full', chrome = 'd
   const desktopImageBlobUrlRef = React.useRef<string>('');
 
   const [loadedFilePath, setLoadedFilePath] = React.useState<string | null>(null);
+  // Opaque read-content revision retained exact with buffer/runtime/path/
+  // generation. `undefined` = unknown/legacy (no guard), `null` = missing.
+  const [loadedFileRevision, setLoadedFileRevision] = React.useState<string | null | undefined>(undefined);
+  const [loadedRevisionScope, setLoadedRevisionScope] = React.useState<{ runtimeKey: string; root: string; path: string; generation: number } | null>(null);
+  const activeRuntimeKey = useFilesViewTabsStore((state) => state.activeRuntimeKey);
+  const [saveConflictDetails, setSaveConflictDetails] = React.useState<{
+    path: string;
+    displayPath: string;
+    exists: boolean;
+    currentRevision: string | null;
+    currentContent: string | null;
+    /** Non-null when the conflict came from a Draw.io diagram save; the
+     *  preserved diagram XML the Overwrite action must re-attempt. */
+    diagramXml: string | null;
+  } | null>(null);
+  const [isResolvingConflict, setIsResolvingConflict] = React.useState(false);
+  const [showConflictCompare, setShowConflictCompare] = React.useState(false);
 
   const [draftContent, setDraftContent] = React.useState('');
   const [loadedFileLineEnding, setLoadedFileLineEnding] = React.useState<FileLineEnding>('\n');
@@ -296,6 +315,10 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full', chrome = 'd
     setFileError(null);
     setDesktopImageSrc('');
     setLoadedFilePath(null);
+    setLoadedFileRevision(undefined);
+    setLoadedRevisionScope(null);
+    setSaveConflictDetails(null);
+    setShowConflictCompare(false);
     if (isMobile) setShowMobilePageContent(false);
   }, [isMobile, root, setSelectedPath]);
   const {
@@ -375,8 +398,34 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full', chrome = 'd
     setFileError(null);
     setDesktopImageSrc('');
     setLoadedFilePath(null);
+    setLoadedFileRevision(undefined);
+    setLoadedRevisionScope(null);
+    setSaveConflictDetails(null);
+    setShowConflictCompare(false);
     setShowMobilePageContent(false);
   }, [root]);
+
+  // Runtime switch with an identical path must never reuse the previous
+  // runtime's bytes or revision. Tabs already reset per runtime; local
+  // content/revision follows the same boundary.
+  const lastFilesViewRuntimeRef = React.useRef<string>(activeRuntimeKey);
+  React.useEffect(() => {
+    if (lastFilesViewRuntimeRef.current === activeRuntimeKey) return;
+    lastFilesViewRuntimeRef.current = activeRuntimeKey;
+    activeFileLoadIdRef.current += 1;
+    loadingFilePathRef.current = null;
+    setFileContent('');
+    setDraftContent('');
+    setFileError(null);
+    setFileLoading(false);
+    setDesktopImageSrc('');
+    setLoadedFilePath(null);
+    setLoadedFileRevision(undefined);
+    setLoadedRevisionScope(null);
+    setSaveConflictDetails(null);
+    setShowConflictCompare(false);
+    setContentDetectedBinary(false);
+  }, [activeRuntimeKey]);
 
   const searchDirectory = mobileChrome ? mobileDirectory : currentDirectory;
   const { results: searchResults, searching } = useFilesViewSearch({
@@ -386,10 +435,10 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full', chrome = 'd
     showGitignored,
   });
 
-  const readFile = React.useCallback(async (path: string, options?: { allowOutsideWorkspace?: boolean; outsideFileGrant?: string; optional?: boolean }): Promise<string> => {
+  const readFileEntry = React.useCallback(async (path: string, options?: { allowOutsideWorkspace?: boolean; outsideFileGrant?: string; optional?: boolean }): Promise<{ content: string; revision?: string | null; exists?: boolean }> => {
     if (files.readFile) {
       const result = await files.readFile(path, { ...(options ?? {}), directory: root || undefined });
-      return result.content ?? '';
+      return { content: result.content ?? '', revision: result.revision, exists: result.exists };
     }
 
     const params = new URLSearchParams({ path });
@@ -412,16 +461,25 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full', chrome = 'd
       const error = await response.json().catch(() => ({ error: response.statusText }));
       throw new Error((error as { error?: string }).error || "Failed to read file");
     }
-    return response.text();
+    const content = await response.text();
+    const rawRevision = response.headers?.get?.('x-pichamber-file-revision');
+    const existsHeader = response.headers?.get?.('x-pichamber-file-exists');
+    const exists = existsHeader === 'false' ? false : true;
+    return {
+      content,
+      revision: typeof rawRevision === 'string' && rawRevision.length > 0 ? rawRevision : (exists ? undefined : null),
+      exists,
+    };
   }, [files, root]);
 
-  const readFileStat = React.useCallback(async (path: string, options?: { allowOutsideWorkspace?: boolean; outsideFileGrant?: string }): Promise<FileStatSnapshot | null> => {
+  const readFileStat = React.useCallback(async (path: string, options?: { allowOutsideWorkspace?: boolean; outsideFileGrant?: string; knownRevision?: string | null }): Promise<FileStatSnapshot | null> => {
     if (files.statFile) {
       const result = await files.statFile(path, { ...(options ?? {}), directory: root || undefined });
       return {
         path: result.path,
         size: result.size,
         mtimeMs: result.mtimeMs,
+        revision: result.revision,
       };
     }
     return null;
@@ -462,12 +520,16 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full', chrome = 'd
 
   const isDirty = draftContent !== displayedContent;
   const readSelectedFileStat = React.useCallback(
-    (path: string) => readFileStat(path, selectedFileReadOptions),
+    (path: string, options?: { knownRevision?: string | null }) => readFileStat(path, { ...selectedFileReadOptions, ...options }),
     [readFileStat, selectedFileReadOptions],
   );
   const reloadExternallyChangedFile = React.useCallback(() => {
     // The selection effect observes this reset and performs exactly one reload.
+    // Dirty drafts never reach here (the reconciler skips them), so clearing
+    // the revision is safe: the reload captures a fresh one.
     setLoadedFilePath(null);
+    setLoadedFileRevision(undefined);
+    setLoadedRevisionScope(null);
   }, []);
   const { recordStat: recordLoadedFileStat } = useFileStatReconciliation({
     selectedPath: selectedFile?.path ?? null,
@@ -476,6 +538,107 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full', chrome = 'd
     readStat: readSelectedFileStat,
     onExternalChange: reloadExternallyChangedFile,
   });
+  // Assigned right after useFileViewerModes resolves; lets handleFileSaved
+  // keep the diagram buffers in sync without a hook-order dependency cycle.
+  const recordDiagramContentRef = React.useRef<((content: string) => void) | null>(null);
+
+  const handleFileSaved = React.useCallback((path: string, content: string, revision?: string | null, scope?: FileRevisionScope | null) => {
+    setFileContent(content);
+    // Bind the saved revision to the save's captured authority (runtime/root/
+    // path/generation), not to whatever is current at completion time; the
+    // save hook has already dropped stale completions.
+    const savedGeneration = scope?.generation ?? activeFileLoadIdRef.current;
+    if (typeof revision !== 'undefined') {
+      setLoadedFileRevision(revision);
+      setLoadedRevisionScope({
+        runtimeKey: scope?.runtimeKey ?? activeRuntimeKey,
+        root: scope?.root ?? root,
+        path,
+        generation: savedGeneration,
+      });
+    }
+    if (root && isPathWithinRoot(path, root)) {
+      const relativePath = getDisplayPath(root, path);
+      if (relativePath) {
+        sessionEvents.requestGitRefresh({ directory: root, paths: [relativePath] });
+      }
+    }
+    if (isDrawioFile(path)) recordDiagramContentRef.current?.(content);
+    // Refresh stat after write so polling does not observe our own stale
+    // metadata. A stat completing after a selection/runtime switch is stale
+    // and must not poison the reconciliation baseline.
+    void readFileStat(path)
+      .then((stat) => {
+        if (!stat) return;
+        if (activeFileLoadIdRef.current !== savedGeneration) return;
+        recordLoadedFileStat(stat);
+      })
+      .catch(() => {});
+  }, [activeRuntimeKey, readFileStat, recordLoadedFileStat, root]);
+
+  const captureSaveScope = React.useCallback((): FileRevisionScope | null => {
+    if (!selectedFile?.path) return null;
+    return {
+      runtimeKey: activeRuntimeKey,
+      root,
+      path: selectedFile.path,
+      generation: activeFileLoadIdRef.current,
+    };
+  }, [activeRuntimeKey, root, selectedFile?.path]);
+  const currentSaveScope = captureSaveScope;
+
+  const handleSaveConflict = React.useCallback(async (conflict: FileEditorConflict, diagramXml: string | null = null) => {
+    // The conflict dialog belongs to the file the save was started for; a
+    // selection/reload/runtime switch (generation bump) during the fetch
+    // must not open it over the now-selected document.
+    const capturedGeneration = activeFileLoadIdRef.current;
+    const targetPath = conflict.path;
+    // Fetch the current version without touching the dirty draft or the
+    // preserved diagram XML. A failed fetch still opens the dialog (reload
+    // then retries the read).
+    let currentContent: string | null = null;
+    let currentRevision: string | null = conflict.currentRevision;
+    let exists = conflict.exists;
+    try {
+      if (exists) {
+        const entry = await readFileEntry(targetPath, selectedFileReadOptions);
+        currentContent = entry.content;
+        if (typeof entry.revision === 'string') currentRevision = entry.revision;
+        exists = entry.exists !== false;
+      }
+    } catch {
+      // Keep the server-advertised revision; Reload will surface the error.
+    }
+    if (activeFileLoadIdRef.current !== capturedGeneration) return;
+    setSaveConflictDetails({
+      path: targetPath,
+      displayPath: getDisplayPath(root, targetPath) || targetPath,
+      exists,
+      currentRevision,
+      currentContent,
+      diagramXml,
+    });
+    setShowConflictCompare(false);
+    // Preserve dirty text and diagram XML: nothing here writes to buffers.
+  }, [readFileEntry, root, selectedFileReadOptions]);
+
+  const guardedExpectedRevision = React.useMemo(() => {
+    if (!selectedFile?.path || loadedFilePath !== selectedFile.path) return undefined;
+    const scope = loadedRevisionScope;
+    if (!scope) return undefined;
+    if (shouldInvalidateLoadedRevision(
+      { ...scope, revision: loadedFileRevision },
+      { runtimeKey: activeRuntimeKey, root, path: selectedFile.path, generation: activeFileLoadIdRef.current },
+    )) {
+      // Stale scope with a known base must never degrade to an unguarded
+      // legacy write. Force a typed conflict so dirty text is preserved and
+      // the explicit reload/overwrite/compare workflow runs.
+      if (typeof loadedFileRevision === 'string' || loadedFileRevision === null) return '__stale__';
+      return undefined;
+    }
+    if (typeof loadedFileRevision === 'string' || loadedFileRevision === null) return loadedFileRevision;
+    return undefined;
+  }, [activeRuntimeKey, loadedFilePath, loadedFileRevision, loadedRevisionScope, root, selectedFile?.path]);
   const {
     clearDiagramContent,
     diagramEditorXml,
@@ -502,30 +665,19 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full', chrome = 'd
     setDraftContent,
     autoSaveEnabled,
     writeFile: files.writeFile,
-    readStat: readSelectedFileStat,
-    recordStat: recordLoadedFileStat,
+    expectedRevision: guardedExpectedRevision,
+    captureSaveScope,
+    currentSaveScope,
+    onSaved: handleFileSaved,
+    onConflict: (conflict) => { void handleSaveConflict(conflict, conflict.xml); },
   });
+  recordDiagramContentRef.current = recordDiagramContent;
   const getMdViewMode = React.useCallback(() => mdViewMode, [mdViewMode]);
 
-  const handleFileSaved = React.useCallback((path: string, content: string) => {
-    setFileContent(content);
-    if (root && isPathWithinRoot(path, root)) {
-      const relativePath = getDisplayPath(root, path);
-      if (relativePath) {
-        sessionEvents.requestGitRefresh({ directory: root, paths: [relativePath] });
-      }
-    }
-    if (isDrawioFile(path)) recordDiagramContent(content);
-    // Refresh stat after write so polling does not observe our own stale metadata.
-    void readFileStat(path)
-      .then((stat) => {
-        if (stat) recordLoadedFileStat(stat);
-      })
-      .catch(() => {});
-  }, [readFileStat, recordDiagramContent, recordLoadedFileStat, root]);
   const {
     autoSaveStatus,
     isSaving,
+    clearSaveConflict,
     saveDraft,
     saveNow,
   } = useFileEditorSave({
@@ -539,7 +691,11 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full', chrome = 'd
     lineEnding: loadedFileLineEnding,
     isNonEditableBinary: Boolean(selectedFile?.path && (isBinaryFile(selectedFile.path) || contentDetectedBinary)),
     writeFile: files.writeFile,
+    expectedRevision: guardedExpectedRevision,
     onSaved: handleFileSaved,
+    captureSaveScope,
+    currentSaveScope,
+    onConflict: (conflict) => { void handleSaveConflict(conflict); },
   });
   const {
     confirmOpen: confirmDiscardOpen,
@@ -571,8 +727,11 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full', chrome = 'd
   const loadSelectedFile = React.useCallback(async (node: FileNode) => {
     const loadId = activeFileLoadIdRef.current + 1;
     activeFileLoadIdRef.current = loadId;
+    const loadRuntimeKey = activeRuntimeKey;
+    const loadRoot = root;
     const isCurrentLoad = () => {
       if (!root) return false;
+      if (loadRuntimeKey !== activeRuntimeKey || loadRoot !== root) return false;
       const rootState = useFilesViewTabsStore.getState().byRoot[root];
       const currentPath = rootState?.selectedPath ?? rootState?.openPaths[0] ?? null;
       return activeFileLoadIdRef.current === loadId && currentPath === node.path;
@@ -581,6 +740,11 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full', chrome = 'd
     setFileError(null);
     setDesktopImageSrc('');
     setLoadedFilePath(null);
+    setLoadedFileRevision(undefined);
+    setLoadedRevisionScope(null);
+    setSaveConflictDetails(null);
+    setShowConflictCompare(false);
+    clearSaveConflict();
     setContentDetectedBinary(false);
 
     if (isMobile) {
@@ -594,11 +758,15 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full', chrome = 'd
     };
     let keepDesktopImageLoading = false;
     setFileLoading(true);
+    let entryRevision: string | null | undefined;
 
     await loadFileDocument(
       node.path,
       runtime.isDesktop,
-      (path) => readFile(path, readOptions),
+      (path) => readFileEntry(path, readOptions).then((entry) => {
+        entryRevision = entry.revision;
+        return entry.content;
+      }),
     )
       .then((result) => {
         if (!isCurrentLoad()) return;
@@ -622,6 +790,8 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full', chrome = 'd
         recordDiagramContent(result.content);
         setDraftContent(result.draft);
         setLoadedFilePath(node.path);
+        setLoadedFileRevision(entryRevision);
+        setLoadedRevisionScope({ runtimeKey: loadRuntimeKey, root: loadRoot, path: node.path, generation: loadId });
         void readFileStat(node.path, readOptions)
           .then((stat) => {
             if (stat && isCurrentLoad()) {
@@ -643,6 +813,8 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full', chrome = 'd
           setFileContent('');
           setDraftContent('');
           setLoadedFilePath(null);
+          setLoadedFileRevision(undefined);
+          setLoadedRevisionScope(null);
           recordLoadedFileStat(null);
           if (searchQuery.trim().length > 0) {
             setSearchQuery('');
@@ -671,6 +843,8 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full', chrome = 'd
           setFileContent('');
           setDraftContent('');
           setFileError(null);
+          setLoadedFileRevision(undefined);
+          setLoadedRevisionScope(null);
           recordLoadedFileStat(null);
           if (isMobile) {
             setShowMobilePageContent(false);
@@ -680,6 +854,8 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full', chrome = 'd
         setFileContent('');
         setDraftContent('');
         setFileError(error instanceof Error ? error.message : "Failed to read file");
+        setLoadedFileRevision(undefined);
+        setLoadedRevisionScope(null);
         recordLoadedFileStat(null);
       })
       .finally(() => {
@@ -687,7 +863,7 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full', chrome = 'd
           setFileLoading(false);
         }
       });
-  }, [expandPaths, isDirectoryLoaded, isMobile, loadDirectory, mode, readFile, readFileStat, recordDiagramContent, recordLoadedFileStat, removeOpenPathsByPrefix, root, runtime.isDesktop, searchQuery, setSelectedPath]);
+  }, [activeRuntimeKey, clearSaveConflict, expandPaths, isDirectoryLoaded, isMobile, loadDirectory, mode, readFileEntry, readFileStat, recordDiagramContent, recordLoadedFileStat, removeOpenPathsByPrefix, root, runtime.isDesktop, searchQuery, setSelectedPath]);
 
   const ensurePathVisible = React.useCallback(async (targetPath: string, includeTarget: boolean) => {
     if (!root || !needsTree) {
@@ -732,10 +908,15 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full', chrome = 'd
     clearDiagramContent();
     setDraftContent('');
     setLoadedFilePath(null);
+    setLoadedFileRevision(undefined);
+    setLoadedRevisionScope(null);
+    setSaveConflictDetails(null);
+    setShowConflictCompare(false);
+    clearSaveConflict();
     if (isMobile) {
       setShowMobilePageContent(true);
     }
-  }, [clearDiagramContent, ensurePathVisible, isMobile, requestNavigation, root, setSelectedPath]);
+  }, [clearDiagramContent, clearSaveConflict, ensurePathVisible, isMobile, requestNavigation, root, setSelectedPath]);
 
   const handleSelectFilePath = React.useCallback((path: string) => {
     void handleSelectFile(toFileNode(path));
@@ -765,6 +946,53 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full', chrome = 'd
       setMobileRefreshing(false);
     }
   }, [mobileDirectory, mobileRefreshing, refreshDirectory]);
+
+  const handleConflictReload = React.useCallback(() => {
+    const details = saveConflictDetails;
+    // Explicit reload discards the dirty draft and loads the current
+    // version (or closes the deleted file). Dirty text is preserved until
+    // this explicit action.
+    if (!details) return;
+    if (!details.exists) {
+      if (root) removeOpenPath(root, details.path);
+      clearSelectedFile();
+      setSaveConflictDetails(null);
+      setShowConflictCompare(false);
+      clearSaveConflict();
+      return;
+    }
+    setDraftContent('');
+    setLoadedFilePath(null);
+    setLoadedFileRevision(undefined);
+    setLoadedRevisionScope(null);
+    setSaveConflictDetails(null);
+    setShowConflictCompare(false);
+    clearSaveConflict();
+  }, [clearSaveConflict, clearSelectedFile, removeOpenPath, root, saveConflictDetails]);
+
+  const handleConflictOverwrite = React.useCallback(async () => {
+    if (!saveConflictDetails || isResolvingConflict) return;
+    setIsResolvingConflict(true);
+    try {
+      // Diagram conflicts re-attempt the preserved diagram write; text
+      // conflicts force the preserved draft through the guarded text save.
+      const overwritten = saveConflictDetails.diagramXml !== null
+        ? await saveDiagramNow(saveConflictDetails.path, saveConflictDetails.diagramXml, { overwrite: true })
+        : await saveNow({ overwrite: true });
+      if (overwritten) {
+        setSaveConflictDetails(null);
+        setShowConflictCompare(false);
+      }
+    } finally {
+      setIsResolvingConflict(false);
+    }
+  }, [isResolvingConflict, saveConflictDetails, saveDiagramNow, saveNow]);
+
+  const handleConflictClose = React.useCallback(() => {
+    // Closing keeps the dirty draft intact for a later explicit choice.
+    setSaveConflictDetails(null);
+    setShowConflictCompare(false);
+  }, []);
 
   React.useEffect(() => {
     if (!selectedFile?.path || !needsTree || !isVisible) {
@@ -1360,6 +1588,23 @@ export const FilesView: React.FC<FilesViewProps> = ({ mode = 'full', chrome = 'd
         isSaving={isSaving}
         onSaveAndContinue={() => void saveAndContinue()}
         onDiscardAndContinue={discardAndContinue}
+      />
+      <FileSaveConflictDialog
+        open={Boolean(saveConflictDetails)}
+        conflict={saveConflictDetails ? {
+          path: saveConflictDetails.path,
+          displayPath: saveConflictDetails.displayPath,
+          exists: saveConflictDetails.exists,
+          currentRevision: saveConflictDetails.currentRevision,
+          currentContent: saveConflictDetails.currentContent,
+          dirtyContent: saveConflictDetails.diagramXml ?? draftContent,
+        } : null}
+        isResolving={isResolvingConflict || isSaving}
+        showCompare={showConflictCompare}
+        onToggleCompare={() => setShowConflictCompare((value) => !value)}
+        onReload={handleConflictReload}
+        onOverwrite={() => { void handleConflictOverwrite(); }}
+        onClose={handleConflictClose}
       />
       <div className={cn('flex flex-col flex-shrink-0', showEditorTabsRow && 'border-b border-border/40')}>
         {/* Row 1: Tabs */}

--- a/packages/ui/src/components/views/GitView.tsx
+++ b/packages/ui/src/components/views/GitView.tsx
@@ -872,7 +872,7 @@ export const GitView: React.FC<GitViewProps> = ({
   const canShowBranchWorkflows = Boolean(currentBranch);
 
   React.useEffect(() => {
-    if (!currentDirectory || !git || !log?.all?.length || !currentBranch || !baseBranch || currentBranch === baseBranch) {
+    if (!currentDirectory || !git || !log?.all?.length || !currentBranch || !baseBranch || !branchScopeAvailable) {
       setHistoryBranchDivider(null);
       return;
     }
@@ -934,7 +934,7 @@ export const GitView: React.FC<GitViewProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [baseBranch, currentBranch, currentDirectory, git, log, logMaxCountLocal]);
+  }, [baseBranch, branchScopeAvailable, currentBranch, currentDirectory, git, log, logMaxCountLocal]);
 
   // Clear graph log when directory changes
   React.useEffect(() => {

--- a/packages/ui/src/components/views/files/FileSaveConflictDialog.tsx
+++ b/packages/ui/src/components/views/files/FileSaveConflictDialog.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+export type FileSaveConflictDetails = {
+  path: string;
+  displayPath: string;
+  exists: boolean;
+  currentRevision: string | null;
+  currentContent: string | null;
+  dirtyContent: string;
+};
+
+type FileSaveConflictDialogProps = {
+  open: boolean;
+  conflict: FileSaveConflictDetails | null;
+  isResolving: boolean;
+  showCompare: boolean;
+  onToggleCompare: () => void;
+  onReload: () => void;
+  onOverwrite: () => void;
+  onClose: () => void;
+};
+
+const truncatePreview = (value: string, maxChars = 4000): string => (
+  value.length > maxChars ? `${value.slice(0, maxChars)}\n\n… truncated …` : value
+);
+
+/**
+ * Explicit reload / overwrite / compare workflow for file-save revision
+ * conflicts. Dirty text is never cleared by this dialog; Reload discards it
+ * only on explicit user action, Overwrite forces the preserved dirty text,
+ * and Compare previews both versions before choosing.
+ */
+export const FileSaveConflictDialog: React.FC<FileSaveConflictDialogProps> = ({
+  open,
+  conflict,
+  isResolving,
+  showCompare,
+  onToggleCompare,
+  onReload,
+  onOverwrite,
+  onClose,
+}) => {
+  if (!conflict) return null;
+  const deleted = !conflict.exists;
+  return (
+    <Dialog open={open} onOpenChange={(nextOpen) => { if (!nextOpen) onClose(); }}>
+      <DialogContent showCloseButton={false} className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{deleted ? 'File deleted on disk' : 'File changed on disk'}</DialogTitle>
+          <DialogDescription>
+            {deleted
+              ? `“${conflict.displayPath}” was deleted since you opened it. Your edits are preserved. Reload to discard them, or overwrite to recreate the file.`
+              : `“${conflict.displayPath}” changed since you opened it. Your edits are preserved. Reload to discard them and load the current version, or overwrite to keep your edits.`}
+          </DialogDescription>
+        </DialogHeader>
+        {showCompare && !deleted ? (
+          <div className="grid max-h-64 grid-cols-1 gap-2 overflow-auto py-2">
+            <div>
+              <div className="typography-meta text-muted-foreground">Current version on disk</div>
+              <pre className="mt-1 max-h-28 overflow-auto rounded-md bg-[var(--surface-subtle)] p-2 text-xs whitespace-pre-wrap break-words">
+                {truncatePreview(conflict.currentContent ?? '')}
+              </pre>
+            </div>
+            <div>
+              <div className="typography-meta text-muted-foreground">Your edits</div>
+              <pre className="mt-1 max-h-28 overflow-auto rounded-md bg-[var(--surface-subtle)] p-2 text-xs whitespace-pre-wrap break-words">
+                {truncatePreview(conflict.dirtyContent)}
+              </pre>
+            </div>
+          </div>
+        ) : null}
+        <DialogFooter className="flex flex-wrap gap-2">
+          {!deleted ? (
+            <Button
+              variant="outline"
+              onClick={onToggleCompare}
+              disabled={isResolving}
+              aria-label={showCompare ? 'Hide version comparison' : 'Compare versions'}
+              title={showCompare ? 'Hide version comparison' : 'Compare versions'}
+            >
+              {showCompare ? 'Hide compare' : 'Compare'}
+            </Button>
+          ) : null}
+          <Button
+            variant="outline"
+            onClick={onReload}
+            disabled={isResolving}
+            aria-label={deleted ? 'Discard edits and close' : 'Reload current version'}
+            title={deleted ? 'Discard edits and close' : 'Reload current version'}
+          >
+            {deleted ? 'Discard edits' : 'Reload'}
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={onOverwrite}
+            disabled={isResolving}
+            aria-label={deleted ? 'Recreate file with my edits' : 'Overwrite with my edits'}
+            title={deleted ? 'Recreate file with my edits' : 'Overwrite with my edits'}
+          >
+            {isResolving ? 'Working…' : 'Overwrite'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/packages/ui/src/components/views/files/fileLineEndings.test.ts
+++ b/packages/ui/src/components/views/files/fileLineEndings.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from 'bun:test';
+
+import { detectFileLineEnding, serializeEditorContent } from './filesViewModel';
+
+describe('editor line endings', () => {
+  test('round-trips CRLF without normalizing on save', () => {
+    expect(detectFileLineEnding('one\r\ntwo\r\n')).toBe('\r\n');
+    expect(serializeEditorContent('one\ntwo\n', '\r\n')).toBe('one\r\ntwo\r\n');
+    expect(serializeEditorContent('one\r\ntwo\r\n', '\r\n')).toBe('one\r\ntwo\r\n');
+    expect(serializeEditorContent('one\ntwo\n', '\n')).toBe('one\ntwo\n');
+  });
+});

--- a/packages/ui/src/components/views/files/fileRevisionCache.test.ts
+++ b/packages/ui/src/components/views/files/fileRevisionCache.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  buildGuardedWriteOptions,
+  isRevisionUsableForSave,
+  isSameFileRevision,
+  isSaveScopeCurrent,
+  shouldInvalidateLoadedRevision,
+  toExpectedRevision,
+} from './fileRevisionCache';
+
+describe('fileRevisionCache', () => {
+  test('compares revisions exact without normalization', () => {
+    expect(isSameFileRevision('v1:1:2:abc', 'v1:1:2:abc')).toBe(true);
+    expect(isSameFileRevision('v1:1:2:abc', 'v1:1:2:abc ')).toBe(false);
+    expect(isSameFileRevision('V1:1:2:ABC', 'v1:1:2:abc')).toBe(false);
+    expect(isSameFileRevision(null, null)).toBe(true);
+    expect(isSameFileRevision(undefined, undefined)).toBe(true);
+    expect(isSameFileRevision(null, undefined)).toBe(false);
+  });
+
+  test('defines usable revisions for guarded saves', () => {
+    expect(isRevisionUsableForSave('v1:1:2:abc')).toBe(true);
+    expect(isRevisionUsableForSave(null)).toBe(true);
+    expect(isRevisionUsableForSave(undefined)).toBe(false);
+  });
+
+  test('invalidates on runtime, path, root, or generation races', () => {
+    const cached = {
+      runtimeKey: 'local',
+      root: '/repo',
+      path: '/repo/a.txt',
+      generation: 3,
+      revision: 'v1:1:2:abc',
+    };
+    const current = { runtimeKey: 'local', root: '/repo', path: '/repo/a.txt', generation: 3 };
+    expect(shouldInvalidateLoadedRevision(cached, current)).toBe(false);
+    expect(shouldInvalidateLoadedRevision(cached, { ...current, runtimeKey: 'url:https://remote' })).toBe(true);
+    expect(shouldInvalidateLoadedRevision(cached, { ...current, path: '/repo/b.txt' })).toBe(true);
+    expect(shouldInvalidateLoadedRevision(cached, { ...current, root: '/other' })).toBe(true);
+    expect(shouldInvalidateLoadedRevision(cached, { ...current, generation: 4 })).toBe(true);
+    expect(shouldInvalidateLoadedRevision(null, current)).toBe(true);
+  });
+
+  test('treats runtime switch as stale even for identical paths', () => {
+    const cached = {
+      runtimeKey: 'local',
+      root: '/repo',
+      path: '/repo/a.txt',
+      generation: 1,
+      revision: 'v1:1:2:abc',
+    };
+    expect(shouldInvalidateLoadedRevision(cached, {
+      runtimeKey: 'url:https://pair',
+      root: '/repo',
+      path: '/repo/a.txt',
+      generation: 1,
+    })).toBe(true);
+  });
+
+  test('resolves wire expectedRevision values', () => {
+    expect(toExpectedRevision('v1:1:2:abc')).toBe('v1:1:2:abc');
+    expect(toExpectedRevision(null)).toBeNull();
+    expect(toExpectedRevision(undefined)).toBeUndefined();
+  });
+
+  test('builds guarded write options for new-file, guarded, legacy, and overwrite saves', () => {
+    expect(buildGuardedWriteOptions(null)).toEqual({ expectedRevision: null });
+    expect(buildGuardedWriteOptions('v1:1:2:abc')).toEqual({ expectedRevision: 'v1:1:2:abc' });
+    expect(buildGuardedWriteOptions(undefined)).toBeUndefined();
+    expect(buildGuardedWriteOptions('v1:1:2:abc', true)).toEqual({
+      expectedRevision: 'v1:1:2:abc',
+      overwrite: true,
+    });
+    expect(buildGuardedWriteOptions(undefined, true)).toEqual({ overwrite: true });
+  });
+
+  test('requires exact runtime/root/path/generation authority for save completions', () => {
+    const scope = { runtimeKey: 'local', root: '/repo', path: '/repo/a.txt', generation: 3 };
+    expect(isSaveScopeCurrent(scope, { ...scope })).toBe(true);
+    expect(isSaveScopeCurrent(scope, { ...scope, runtimeKey: 'url:https://remote' })).toBe(false);
+    expect(isSaveScopeCurrent(scope, { ...scope, root: '/other' })).toBe(false);
+    expect(isSaveScopeCurrent(scope, { ...scope, path: '/repo/b.txt' })).toBe(false);
+    expect(isSaveScopeCurrent(scope, { ...scope, generation: 4 })).toBe(false);
+    expect(isSaveScopeCurrent(scope, null)).toBe(false);
+    expect(isSaveScopeCurrent(null, scope)).toBe(false);
+    expect(isSaveScopeCurrent(undefined, undefined)).toBe(false);
+  });
+});

--- a/packages/ui/src/components/views/files/fileRevisionCache.ts
+++ b/packages/ui/src/components/views/files/fileRevisionCache.ts
@@ -1,0 +1,92 @@
+import type { FileContentRevision } from '@/lib/api/types';
+
+/**
+ * File-save revision cache helpers (finding #8).
+ *
+ * The opaque read-content revision is retained exact with buffer (draft),
+ * runtime, path, and load generation. Any mismatch invalidates the cached
+ * revision so a stale read can never authorize a guarded save against the
+ * wrong file, runtime, or generation.
+ */
+
+export type FileRevisionScope = {
+  runtimeKey: string;
+  root: string;
+  path: string;
+  generation: number;
+};
+
+export type CachedFileRevision = FileRevisionScope & {
+  revision: FileContentRevision;
+};
+
+/** Exact opaque compare: no trimming, no case folding, no coercion. */
+export const isSameFileRevision = (
+  left: FileContentRevision,
+  right: FileContentRevision,
+): boolean => left === right;
+
+/** Whether a cached revision may be sent as `expectedRevision`. */
+export const isRevisionUsableForSave = (revision: FileContentRevision): boolean => (
+  typeof revision === 'string' || revision === null
+);
+
+/**
+ * Whether the cached revision is stale for the current scope. True when
+ * runtime, root, path, or generation differ, or when no revision was ever
+ * captured. Path/root callers must pass already-normalized values so this
+ * stays an exact compare.
+ */
+export const shouldInvalidateLoadedRevision = (
+  cached: CachedFileRevision | null | undefined,
+  current: FileRevisionScope,
+): boolean => {
+  if (!cached) return true;
+  if (cached.runtimeKey !== current.runtimeKey) return true;
+  if (cached.root !== current.root) return true;
+  if (cached.path !== current.path) return true;
+  if (cached.generation !== current.generation) return true;
+  return false;
+};
+
+/** Resolve the `expectedRevision` wire value for a guarded save. */
+export const toExpectedRevision = (
+  revision: FileContentRevision,
+): string | null | undefined => {
+  if (typeof revision === 'string') return revision;
+  if (revision === null) return null;
+  return undefined;
+};
+
+/** Build the adapter write options for a guarded save. */
+export const buildGuardedWriteOptions = (
+  expectedRevision: FileContentRevision,
+  overwrite?: boolean,
+): { expectedRevision?: string | null; overwrite?: boolean } | undefined => {
+  if (overwrite === true) {
+    return expectedRevision !== undefined
+      ? { expectedRevision: toExpectedRevision(expectedRevision), overwrite: true }
+      : { overwrite: true };
+  }
+  if (expectedRevision === undefined) return undefined;
+  return { expectedRevision: toExpectedRevision(expectedRevision) };
+};
+
+/**
+ * Whether an in-flight save captured under `scope` may still commit its
+ * completion: runtime, root, path, and generation must all match the current
+ * scope exactly. A save that outlives its authority (file switch, reload,
+ * runtime switch) must be dropped instead of clobbering the now-selected
+ * document with the previous buffer.
+ */
+export const isSaveScopeCurrent = (
+  scope: FileRevisionScope | null | undefined,
+  current: FileRevisionScope | null | undefined,
+): boolean => Boolean(
+  scope
+  && current
+  && scope.runtimeKey === current.runtimeKey
+  && scope.root === current.root
+  && scope.path === current.path
+  && scope.generation === current.generation,
+);

--- a/packages/ui/src/components/views/files/filesViewModel.ts
+++ b/packages/ui/src/components/views/files/filesViewModel.ts
@@ -11,6 +11,8 @@ export type FileStatSnapshot = {
   path: string;
   size: number;
   mtimeMs?: number;
+  /** Opaque read/write revision when the stat source supplied one. */
+  revision?: string | null;
 };
 
 export const getParentDirectoryPath = (path: string): string => {

--- a/packages/ui/src/components/views/files/useFileEditorSave.test.tsx
+++ b/packages/ui/src/components/views/files/useFileEditorSave.test.tsx
@@ -1,0 +1,244 @@
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+
+import type { FileRevisionScope } from './fileRevisionCache';
+
+// The hook only uses `toast` from the UI barrel; replace it so the test stays
+// self-contained and records error surfacing.
+const toastErrors: string[] = [];
+mock.module('@/components/ui', () => ({
+  toast: {
+    error: (message: string) => { toastErrors.push(message); },
+    success: () => undefined,
+  },
+}));
+
+import type { FileEditorConflict } from './useFileEditorSave';
+const { useFileEditorSave } = await import('./useFileEditorSave');
+
+type HookOptions = Parameters<typeof useFileEditorSave>[0];
+type HookResult = ReturnType<typeof useFileEditorSave>;
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => { resolve = res; });
+  return { promise, resolve };
+};
+
+let latest: HookResult | null = null;
+const Probe = (props: HookOptions) => {
+  latest = useFileEditorSave(props);
+  return null;
+};
+
+const installMinimalDom = () => {
+  const descriptors = new Map<string, PropertyDescriptor | undefined>();
+  const setGlobal = (name: string, value: unknown) => {
+    descriptors.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
+    Object.defineProperty(globalThis, name, { configurable: true, writable: true, value });
+  };
+  class ElementStub {}
+  const documentStub: Record<string, unknown> = {
+    nodeType: 9,
+    defaultView: globalThis,
+    activeElement: null,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+  };
+  const container = {
+    nodeType: 1,
+    tagName: 'DIV',
+    nodeName: 'DIV',
+    namespaceURI: 'http://www.w3.org/1999/xhtml',
+    ownerDocument: documentStub,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+  };
+  documentStub.documentElement = container;
+  documentStub.body = container;
+  setGlobal('document', documentStub);
+  setGlobal('window', globalThis);
+  setGlobal('Element', ElementStub);
+  setGlobal('HTMLElement', ElementStub);
+  setGlobal('HTMLIFrameElement', ElementStub);
+  setGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  return {
+    container: container as unknown as Element,
+    restore: () => {
+      for (const [name, descriptor] of descriptors) {
+        if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+        else Reflect.deleteProperty(globalThis, name);
+      }
+    },
+  };
+};
+
+const roots: Root[] = [];
+const restoreFns: Array<() => void> = [];
+
+const renderHook = async (props: HookOptions) => {
+  const dom = installMinimalDom();
+  restoreFns.push(dom.restore);
+  const root = createRoot(dom.container);
+  roots.push(root);
+  await act(async () => {
+    root.render(<Probe {...props} />);
+  });
+};
+
+afterEach(async () => {
+  for (const root of roots.splice(0)) {
+    await act(async () => root.unmount());
+  }
+  restoreFns.splice(0).forEach((restore) => restore());
+  latest = null;
+  toastErrors.length = 0;
+});
+
+const baseOptions = (overrides: Partial<HookOptions>): HookOptions => ({
+  autoSaveEnabled: false,
+  selectedPath: '/repo/a.txt',
+  loadedPath: '/repo/a.txt',
+  fileLoading: false,
+  isDirty: true,
+  draftContent: 'draft',
+  fileContent: 'base',
+  lineEnding: '\n',
+  isNonEditableBinary: false,
+  writeFile: async () => ({ success: true, path: '/repo/a.txt', revision: 'rev-2' }),
+  expectedRevision: 'rev-1',
+  onSaved: () => undefined,
+  ...overrides,
+});
+
+const baseScope: FileRevisionScope = {
+  runtimeKey: 'local',
+  root: '/repo',
+  path: '/repo/a.txt',
+  generation: 1,
+};
+
+describe('useFileEditorSave authority', () => {
+  test('forwards the guarded revision and reports saved revision with scope', async () => {
+    const writes: Array<{ path: string; content: string; options?: unknown }> = [];
+    const onSavedCalls: Array<{ path: string; content: string; revision?: string | null; scope?: FileRevisionScope | null }> = [];
+    await renderHook(baseOptions({
+      writeFile: async (path, content, options) => {
+        writes.push({ path, content, options });
+        return { success: true, path, revision: 'rev-2' };
+      },
+      onSaved: (path, content, revision, scope) => { onSavedCalls.push({ path, content, revision, scope }); },
+      captureSaveScope: () => baseScope,
+      currentSaveScope: () => baseScope,
+    }));
+
+    let saved = false;
+    await act(async () => {
+      saved = await latest!.saveNow();
+    });
+    expect(saved).toBe(true);
+    expect(writes).toHaveLength(1);
+    expect(writes[0].options).toEqual({ expectedRevision: 'rev-1' });
+    expect(onSavedCalls).toHaveLength(1);
+    expect(onSavedCalls[0]).toMatchObject({
+      path: '/repo/a.txt',
+      content: 'draft',
+      revision: 'rev-2',
+      scope: baseScope,
+    });
+  });
+
+  test('drops stale save completions after a selection/generation switch', async () => {
+    const onSavedCalls: unknown[] = [];
+    let currentGeneration = 1;
+    const writeGate = deferred<void>();
+    let writes = 0;
+    await renderHook(baseOptions({
+      writeFile: async () => {
+        writes += 1;
+        await writeGate.promise;
+        return { success: true, path: '/repo/a.txt', revision: 'rev-2' };
+      },
+      onSaved: () => { onSavedCalls.push('saved'); },
+      captureSaveScope: () => ({ ...baseScope, generation: 1 }),
+      currentSaveScope: () => ({ ...baseScope, generation: currentGeneration }),
+    }));
+
+    let saved: boolean | undefined;
+    await act(async () => {
+      const pending = latest!.saveNow().then((value) => { saved = value; });
+      // The selection switches to another file (generation bump) while the
+      // write is in flight; the completion must not clobber the new document.
+      currentGeneration = 2;
+      writeGate.resolve();
+      await pending;
+    });
+    expect(writes).toBe(1);
+    expect(saved).toBe(false);
+    expect(onSavedCalls).toHaveLength(0);
+  });
+
+  test('drops stale conflict completions after a selection/generation switch', async () => {
+    const onConflictCalls: FileEditorConflict[] = [];
+    let currentGeneration = 1;
+    const writeGate = deferred<void>();
+    await renderHook(baseOptions({
+      writeFile: async () => {
+        await writeGate.promise;
+        throw Object.assign(new Error('File has changed on disk'), {
+          name: 'FileRevisionConflictError',
+          reason: 'file-revision-conflict',
+          currentRevision: 'rev-9',
+          exists: true,
+          filePath: '/repo/a.txt',
+        });
+      },
+      onConflict: (conflict) => { onConflictCalls.push(conflict); },
+      captureSaveScope: () => baseScope,
+      currentSaveScope: () => ({ ...baseScope, generation: currentGeneration }),
+    }));
+
+    let saved: boolean | undefined;
+    await act(async () => {
+      const pending = latest!.saveNow().then((value) => { saved = value; });
+      currentGeneration = 2;
+      writeGate.resolve();
+      await pending;
+    });
+    expect(saved).toBe(false);
+    expect(onConflictCalls).toHaveLength(0);
+    expect(latest!.saveConflict).toBeNull();
+  });
+
+  test('surfaces typed conflicts with the current revision for current scopes', async () => {
+    const onConflictCalls: FileEditorConflict[] = [];
+    await renderHook(baseOptions({
+      writeFile: async () => {
+        throw Object.assign(new Error('File has changed on disk'), {
+          name: 'FileRevisionConflictError',
+          reason: 'file-revision-conflict',
+          currentRevision: 'rev-9',
+          exists: true,
+          filePath: '/repo/a.txt',
+        });
+      },
+      onConflict: (conflict) => { onConflictCalls.push(conflict); },
+      captureSaveScope: () => baseScope,
+      currentSaveScope: () => baseScope,
+    }));
+
+    let saved: boolean | undefined;
+    await act(async () => {
+      saved = await latest!.saveNow();
+    });
+    expect(saved).toBe(false);
+    expect(latest!.saveConflict).not.toBeNull();
+    expect(latest!.saveConflict).toMatchObject({
+      path: '/repo/a.txt',
+      currentRevision: 'rev-9',
+      exists: true,
+    });
+    expect(onConflictCalls).toHaveLength(1);
+  });
+});

--- a/packages/ui/src/components/views/files/useFileEditorSave.ts
+++ b/packages/ui/src/components/views/files/useFileEditorSave.ts
@@ -2,8 +2,16 @@ import * as React from 'react';
 
 import { toast } from '@/components/ui';
 import type { FilesAPI } from '@/lib/api/types';
+import { isFileRevisionConflict } from '@/lib/api/files-errors';
+import { buildGuardedWriteOptions, isSaveScopeCurrent, type FileRevisionScope } from './fileRevisionCache';
 import { shouldAllowFileDraftSave, shouldScheduleFileAutosave } from '@/lib/fileEditorAutosave';
 import { serializeEditorContent, type FileLineEnding } from './filesViewModel';
+
+export type FileEditorConflict = {
+  path: string;
+  currentRevision: string | null;
+  exists: boolean;
+};
 
 type UseFileEditorSaveOptions = {
   autoSaveEnabled: boolean;
@@ -16,7 +24,14 @@ type UseFileEditorSaveOptions = {
   lineEnding: FileLineEnding;
   isNonEditableBinary: boolean;
   writeFile: FilesAPI['writeFile'];
-  onSaved: (path: string, content: string) => void;
+  /** Opaque base revision from the last successful read/save; null = missing (create-only). */
+  expectedRevision?: string | null;
+  onSaved: (path: string, content: string, revision?: string | null, scope?: FileRevisionScope | null) => void;
+  /** Captures the runtime/root/path/generation authority for a save started now. */
+  captureSaveScope?: () => FileRevisionScope | null;
+  /** Resolves the current authority for stale-completion checks at commit time. */
+  currentSaveScope?: () => FileRevisionScope | null;
+  onConflict?: (conflict: FileEditorConflict) => void;
 };
 
 const AUTO_SAVE_DELAY_MS = 1500;
@@ -34,12 +49,30 @@ export function useFileEditorSave({
   lineEnding,
   isNonEditableBinary,
   writeFile,
+  expectedRevision,
   onSaved,
+  captureSaveScope,
+  currentSaveScope,
+  onConflict,
 }: UseFileEditorSaveOptions) {
   const [isSaving, setIsSaving] = React.useState(false);
   const [autoSaveStatus, setAutoSaveStatus] = React.useState<'idle' | 'saved'>('idle');
+  const [saveConflict, setSaveConflict] = React.useState<FileEditorConflict | null>(null);
   const autoSaveTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
   const savedStatusTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onConflictRef = React.useRef(onConflict);
+  onConflictRef.current = onConflict;
+  // Authority callbacks are read through refs so an in-flight save verifies
+  // against the latest render's scope, not the closure it was started in.
+  const captureSaveScopeRef = React.useRef(captureSaveScope);
+  captureSaveScopeRef.current = captureSaveScope;
+  const currentSaveScopeRef = React.useRef(currentSaveScope);
+  currentSaveScopeRef.current = currentSaveScope;
+
+  const isSaveCompletionCurrent = React.useCallback((saveScope: FileRevisionScope | null) => {
+    if (!saveScope) return true; // No authority provider: legacy behavior.
+    return isSaveScopeCurrent(saveScope, currentSaveScopeRef.current?.() ?? null);
+  }, []);
 
   const cancelPendingAutosave = React.useCallback(() => {
     if (!autoSaveTimerRef.current) return;
@@ -56,7 +89,7 @@ export function useFileEditorSave({
     }, SAVED_STATUS_DURATION_MS);
   }, []);
 
-  const saveDraft = React.useCallback(async () => {
+  const saveDraft = React.useCallback(async (options?: { overwrite?: boolean }) => {
     if (!selectedPath || !writeFile) {
       toast.error('Saving not supported');
       return false;
@@ -87,27 +120,53 @@ export function useFileEditorSave({
     if (!isDirty) return true;
 
     setIsSaving(true);
+    // Capture the save authority before awaiting so the completion can be
+    // verified against it; selection/reload/runtime switches invalidate it.
+    const saveScope = captureSaveScopeRef.current?.() ?? null;
     try {
       const contentToWrite = serializeEditorContent(draftContent, lineEnding);
-      const result = await writeFile(selectedPath, contentToWrite);
+      const writeOptions = buildGuardedWriteOptions(expectedRevision, options?.overwrite);
+      const result = await writeFile(selectedPath, contentToWrite, writeOptions);
       if (!result?.success) {
         toast.error('Failed to write file');
         return false;
       }
-      onSaved(selectedPath, draftContent);
+      if (!isSaveCompletionCurrent(saveScope)) {
+        // Stale completion: the file/runtime/generation moved on while the
+        // write was in flight, so this buffer no longer owns the document.
+        // The bytes are on disk; dropping the completion here keeps the
+        // newly selected document from being clobbered by the old buffer.
+        return false;
+      }
+      // Dirty text is preserved until success; conflict never reaches here.
+      setSaveConflict(null);
+      onSaved(selectedPath, draftContent, result?.revision, saveScope);
       return true;
     } catch (error) {
+      if (isFileRevisionConflict(error)) {
+        // Preserve the dirty draft, surface the typed conflict, and let
+        // FilesView fetch the current version for reload/overwrite/compare.
+        if (!isSaveCompletionCurrent(saveScope)) return false;
+        const conflict: FileEditorConflict = {
+          path: selectedPath,
+          currentRevision: error.currentRevision ?? null,
+          exists: error.exists,
+        };
+        setSaveConflict(conflict);
+        onConflictRef.current?.(conflict);
+        return false;
+      }
       toast.error(error instanceof Error ? error.message : 'Save failed');
       return false;
     } finally {
       setIsSaving(false);
     }
-  }, [draftContent, fileContent, fileLoading, isDirty, isNonEditableBinary, lineEnding, loadedPath, onSaved, selectedPath, writeFile]);
+  }, [draftContent, expectedRevision, fileContent, fileLoading, isDirty, isNonEditableBinary, isSaveCompletionCurrent, lineEnding, loadedPath, onSaved, selectedPath, writeFile]);
 
-  const saveNow = React.useCallback(async () => {
+  const saveNow = React.useCallback(async (options?: { overwrite?: boolean }) => {
     cancelPendingAutosave();
     if (isSaving) return false;
-    const saved = await saveDraft();
+    const saved = await saveDraft(options);
     if (saved) showSavedStatus();
     return saved;
   }, [cancelPendingAutosave, isSaving, saveDraft, showSavedStatus]);
@@ -144,6 +203,7 @@ export function useFileEditorSave({
   React.useEffect(() => {
     setAutoSaveStatus('idle');
     setIsSaving(false);
+    setSaveConflict(null);
   }, [selectedPath]);
 
   React.useEffect(() => () => {
@@ -151,5 +211,5 @@ export function useFileEditorSave({
     if (savedStatusTimerRef.current) clearTimeout(savedStatusTimerRef.current);
   }, [cancelPendingAutosave]);
 
-  return { autoSaveStatus, cancelPendingAutosave, isSaving, saveDraft, saveNow };
+  return { autoSaveStatus, cancelPendingAutosave, isSaving, saveConflict, clearSaveConflict: () => setSaveConflict(null), saveDraft, saveNow };
 }

--- a/packages/ui/src/components/views/files/useFileOperations.ts
+++ b/packages/ui/src/components/views/files/useFileOperations.ts
@@ -74,10 +74,22 @@ export function useFileOperations({
       if (operation === 'createFile') {
         const parent = target.path;
         const path = normalizePath(`${parent ? `${parent}/` : ''}${name}`);
-        const result = await files.writeFile!(path, '');
-        if (result.success) {
-          toast.success('File created');
-          await refreshDirectory(parent);
+        // Create-only guarded write: two creators racing the same missing
+        // path serialize per file; the loser receives a typed revision
+        // conflict instead of silently winning.
+        try {
+          const result = await files.writeFile!(path, '', { expectedRevision: null });
+          if (result.success) {
+            toast.success('File created');
+            await refreshDirectory(parent);
+          }
+        } catch (error) {
+          const reason = (error as { reason?: unknown })?.reason;
+          if (reason === 'file-revision-conflict' || (error as Error)?.name === 'FileRevisionConflictError') {
+            toast.error('File already exists');
+          } else {
+            throw error;
+          }
         }
       } else if (operation === 'createFolder') {
         const parent = target.path;

--- a/packages/ui/src/components/views/files/useFileStatReconciliation.test.ts
+++ b/packages/ui/src/components/views/files/useFileStatReconciliation.test.ts
@@ -14,6 +14,28 @@ describe('didFileStatChange', () => {
     )).toBe(true);
   });
 
+  test('treats opaque revision mismatch as an external change', () => {
+    expect(didFileStatChange(
+      { path: '/tmp/file', size: 2, mtimeMs: 10, revision: 'v1:2:10:aaa' },
+      { path: '/tmp/file', size: 2, mtimeMs: 10, revision: 'v1:2:10:bbb' },
+    )).toBe(true);
+    expect(didFileStatChange(
+      { path: '/tmp/file', size: 2, mtimeMs: 10, revision: 'v1:2:10:aaa' },
+      { path: '/tmp/file', size: 2, mtimeMs: 10, revision: 'v1:2:10:aaa' },
+    )).toBe(false);
+  });
+
+  test('falls back to size/mtime when either side omits a revision', () => {
+    expect(didFileStatChange(
+      { path: '/tmp/file', size: 2, mtimeMs: 10 },
+      { path: '/tmp/file', size: 2, mtimeMs: 10, revision: 'v1:2:10:bbb' },
+    )).toBe(false);
+    expect(didFileStatChange(
+      { path: '/tmp/file', size: 2, mtimeMs: 10, revision: 'v1:2:10:aaa' },
+      { path: '/tmp/file', size: 3, mtimeMs: 10 },
+    )).toBe(true);
+  });
+
   test('does not infer an mtime change when either snapshot omits it', () => {
     expect(didFileStatChange(
       { path: '/tmp/file', size: 2, mtimeMs: 10 },

--- a/packages/ui/src/components/views/files/useFileStatReconciliation.ts
+++ b/packages/ui/src/components/views/files/useFileStatReconciliation.ts
@@ -3,6 +3,10 @@ import * as React from 'react';
 import type { FileStatSnapshot } from './filesViewModel';
 
 export function didFileStatChange(previous: FileStatSnapshot, latest: FileStatSnapshot): boolean {
+  // Opaque revision mismatch is authoritative when both sides carry one.
+  if (typeof previous.revision === 'string' && typeof latest.revision === 'string') {
+    if (previous.revision !== latest.revision) return true;
+  }
   const mtimeChanged = latest.mtimeMs !== undefined
     && previous.mtimeMs !== undefined
     && latest.mtimeMs !== previous.mtimeMs;
@@ -13,7 +17,7 @@ type UseFileStatReconciliationOptions = {
   selectedPath: string | null;
   loadedPath: string | null;
   isDirty: boolean;
-  readStat: (path: string) => Promise<FileStatSnapshot | null>;
+  readStat: (path: string, options?: { knownRevision?: string | null }) => Promise<FileStatSnapshot | null>;
   onExternalChange: () => void;
   pollIntervalMs?: number;
 };
@@ -46,16 +50,22 @@ export function useFileStatReconciliation({
     const interval = window.setInterval(() => {
       if (document.hidden) return;
 
-      void readStat(selectedPath)
+      // Send the revision we already hold so the server can skip its
+      // read+hash when metadata is unchanged (the steady-state poll case).
+      const previous = lastStatRef.current;
+      const knownRevision = previous && previous.path === selectedPath && typeof previous.revision === 'string'
+        ? previous.revision
+        : null;
+      void readStat(selectedPath, { knownRevision })
         .then((latest) => {
           if (cancelled || !latest) return;
 
-          const previous = lastStatRef.current;
-          if (!previous || previous.path !== selectedPath) {
+          const prior = lastStatRef.current;
+          if (!prior || prior.path !== selectedPath) {
             lastStatRef.current = latest;
             return;
           }
-          if (!didFileStatChange(previous, latest) || isDirtyRef.current) return;
+          if (!didFileStatChange(prior, latest) || isDirtyRef.current) return;
 
           lastStatRef.current = latest;
           onExternalChange();

--- a/packages/ui/src/components/views/files/useFileViewerModes.test.tsx
+++ b/packages/ui/src/components/views/files/useFileViewerModes.test.tsx
@@ -1,0 +1,315 @@
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+
+import type { FileRevisionScope } from './fileRevisionCache';
+import type { DiagramSaveConflict } from './useFileViewerModes';
+
+// The hook only uses `toast` from the UI barrel; replace it so the test stays
+// self-contained and records error surfacing.
+const toastErrors: string[] = [];
+mock.module('@/components/ui', () => ({
+  toast: {
+    error: (message: string) => { toastErrors.push(message); },
+    success: () => undefined,
+  },
+}));
+
+const { useFileViewerModes } = await import('./useFileViewerModes');
+
+type HookOptions = Parameters<typeof useFileViewerModes>[0];
+type HookResult = ReturnType<typeof useFileViewerModes>;
+
+let latest: HookResult | null = null;
+const Probe = (props: HookOptions) => {
+  latest = useFileViewerModes(props);
+  return null;
+};
+
+const installMinimalDom = () => {
+  const descriptors = new Map<string, PropertyDescriptor | undefined>();
+  const setGlobal = (name: string, value: unknown) => {
+    descriptors.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
+    Object.defineProperty(globalThis, name, { configurable: true, writable: true, value });
+  };
+  class ElementStub {}
+  const documentStub: Record<string, unknown> = {
+    nodeType: 9,
+    defaultView: globalThis,
+    activeElement: null,
+    documentElement: { getAttribute: () => null },
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+  };
+  const container = {
+    nodeType: 1,
+    tagName: 'DIV',
+    nodeName: 'DIV',
+    namespaceURI: 'http://www.w3.org/1999/xhtml',
+    ownerDocument: documentStub,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+  };
+  documentStub.documentElement = container;
+  documentStub.body = container;
+  setGlobal('document', documentStub);
+  setGlobal('window', globalThis);
+  setGlobal('Element', ElementStub);
+  setGlobal('HTMLElement', ElementStub);
+  setGlobal('HTMLIFrameElement', ElementStub);
+  setGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  return {
+    container: container as unknown as Element,
+    restore: () => {
+      for (const [name, descriptor] of descriptors) {
+        if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+        else Reflect.deleteProperty(globalThis, name);
+      }
+    },
+  };
+};
+
+const roots: Root[] = [];
+const restoreFns: Array<() => void> = [];
+
+const renderHook = async (props: HookOptions) => {
+  const dom = installMinimalDom();
+  restoreFns.push(dom.restore);
+  const root = createRoot(dom.container);
+  roots.push(root);
+  await act(async () => {
+    root.render(<Probe {...props} />);
+  });
+};
+
+afterEach(async () => {
+  for (const root of roots.splice(0)) {
+    await act(async () => root.unmount());
+  }
+  restoreFns.splice(0).forEach((restore) => restore());
+  latest = null;
+  toastErrors.length = 0;
+});
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => { resolve = res; });
+  return { promise, resolve };
+};
+
+const baseScope: FileRevisionScope = {
+  runtimeKey: 'local',
+  root: '/repo',
+  path: '/repo/d.drawio',
+  generation: 1,
+};
+
+const baseOptions = (overrides: Partial<HookOptions>): HookOptions => ({
+  root: '/repo',
+  selectedPath: '/repo/d.drawio',
+  fileContent: '<base/>',
+  draftContent: '<base/>',
+  setDraftContent: () => undefined,
+  autoSaveEnabled: false,
+  writeFile: async () => ({ success: true, path: '/repo/d.drawio', revision: 'rev-2' }),
+  expectedRevision: 'rev-1',
+  captureSaveScope: () => baseScope,
+  currentSaveScope: () => baseScope,
+  onSaved: () => undefined,
+  onConflict: () => undefined,
+  ...overrides,
+});
+
+const conflictError = () => Object.assign(new Error('File has changed on disk'), {
+  name: 'FileRevisionConflictError',
+  reason: 'file-revision-conflict',
+  currentRevision: 'rev-9',
+  exists: true,
+  filePath: '/repo/d.drawio',
+});
+
+describe('useFileViewerModes diagram save authority', () => {
+  test('forwards the guarded revision and reports the save with scope', async () => {
+    const writes: Array<{ path: string; content: string; options?: unknown }> = [];
+    const onSavedCalls: Array<{ path: string; content: string; revision?: string | null; scope?: FileRevisionScope | null }> = [];
+    const drafts: string[] = [];
+    await renderHook(baseOptions({
+      writeFile: async (path, content, options) => {
+        writes.push({ path, content, options });
+        return { success: true, path, revision: 'rev-2' };
+      },
+      setDraftContent: (content) => { drafts.push(content); },
+      onSaved: (path, content, revision, scope) => { onSavedCalls.push({ path, content, revision, scope }); },
+    }));
+
+    let saved = false;
+    await act(async () => {
+      saved = await latest!.saveDiagramXml('/repo/d.drawio', '<xml/>');
+    });
+    expect(saved).toBe(true);
+    expect(writes).toEqual([{ path: '/repo/d.drawio', content: '<xml/>', options: { expectedRevision: 'rev-1' } }]);
+    expect(drafts).toEqual(['<xml/>']);
+    expect(onSavedCalls).toHaveLength(1);
+    expect(onSavedCalls[0]).toMatchObject({
+      path: '/repo/d.drawio',
+      content: '<xml/>',
+      revision: 'rev-2',
+      scope: baseScope,
+    });
+  });
+
+  test('no-ops when the diagram XML already matches the saved buffer', async () => {
+    let writes = 0;
+    await renderHook(baseOptions({
+      writeFile: async () => { writes += 1; return { success: true, path: '/repo/d.drawio', revision: 'rev-2' }; },
+    }));
+
+    let saved = false;
+    await act(async () => {
+      saved = await latest!.saveDiagramXml('/repo/d.drawio', '<xml/>');
+    });
+    expect(saved).toBe(true);
+    // Second attempt with identical XML must not write again.
+    await act(async () => {
+      saved = await latest!.saveDiagramXml('/repo/d.drawio', '<xml/>');
+    });
+    expect(saved).toBe(false);
+    expect(writes).toBe(1);
+  });
+
+  test('forces overwrite past the guarded revision when asked', async () => {
+    const writes: Array<{ options?: unknown }> = [];
+    await renderHook(baseOptions({
+      writeFile: async (_path, _content, options) => {
+        writes.push({ options });
+        return { success: true, path: '/repo/d.drawio', revision: 'rev-3' };
+      },
+    }));
+
+    let saved = false;
+    await act(async () => {
+      saved = await latest!.saveDiagramXml('/repo/d.drawio', '<xml/>', { overwrite: true });
+    });
+    expect(saved).toBe(true);
+    expect(writes[0]?.options).toEqual({ expectedRevision: 'rev-1', overwrite: true });
+  });
+
+  test('skips the write when the diagram is no longer the selected document', async () => {
+    let writes = 0;
+    await renderHook(baseOptions({
+      writeFile: async () => { writes += 1; return { success: true, path: '/repo/d.drawio', revision: 'rev-2' }; },
+      captureSaveScope: () => ({ ...baseScope, path: '/repo/other.drawio' }),
+    }));
+
+    let saved: boolean | undefined;
+    await act(async () => {
+      saved = await latest!.saveDiagramXml('/repo/d.drawio', '<xml/>');
+    });
+    expect(saved).toBe(false);
+    expect(writes).toBe(0);
+  });
+
+  test('drops stale save completions after a selection/generation switch', async () => {
+    const onSavedCalls: unknown[] = [];
+    const drafts: string[] = [];
+    let currentGeneration = 1;
+    const writeGate = deferred<void>();
+    let writes = 0;
+    await renderHook(baseOptions({
+      writeFile: async () => {
+        writes += 1;
+        await writeGate.promise;
+        return { success: true, path: '/repo/d.drawio', revision: 'rev-2' };
+      },
+      setDraftContent: (content) => { drafts.push(content); },
+      onSaved: () => { onSavedCalls.push('saved'); },
+      currentSaveScope: () => ({ ...baseScope, generation: currentGeneration }),
+    }));
+
+    let saved: boolean | undefined;
+    await act(async () => {
+      const pending = latest!.saveDiagramXml('/repo/d.drawio', '<xml/>').then((value) => { saved = value; });
+      // The selection switches to another file (generation bump) while the
+      // write is in flight; the completion must not clobber the new document.
+      currentGeneration = 2;
+      writeGate.resolve();
+      await pending;
+    });
+    expect(writes).toBe(1);
+    expect(saved).toBe(false);
+    expect(drafts).toEqual([]);
+    expect(onSavedCalls).toHaveLength(0);
+  });
+
+  test('drops stale conflict completions after a selection/generation switch', async () => {
+    const onConflictCalls: DiagramSaveConflict[] = [];
+    let currentGeneration = 1;
+    const writeGate = deferred<void>();
+    await renderHook(baseOptions({
+      writeFile: async () => {
+        await writeGate.promise;
+        throw conflictError();
+      },
+      onConflict: (conflict) => { onConflictCalls.push(conflict); },
+      currentSaveScope: () => ({ ...baseScope, generation: currentGeneration }),
+    }));
+
+    let saved: boolean | undefined;
+    await act(async () => {
+      const pending = latest!.saveDiagramXml('/repo/d.drawio', '<xml/>').then((value) => { saved = value; });
+      currentGeneration = 2;
+      writeGate.resolve();
+      await pending;
+    });
+    expect(saved).toBe(false);
+    expect(onConflictCalls).toHaveLength(0);
+    expect(toastErrors).toEqual([]);
+  });
+
+  test('surfaces typed conflicts with the preserved diagram XML', async () => {
+    const onConflictCalls: DiagramSaveConflict[] = [];
+    const drafts: string[] = [];
+    await renderHook(baseOptions({
+      writeFile: async () => { throw conflictError(); },
+      setDraftContent: (content) => { drafts.push(content); },
+      onConflict: (conflict) => { onConflictCalls.push(conflict); },
+    }));
+
+    let saved: boolean | undefined;
+    await act(async () => {
+      saved = await latest!.saveDiagramXml('/repo/d.drawio', '<xml/>');
+    });
+    expect(saved).toBe(false);
+    expect(drafts).toEqual([]);
+    expect(onConflictCalls).toHaveLength(1);
+    expect(onConflictCalls[0]).toMatchObject({
+      path: '/repo/d.drawio',
+      currentRevision: 'rev-9',
+      exists: true,
+      xml: '<xml/>',
+    });
+    expect(toastErrors).toEqual([]);
+  });
+
+  test('toasts non-conflict write failures without touching buffers', async () => {
+    const onConflictCalls: unknown[] = [];
+    const onSavedCalls: unknown[] = [];
+    const drafts: string[] = [];
+    await renderHook(baseOptions({
+      writeFile: async () => { throw new Error('Disk full'); },
+      setDraftContent: (content) => { drafts.push(content); },
+      onSaved: () => { onSavedCalls.push('saved'); },
+      onConflict: () => { onConflictCalls.push('conflict'); },
+    }));
+
+    let saved: boolean | undefined;
+    await act(async () => {
+      saved = await latest!.saveDiagramXml('/repo/d.drawio', '<xml/>');
+    });
+    expect(saved).toBe(false);
+    expect(toastErrors).toEqual(['Disk full']);
+    expect(drafts).toEqual([]);
+    expect(onSavedCalls).toEqual([]);
+    expect(onConflictCalls).toEqual([]);
+  });
+});

--- a/packages/ui/src/components/views/files/useFileViewerModes.ts
+++ b/packages/ui/src/components/views/files/useFileViewerModes.ts
@@ -1,10 +1,12 @@
 import * as React from 'react';
 
 import { toast } from '@/components/ui';
-import type { FilesAPI } from '@/lib/api/types';
+import type { FileContentRevision, FilesAPI } from '@/lib/api/types';
+import { isFileRevisionConflict } from '@/lib/api/files-errors';
 import { isDrawioFile } from '@/lib/toolHelpers';
 import { useFilesViewTabsStore } from '@/stores/useFilesViewTabsStore';
-import type { FileStatSnapshot } from './filesViewModel';
+import { buildGuardedWriteOptions, isSaveScopeCurrent, type FileRevisionScope } from './fileRevisionCache';
+import type { FileEditorConflict } from './useFileEditorSave';
 
 export type TextViewMode = 'view' | 'edit';
 export type PreviewViewMode = 'preview' | 'edit';
@@ -34,6 +36,11 @@ function storeMode(key: string, mode: string) {
   }
 }
 
+export type DiagramSaveConflict = FileEditorConflict & {
+  /** The diagram XML that failed to write; never cleared by the conflict. */
+  xml: string;
+};
+
 type UseFileViewerModesOptions = {
   root: string;
   selectedPath: string | null;
@@ -42,8 +49,16 @@ type UseFileViewerModesOptions = {
   setDraftContent: (content: string) => void;
   autoSaveEnabled: boolean;
   writeFile: FilesAPI['writeFile'];
-  readStat: (path: string) => Promise<FileStatSnapshot | null>;
-  recordStat: (stat: FileStatSnapshot | null) => void;
+  /** Opaque base revision for guarded diagram writes; undefined = legacy. */
+  expectedRevision?: FileContentRevision;
+  /** Captures the runtime/root/path/generation authority for a save started now. */
+  captureSaveScope?: () => FileRevisionScope | null;
+  /** Resolves the current authority for stale-completion checks at commit time. */
+  currentSaveScope?: () => FileRevisionScope | null;
+  /** Same contract as the text editor save: revision/scope bookkeeping. */
+  onSaved?: (path: string, content: string, revision?: string | null, scope?: FileRevisionScope | null) => void;
+  /** Typed revision conflict; the owner surfaces the shared conflict dialog. */
+  onConflict?: (conflict: DiagramSaveConflict) => void;
 };
 
 /** Owns per-file viewer choices and the Draw.io preview document lifecycle. Manual mode switching stays; the default is always edit. */
@@ -55,8 +70,11 @@ export function useFileViewerModes({
   setDraftContent,
   autoSaveEnabled,
   writeFile,
-  readStat,
-  recordStat,
+  expectedRevision,
+  captureSaveScope,
+  currentSaveScope,
+  onSaved,
+  onConflict,
 }: UseFileViewerModesOptions) {
   const [textViewMode, setTextViewMode] = React.useState<TextViewMode>('edit');
   const [mdViewMode, setMdViewMode] = React.useState<PreviewViewMode>('edit');
@@ -74,6 +92,18 @@ export function useFileViewerModes({
   const diagramAutoSaveTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
   const diagramSavedTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingPreviewFrameRef = React.useRef<number | null>(null);
+  // Authority callbacks are read through refs so an in-flight diagram save
+  // verifies against the latest render's scope, not the closure it started in.
+  const expectedRevisionRef = React.useRef(expectedRevision);
+  expectedRevisionRef.current = expectedRevision;
+  const captureSaveScopeRef = React.useRef(captureSaveScope);
+  captureSaveScopeRef.current = captureSaveScope;
+  const currentSaveScopeRef = React.useRef(currentSaveScope);
+  currentSaveScopeRef.current = currentSaveScope;
+  const onSavedRef = React.useRef(onSaved);
+  onSavedRef.current = onSaved;
+  const onConflictRef = React.useRef(onConflict);
+  onConflictRef.current = onConflict;
 
   const cancelDiagramTransitions = React.useCallback(() => {
     if (diagramAutoSaveTimerRef.current) {
@@ -149,20 +179,54 @@ export function useFileViewerModes({
     });
   }, [cancelDiagramTransitions, draftContent, fileContent, root, selectedPath, setDraftContent]);
 
-  const saveDiagramXml = React.useCallback(async (path: string, xml: string) => {
+  const isDiagramSaveCurrent = React.useCallback((saveScope: FileRevisionScope | null) => {
+    if (!saveScope) return true; // No authority provider: legacy behavior.
+    return isSaveScopeCurrent(saveScope, currentSaveScopeRef.current?.() ?? null);
+  }, []);
+
+  const saveDiagramXml = React.useCallback(async (path: string, xml: string, options?: { overwrite?: boolean }) => {
     if (!writeFile || xml === diagramSavedXmlRef.current) return false;
-    const result = await writeFile(path, xml);
-    if (!result?.success) {
-      toast.error('Failed to write file');
+    // Capture the save authority before awaiting so the completion can be
+    // verified against it; selection/reload/runtime switches invalidate it.
+    const saveScope = captureSaveScopeRef.current?.() ?? null;
+    if (saveScope && saveScope.path !== path) {
+      // The diagram being written is no longer the selected document.
       return false;
     }
-
-    recordDiagramContent(xml);
-    setDraftContent(xml);
-    const stat = await readStat(path).catch(() => null);
-    if (stat) recordStat(stat);
-    return true;
-  }, [readStat, recordDiagramContent, recordStat, setDraftContent, writeFile]);
+    try {
+      const result = await writeFile(path, xml, buildGuardedWriteOptions(expectedRevisionRef.current, options?.overwrite));
+      if (!result?.success) {
+        toast.error('Failed to write file');
+        return false;
+      }
+      if (!isDiagramSaveCurrent(saveScope)) {
+        // Stale completion: the bytes are on disk, but the buffer no longer
+        // owns the document. Dropping the completion keeps the newly selected
+        // document's draft and stat baseline from being clobbered by the old
+        // diagram.
+        return false;
+      }
+      recordDiagramContent(xml);
+      setDraftContent(xml);
+      onSavedRef.current?.(path, xml, result?.revision, saveScope);
+      return true;
+    } catch (error) {
+      if (isFileRevisionConflict(error)) {
+        // Preserve the diagram edits (refs stay untouched) and surface the
+        // typed conflict through the shared reload/overwrite/compare dialog.
+        if (!isDiagramSaveCurrent(saveScope)) return false;
+        onConflictRef.current?.({
+          path,
+          currentRevision: error.currentRevision ?? null,
+          exists: error.exists,
+          xml,
+        });
+        return false;
+      }
+      toast.error(error instanceof Error ? error.message : 'Save failed');
+      return false;
+    }
+  }, [isDiagramSaveCurrent, recordDiagramContent, setDraftContent, writeFile]);
 
   const showDiagramSaved = React.useCallback(() => {
     setDiagramSaved(true);
@@ -170,12 +234,12 @@ export function useFileViewerModes({
     diagramSavedTimerRef.current = setTimeout(() => setDiagramSaved(false), DIAGRAM_SAVED_STATUS_MS);
   }, []);
 
-  const saveDiagramNow = React.useCallback(async (path: string, xml: string) => {
+  const saveDiagramNow = React.useCallback(async (path: string, xml: string, options?: { overwrite?: boolean }) => {
     if (diagramAutoSaveTimerRef.current) {
       clearTimeout(diagramAutoSaveTimerRef.current);
       diagramAutoSaveTimerRef.current = null;
     }
-    const saved = await saveDiagramXml(path, xml);
+    const saved = await saveDiagramXml(path, xml, options);
     if (saved) showDiagramSaved();
     return saved;
   }, [saveDiagramXml, showDiagramSaved]);
@@ -187,11 +251,10 @@ export function useFileViewerModes({
 
     diagramAutoSaveTimerRef.current = setTimeout(() => {
       diagramAutoSaveTimerRef.current = null;
+      // saveDiagramXml owns error surfacing and stale-completion drops.
       void saveDiagramXml(selectedPath, xml).then((saved) => {
         if (!saved) return;
         showDiagramSaved();
-      }).catch((error) => {
-        toast.error(error instanceof Error ? error.message : 'Save failed');
       });
     }, DIAGRAM_AUTO_SAVE_DELAY_MS);
   }, [autoSaveEnabled, drawioViewMode, saveDiagramXml, selectedPath, showDiagramSaved, writeFile]);

--- a/packages/ui/src/contexts/content-cache-owner.test.ts
+++ b/packages/ui/src/contexts/content-cache-owner.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import type { FilesAPI } from "@/lib/api/types"
+import { FileRevisionConflictError } from "@/lib/api/files-errors"
 import { createContentCachedFiles } from "./content-cache-owner"
 
 const deferred = <T>() => {
@@ -83,7 +84,107 @@ describe("content cache owner", () => {
       .rejects.toThrow("File cache owner disposed")
   })
 
-  test("runtime endpoint changes clear cache but keep serving reads", async () => {
+  test("forwards guarded write options to the underlying API", async () => {
+    const calls: Array<{ path: string; content: string; options?: unknown }> = []
+    const owner = createContentCachedFiles({
+      readFile: async (path: string) => ({ path, content: "base", revision: "v1:4:1:abc" }),
+      statFile: async () => ({ isFile: true, isDirectory: false, size: 4, mtimeMs: 1 }),
+      writeFile: async (path: string, content: string, options?: unknown) => {
+        calls.push({ path, content, options })
+        return { success: true, path, revision: "v1:4:2:def" }
+      },
+    } as unknown as FilesAPI)
+
+    const result = await owner.files.writeFile!("file.ts", "next", { expectedRevision: "v1:4:1:abc" })
+    expect(result.success).toBe(true)
+    expect(result.revision).toBe("v1:4:2:def")
+    expect(calls).toHaveLength(1)
+    expect(calls[0].options).toEqual({ expectedRevision: "v1:4:1:abc" })
+    owner.dispose()
+  })
+
+  test("forwards overwrite option and create-only null expectedRevision", async () => {
+    const calls: Array<unknown> = []
+    const owner = createContentCachedFiles({
+      writeFile: async (_path: string, _content: string, options?: unknown) => {
+        calls.push(options)
+        return { success: true, path: _path }
+      },
+    } as unknown as FilesAPI)
+
+    await owner.files.writeFile!("new.ts", "", { expectedRevision: null })
+    await owner.files.writeFile!("new.ts", "x", { expectedRevision: "v1:1:2:aa", overwrite: true })
+    expect(calls[0]).toEqual({ expectedRevision: null })
+    expect(calls[1]).toEqual({ expectedRevision: "v1:1:2:aa", overwrite: true })
+    owner.dispose()
+  })
+
+  test("cached hits preserve the exact read revision", async () => {
+    let reads = 0
+    const owner = createContentCachedFiles({
+      readFile: async (path: string) => ({ path, content: `value-${++reads}`, revision: `rev-${reads}` }),
+      statFile: async () => ({ isFile: true, isDirectory: false, size: 7, mtimeMs: 1 }),
+    } as unknown as FilesAPI)
+
+    const first = await owner.files.readFile!("file.ts")
+    const second = await owner.files.readFile!("file.ts")
+    expect(reads).toBe(1)
+    expect(second.content).toBe(first.content)
+    expect(second.revision).toBe("rev-1")
+    owner.dispose()
+  })
+
+  test("propagates typed conflicts and invalidates cached content", async () => {
+    let reads = 0
+    const owner = createContentCachedFiles({
+      readFile: async (path: string) => ({ path, content: `value-${++reads}`, revision: `rev-${reads}` }),
+      statFile: async () => ({ isFile: true, isDirectory: false, size: 7, mtimeMs: 1 }),
+      writeFile: async () => {
+        throw new FileRevisionConflictError("File has changed on disk", { currentRevision: "rev-9", exists: true })
+      },
+    } as unknown as FilesAPI)
+
+    await owner.files.readFile!("file.ts")
+    await expect(owner.files.writeFile!("file.ts", "next", { expectedRevision: "rev-1" }))
+      .rejects.toBeInstanceOf(FileRevisionConflictError)
+    expect(reads).toBe(1)
+    // The write invalidates the entry even on conflict: the next read refetches.
+    const after = await owner.files.readFile!("file.ts")
+    expect(reads).toBe(2)
+    expect(after.content).toBe("value-2")
+    expect(after.revision).toBe("rev-2")
+    owner.dispose()
+  })
+
+  test("guarded writes invalidate the cache and reads adopt the new revision", async () => {
+    let content = "base"
+    let mtime = 1
+    let reads = 0
+    const owner = createContentCachedFiles({
+      readFile: async (path: string) => {
+        reads += 1
+        return { path, content, revision: `rev:${content}:${mtime}` }
+      },
+      statFile: async () => ({ isFile: true, isDirectory: false, size: content.length, mtimeMs: mtime }),
+      writeFile: async (path: string, next: string) => {
+        content = next
+        mtime += 1
+        return { success: true, path, revision: `rev:${content}:${mtime}` }
+      },
+    } as unknown as FilesAPI)
+
+    const first = await owner.files.readFile!("file.ts")
+    expect(first.revision).toBe("rev:base:1")
+    const written = await owner.files.writeFile!("file.ts", "next", { expectedRevision: first.revision })
+    expect(written.revision).toBe("rev:next:2")
+    const second = await owner.files.readFile!("file.ts")
+    expect(second.content).toBe("next")
+    expect(second.revision).toBe("rev:next:2")
+    expect(reads).toBe(2)
+    owner.dispose()
+  })
+
+  test("runtime endpoint changes clear cached revisions", async () => {
     const originalWindow = globalThis.window
     const events = new EventTarget()
     Object.defineProperty(globalThis, "window", {
@@ -98,11 +199,11 @@ describe("content cache owner", () => {
     try {
       let reads = 0
       const owner = createContentCachedFiles({
-        readFile: async (path: string) => ({ path, content: `value-${++reads}` }),
+        readFile: async (path: string) => ({ path, content: `value-${++reads}`, revision: `rev-${reads}` }),
         statFile: async () => ({ isFile: true, isDirectory: false, size: 7, mtimeMs: 1 }),
       } as unknown as FilesAPI)
 
-      expect((await owner.files.readFile!("notes.txt")).content).toBe("value-1")
+      expect((await owner.files.readFile!("notes.txt")).revision).toBe("rev-1")
       window.dispatchEvent(new CustomEvent("pichamber:runtime-endpoint-will-change", {
         detail: {
           apiBaseUrl: "http://127.0.0.1:3902",
@@ -111,7 +212,9 @@ describe("content cache owner", () => {
           previousRuntimeKey: "url:http://127.0.0.1:3901",
         },
       }))
-      expect((await owner.files.readFile!("notes.txt")).content).toBe("value-2")
+      const after = await owner.files.readFile!("notes.txt")
+      expect(after.content).toBe("value-2")
+      expect(after.revision).toBe("rev-2")
       expect(reads).toBe(2)
       owner.dispose()
     } finally {

--- a/packages/ui/src/contexts/content-cache-owner.ts
+++ b/packages/ui/src/contexts/content-cache-owner.ts
@@ -1,9 +1,9 @@
-import type { FilesAPI } from '@/lib/api/types';
+import type { FileContentRevision, FilesAPI } from '@/lib/api/types';
 import { subscribeRuntimeEndpointWillChange } from '@/lib/runtime-switch';
 
 const MAX_ENTRIES = 40;
 const MAX_BYTES = 20 * 1024 * 1024;
-type Entry = { content: string; path: string; sourcePath: string; size: number; mtimeMs: number; bytes: number };
+type Entry = { content: string; path: string; sourcePath: string; size: number; mtimeMs: number; bytes: number; revision?: FileContentRevision };
 
 /**
  * Content-cached `FilesAPI.readFile` wrapper.
@@ -47,7 +47,7 @@ export function createContentCachedFiles(files: FilesAPI): { files: FilesAPI; di
   const cacheResult = (
     key: string,
     sourcePath: string,
-    result: { content: string; path: string },
+    result: { content: string; path: string; revision?: FileContentRevision },
     stat: { isFile: boolean; size: number; mtimeMs?: number },
   ) => {
     if (!active || !stat.isFile || stat.mtimeMs === undefined) return result;
@@ -69,7 +69,7 @@ export function createContentCachedFiles(files: FilesAPI): { files: FilesAPI; di
     path: string,
     options: Parameters<NonNullable<FilesAPI['readFile']>>[1] | undefined,
     capturedGeneration: number,
-  ): Promise<{ content: string; path: string }> => {
+  ): Promise<{ content: string; path: string; revision?: FileContentRevision }> => {
     const before = await files.statFile?.(path, options).catch(() => null);
     const result = await files.readFile!(path, options);
     const after = await files.statFile?.(path, options).catch(() => null);
@@ -99,7 +99,9 @@ export function createContentCachedFiles(files: FilesAPI): { files: FilesAPI; di
         }
         cache.delete(key);
         cache.set(key, hit);
-        return { content: hit.content, path: hit.path };
+        // Serve the cached bytes with their exact captured revision so a
+        // cached read can still authorize a guarded save for those bytes.
+        return { content: hit.content, path: hit.path, revision: hit.revision };
       }
     : undefined;
 
@@ -122,7 +124,12 @@ export function createContentCachedFiles(files: FilesAPI): { files: FilesAPI; di
   const cachedFiles: FilesAPI = {
     ...files,
     readFile: cachedReadFile,
-    writeFile: files.writeFile ? (path, content) => mutate([path], () => files.writeFile!(path, content)) : undefined,
+    // Guarded saves must reach the underlying API with their write options
+    // intact; dropping them would silently degrade every guarded save made
+    // through this cache into a legacy unconditional write.
+    writeFile: files.writeFile
+      ? (path, content, options) => mutate([path], () => files.writeFile!(path, content, options))
+      : undefined,
     delete: files.delete ? (path) => mutate([path], () => files.delete!(path)) : undefined,
     rename: files.rename ? (oldPath, newPath) => mutate([oldPath, newPath], () => files.rename!(oldPath, newPath)) : undefined,
   };

--- a/packages/ui/src/lib/api/files-errors.test.ts
+++ b/packages/ui/src/lib/api/files-errors.test.ts
@@ -1,28 +1,47 @@
 import { describe, expect, test } from 'bun:test';
 
 import {
+  FileRevisionConflictError,
   FilesystemError,
-  isFilesystemError,
+  isFileRevisionConflict,
   parseFilesystemErrorReason,
-} from './files-errors';
+} from '@/lib/api/files-errors';
 
-describe('FilesystemError', () => {
-  test('retains a stable reason and HTTP status', () => {
-    const error = new FilesystemError('Access denied', {
-      reason: 'os-permission',
-      status: 403,
+describe('file revision conflict errors', () => {
+  test('carries typed conflict details for explicit overwrite workflows', () => {
+    const error = new FileRevisionConflictError('File has changed on disk', {
+      currentRevision: 'v1:8:2000:def',
+      exists: true,
+      path: '/repo/a.txt',
     });
-
-    expect(isFilesystemError(error)).toBe(true);
-    expect(error.name).toBe('FilesystemError');
-    expect(error.message).toBe('Access denied');
-    expect(error.reason).toBe('os-permission');
-    expect(error.status).toBe(403);
+    expect(error).toBeInstanceOf(FilesystemError);
+    expect(error.reason).toBe('file-revision-conflict');
+    expect(error.status).toBe(409);
+    expect(error.currentRevision).toBe('v1:8:2000:def');
+    expect(error.exists).toBe(true);
+    expect(error.filePath).toBe('/repo/a.txt');
+    expect(isFileRevisionConflict(error)).toBe(true);
   });
 
-  test('normalizes unsupported response reasons to unknown', () => {
+  test('represents deleted files with null revision', () => {
+    const error = new FileRevisionConflictError('File has changed on disk', {
+      currentRevision: null,
+      exists: false,
+      path: '/repo/gone.txt',
+    });
+    expect(error.exists).toBe(false);
+    expect(error.currentRevision).toBeNull();
+    expect(isFileRevisionConflict(error)).toBe(true);
+  });
+
+  test('rejects non-conflict errors', () => {
+    expect(isFileRevisionConflict(new FilesystemError('nope', { reason: 'unknown' }))).toBe(false);
+    expect(isFileRevisionConflict(new Error('nope'))).toBe(false);
+  });
+
+  test('parses the conflict reason from wire payloads', () => {
+    expect(parseFilesystemErrorReason('file-revision-conflict')).toBe('file-revision-conflict');
     expect(parseFilesystemErrorReason('os-permission')).toBe('os-permission');
-    expect(parseFilesystemErrorReason('made-up')).toBe('unknown');
-    expect(parseFilesystemErrorReason(undefined)).toBe('unknown');
+    expect(parseFilesystemErrorReason('bogus')).toBe('unknown');
   });
 });

--- a/packages/ui/src/lib/api/files-errors.ts
+++ b/packages/ui/src/lib/api/files-errors.ts
@@ -3,6 +3,7 @@ export type FilesystemErrorReason =
   | 'not-found'
   | 'not-directory'
   | 'invalid-response'
+  | 'file-revision-conflict'
   | 'unknown';
 
 export class FilesystemError extends Error {
@@ -16,6 +17,31 @@ export class FilesystemError extends Error {
     this.status = options.status;
   }
 }
+
+/** Typed save conflict carrying the current server revision (finding #8). */
+export class FileRevisionConflictError extends FilesystemError {
+  readonly currentRevision: string | null;
+  readonly exists: boolean;
+  readonly filePath: string;
+
+  constructor(message: string, options: {
+    currentRevision?: string | null;
+    exists?: boolean;
+    path?: string;
+    status?: number;
+  } = {}) {
+    super(message, { reason: 'file-revision-conflict', status: options.status ?? 409 });
+    this.name = 'FileRevisionConflictError';
+    this.currentRevision = options.currentRevision ?? null;
+    this.exists = options.exists ?? (options.currentRevision != null);
+    this.filePath = options.path ?? '';
+  }
+}
+
+export const isFileRevisionConflict = (error: unknown): error is FileRevisionConflictError => (
+  error instanceof FileRevisionConflictError
+  || (isFilesystemError(error) && error.reason === 'file-revision-conflict')
+);
 
 export const isFilesystemError = (error: unknown): error is FilesystemError => (
   error instanceof FilesystemError
@@ -33,6 +59,7 @@ export const parseFilesystemErrorReason = (value: unknown): FilesystemErrorReaso
     case 'not-found':
     case 'not-directory':
     case 'invalid-response':
+    case 'file-revision-conflict':
       return value;
     default:
       return 'unknown';

--- a/packages/ui/src/lib/api/types.ts
+++ b/packages/ui/src/lib/api/types.ts
@@ -540,16 +540,68 @@ interface FileReadOptions {
   outsideFileGrant?: string;
   optional?: boolean;
   directory?: string;
+  /**
+   * Stat-only optimization: the exact revision the client already holds for
+   * this file. When size+mtime still match, the server skips the read+hash
+   * and echoes the revision unchanged. Opaque: never modified or reinterpreted.
+   */
+  knownRevision?: string | null;
+}
+
+/**
+ * Opaque read-content revision for file-save conflict detection (finding #8).
+ * Clients retain the exact string with buffer/runtime/path/generation and
+ * send it back as `expectedRevision`. `null` means the file was missing at
+ * read time (create-only expectation). `undefined` means the server did not
+ * supply a revision (legacy) and must not be used for guarded saves.
+ */
+export type FileContentRevision = string | null | undefined;
+
+export interface FileReadResult {
+  content: string;
+  path: string;
+  /** Opaque revision; `null` when the optional read found no file. */
+  revision?: FileContentRevision;
+  /** False when an optional read found no file. */
+  exists?: boolean;
+}
+
+export interface FileStatResult {
+  path: string;
+  isFile: boolean;
+  size: number;
+  mtimeMs?: number;
+  /** Opaque revision matching `readFile` for the same bytes. */
+  revision?: FileContentRevision;
+  exists?: boolean;
+}
+
+export interface FileWriteOptions {
+  /**
+   * Guarded-save expectation: exact revision from the base read, `null` to
+   * require a missing file (create-only), or omitted for legacy
+   * unconditional writes. `overwrite: true` forces explicit overwrite.
+   */
+  expectedRevision?: string | null;
+  overwrite?: boolean;
+}
+
+export interface FileWriteResult {
+  success: boolean;
+  path: string;
+  /** New current revision after write (or the existing revision for no-ops). */
+  revision?: string | null;
+  noop?: boolean;
 }
 
 export interface FilesAPI {
   listDirectory(path: string, options?: ListDirectoryOptions): Promise<DirectoryListResult>;
   search(payload: FileSearchQuery): Promise<FileSearchResult[]>;
   createDirectory(path: string): Promise<{ success: boolean; path: string }>;
-  statFile?(path: string, options?: FileReadOptions): Promise<{ path: string; isFile: boolean; size: number; mtimeMs?: number }>;
-  readFile?(path: string, options?: FileReadOptions): Promise<{ content: string; path: string }>;
+  statFile?(path: string, options?: FileReadOptions): Promise<FileStatResult>;
+  readFile?(path: string, options?: FileReadOptions): Promise<FileReadResult>;
   readFileBinary?(path: string, options?: FileReadOptions): Promise<{ dataUrl: string; path: string }>;
-  writeFile?(path: string, content: string): Promise<{ success: boolean; path: string }>;
+  writeFile?(path: string, content: string, options?: FileWriteOptions): Promise<FileWriteResult>;
   delete?(path: string): Promise<{ success: boolean }>;
   rename?(oldPath: string, newPath: string): Promise<{ success: boolean; path: string }>;
   revealPath?(path: string): Promise<{ success: boolean }>;

--- a/packages/ui/src/types/bun-test.d.ts
+++ b/packages/ui/src/types/bun-test.d.ts
@@ -10,10 +10,13 @@ declare module "bun:test" {
     toBeTruthy(): void;
     toBeFalsy(): void;
     toBeNull(): void;
+    toBeUndefined(): void;
+    toMatchObject(expected: unknown): void;
     toThrow(expected?: string | RegExp | (new (...args: never[]) => unknown)): void;
     toContain(expected: unknown): void;
     toBeDefined(): void;
     rejects: {
+      toBeInstanceOf(expected: unknown): Promise<void>;
       toThrow(expected?: string | RegExp | (new (...args: never[]) => unknown)): Promise<void>;
     };
     toBeGreaterThan(expected: number): void;

--- a/packages/web/server/lib/fs/DOCUMENTATION.md
+++ b/packages/web/server/lib/fs/DOCUMENTATION.md
@@ -14,6 +14,7 @@ Own filesystem API behavior for the web server runtime, including workspace-boun
     - `POST /api/fs/mkdir`
     - `POST /api/fs/clone`
     - `GET /api/fs/read`
+    - `GET /api/fs/stat`
     - `GET /api/fs/raw`
     - `GET /api/fs/serve/:path(*)`
     - `POST /api/fs/write`
@@ -28,6 +29,13 @@ Own filesystem API behavior for the web server runtime, including workspace-boun
 - `createFsSearchRuntime({ fsPromises, path, spawn, resolveGitBinaryForSpawn })` from `search.js`
   - Returns `{ searchFilesystemFiles(rootPath, options) }`.
   - Supports fuzzy matching, hidden-file handling, and optional `git check-ignore` filtering.
+
+## File-save revisions (finding #8)
+- Revisions are opaque exact strings (`v1:<size>:<mtimeMs>[:<sha256>]`, 5 MiB hash ceiling). `null` means missing at read time; `undefined` means legacy/unknown and never guards a save.
+- `GET /api/fs/read` returns `x-pichamber-file-revision` plus `Cache-Control: no-store`; optional missing reads also return `x-pichamber-file-exists: false`.
+- `GET /api/fs/stat` returns `{ revision, exists }` and accepts `?knownRevision=` to echo the client revision when size+mtime (and hash-ceiling category) match, skipping read+hash.
+- `POST /api/fs/write` accepts `{ expectedRevision, overwrite }`. Omitting `expectedRevision` keeps legacy unconditional writes. `expectedRevision: null` (or `'missing'`) is create-only. `overwrite: true` is the explicit force path. Mismatches return HTTP 409 `{ reason: 'file-revision-conflict', currentRevision, exists, path }`. Identical content is an idempotent `{ noop: true }` success without rewrite. Writes serialize per canonical (realpath) file with re-keying for create/re-point races, preserve mode across atomic temp+rename, and never normalize line endings.
+- External writers that bypass the protocol are non-cooperating: last writer wins on disk, and the next cooperating save conflicts instead of silently overwriting.
 
 ## Composition contract with `index.js`
 - `index.js` provides composition-time dependencies only (platform primitives + callbacks such as `resolveProjectDirectory`, `normalizeDirectoryPath`, and `buildAugmentedPath`).

--- a/packages/web/server/lib/fs/DOCUMENTATION.md
+++ b/packages/web/server/lib/fs/DOCUMENTATION.md
@@ -35,10 +35,11 @@ Own filesystem API behavior for the web server runtime, including workspace-boun
 
 ## File-save revisions (finding #8)
 - Revisions are opaque exact strings (`v1:<size>:<mtimeMs>[:<sha256>]`, 5 MiB hash ceiling). `null` means missing at read time; `undefined` means legacy/unknown and never guards a save.
-- `GET /api/fs/read` returns `x-pichamber-file-revision` plus `Cache-Control: no-store`; optional missing reads also return `x-pichamber-file-exists: false`.
+- `GET /api/fs/read` returns `x-pichamber-file-revision` plus `Cache-Control: no-store`; optional missing reads also return `x-pichamber-file-exists: false`. The server CORS policy exposes both headers so HMR, packaged desktop, and Capacitor clients retain revision authority across origins.
 - `GET /api/fs/stat` returns `{ revision, exists }` and accepts `?knownRevision=` to echo the client revision when size+mtime (and hash-ceiling category) match, skipping read+hash.
 - `POST /api/fs/write` accepts `{ expectedRevision, overwrite }`. Omitting `expectedRevision` keeps legacy unconditional writes. `expectedRevision: null` (or `'missing'`) is create-only. `overwrite: true` is the explicit force path. Mismatches return HTTP 409 `{ reason: 'file-revision-conflict', currentRevision, exists, path }`. Identical content is an idempotent `{ noop: true }` success without rewrite. Writes serialize per canonical (realpath) file with re-keying for create/re-point races, preserve mode across atomic temp+rename, and never normalize line endings.
 - External writers that bypass the protocol are non-cooperating: last writer wins on disk, and the next cooperating save conflicts instead of silently overwriting.
+- The exact `~` global-session sentinel resolves to the server user's home directory before workspace validation. Other relative paths keep normal server-cwd resolution.
 
 ## Composition contract with `index.js`
 - `index.js` provides composition-time dependencies only (platform primitives + callbacks such as `resolveProjectDirectory`, `normalizeDirectoryPath`, and `buildAugmentedPath`).

--- a/packages/web/server/lib/fs/routes.js
+++ b/packages/web/server/lib/fs/routes.js
@@ -1,6 +1,7 @@
 import { createRealpathCache } from '../path-realpath-cache.js';
 import nodeFsPromises from 'node:fs/promises';
 import nodePath from 'node:path';
+import { createHash } from 'node:crypto';
 import { resolvePiChamberDataDir } from '../pichamber-data-dir.js';
 import { createFsSearchRuntime } from './search.js';
 import { pickHostDirectory } from './pick-directory.js';
@@ -27,6 +28,155 @@ const isOsPermissionError = (error) => (
 
 const sendOsPermissionDenied = (res, message) => (
   res.status(403).json({ error: message, reason: 'os-permission' })
+);
+
+// File-save revision protocol (finding #8).
+//
+// Cooperating PiChamber writers attach the opaque `expectedRevision` they read
+// to every save. The server serializes compare+atomic-replace per canonical
+// file so two writers with the same base revision cannot both win: the first
+// commits, the second receives a typed 409 `file-revision-conflict` with the
+// current revision and re-reads before retrying.
+//
+// Revision format is opaque to clients (exact string compare only):
+//   `v1:<size>:<mtimeMs>:<sha256hex>` for hashed text, or
+//   `v1:<size>:<mtimeMs>` when content exceeds the hash ceiling.
+// A missing file has revision `null` on the wire; `expectedRevision: null`
+// (or the literal `'missing'`) means "create only". `overwrite: true` is
+// the explicit force path that bypasses the check. Omitting
+// `expectedRevision` preserves legacy unconditional writes for older clients
+// and non-editor callers.
+//
+// External processes that write without this protocol are non-cooperating:
+// check and replace cannot be atomic against them. Last writer still wins on
+// disk; the next cooperating save observes a revision mismatch and conflicts
+// instead of silently overwriting. See DOCUMENTATION.md.
+const FILE_REVISION_PREFIX = 'v1';
+const FILE_REVISION_MISSING_LITERAL = 'missing';
+const FILE_REVISION_HASH_MAX_BYTES = 5 * 1024 * 1024;
+const FILE_REVISION_HEADER = 'x-pichamber-file-revision';
+
+const fileWriteLocks = new Map();
+
+// Canonical write-lock key. Locking on the pre-realpath workspace path would
+// let symlink aliases of the same file bypass serialization, so key on the
+// realpath target instead. For a missing target (create-only writes) walk up
+// to the deepest existing ancestor so aliases of the same missing file still
+// share one key; the write body re-keys inside the lock when the target
+// appears or is re-pointed between key resolution and lock acquisition.
+const canonicalFileWriteLockKey = async (fsPromises, path, target) => {
+  try {
+    return await fsPromises.realpath(target);
+  } catch (error) {
+    if (!error || typeof error !== 'object' || error.code !== 'ENOENT') {
+      return path.resolve(target);
+    }
+    let current = target;
+    const segments = [];
+    for (;;) {
+      const parent = path.dirname(current);
+      if (parent === current) return path.resolve(target);
+      segments.unshift(path.basename(current));
+      try {
+        const realParent = await fsPromises.realpath(parent);
+        return path.join(realParent, ...segments);
+      } catch (parentError) {
+        if (parentError && typeof parentError === 'object' && parentError.code === 'ENOENT') {
+          current = parent;
+          continue;
+        }
+        return path.resolve(target);
+      }
+    }
+  }
+};
+
+const withFileWriteLock = (key, fn) => {
+  const previous = fileWriteLocks.get(key) || Promise.resolve();
+  const next = previous.then(fn, fn);
+  const tracked = next.catch(() => {});
+  fileWriteLocks.set(key, tracked);
+  void tracked.finally(() => {
+    if (fileWriteLocks.get(key) === tracked) {
+      fileWriteLocks.delete(key);
+    }
+  });
+  return next;
+};
+
+const hashBytes = (buffer) => {
+  try {
+    return createHash('sha256').update(buffer).digest('hex');
+  } catch {
+    return null;
+  }
+};
+
+const buildFileRevision = ({ size, mtimeMs, hash }) => {
+  const safeSize = Number.isFinite(Number(size)) ? Number(size) : 0;
+  const safeMtime = Number.isFinite(Number(mtimeMs)) ? Number(mtimeMs) : 0;
+  if (typeof hash === 'string' && hash.length > 0) {
+    return `${FILE_REVISION_PREFIX}:${safeSize}:${safeMtime}:${hash}`;
+  }
+  return `${FILE_REVISION_PREFIX}:${safeSize}:${safeMtime}`;
+};
+
+const revisionForContentAndStat = (content, stats) => {
+  const size = typeof stats?.size === 'number' ? stats.size : Buffer.byteLength(typeof content === 'string' ? content : String(content ?? ''), 'utf8');
+  const mtimeMs = typeof stats?.mtimeMs === 'number' ? stats.mtimeMs : 0;
+  if (size > FILE_REVISION_HASH_MAX_BYTES) {
+    return buildFileRevision({ size, mtimeMs, hash: null });
+  }
+  const hash = hashBytes(Buffer.from(typeof content === 'string' ? content : String(content ?? ''), 'utf8'));
+  return buildFileRevision({ size, mtimeMs, hash });
+};
+
+const revisionForBufferAndStat = (buffer, stats) => {
+  const size = typeof stats?.size === 'number' ? stats.size : buffer.length;
+  const mtimeMs = typeof stats?.mtimeMs === 'number' ? stats.mtimeMs : 0;
+  if (size > FILE_REVISION_HASH_MAX_BYTES) {
+    return buildFileRevision({ size, mtimeMs, hash: null });
+  }
+  return buildFileRevision({ size, mtimeMs, hash: hashBytes(buffer) });
+};
+
+const normalizeExpectedRevision = (value) => {
+  if (value === undefined) return { mode: 'legacy' };
+  if (value === null) return { mode: 'missing' };
+  if (typeof value === 'string') {
+    if (value === FILE_REVISION_MISSING_LITERAL) return { mode: 'missing' };
+    // Opaque: retain exact, compare exact. Empty string is invalid.
+    if (value.length === 0) return { mode: 'invalid' };
+    return { mode: 'revision', revision: value };
+  }
+  return { mode: 'invalid' };
+};
+
+// Parses a client-supplied `knownRevision` for the stat cheap-path. Opaque
+// contract: a v1 revision is only ever compared for size/mtime equality, and
+// the exact client string is echoed back; anything else returns null and the
+// route computes a fresh revision the normal way.
+const parseKnownStatRevision = (value) => {
+  if (typeof value !== 'string' || !value.startsWith(`${FILE_REVISION_PREFIX}:`)) return null;
+  const parts = value.split(':');
+  if (parts.length !== 3 && parts.length !== 4) return null;
+  const size = Number(parts[1]);
+  const mtimeMs = Number(parts[2]);
+  if (!Number.isFinite(size) || !Number.isFinite(mtimeMs)) return null;
+  if (parts.length === 3) return { size, mtimeMs, hash: null };
+  const hash = parts[3];
+  if (!/^[0-9a-f]{64}$/.test(hash)) return null;
+  return { size, mtimeMs, hash };
+};
+
+const sendFileRevisionConflict = (res, { path: conflictPath, currentRevision, exists }) => (
+  res.status(409).json({
+    error: 'File has changed on disk',
+    reason: 'file-revision-conflict',
+    path: conflictPath,
+    exists: Boolean(exists),
+    currentRevision: exists ? currentRevision : null,
+  })
 );
 
 export const mintOutsideFileGrant = async (targetPath, {
@@ -779,7 +929,44 @@ export const registerFsRoutes = (app, dependencies) => {
         return res.status(400).json({ error: 'Specified path is not a file' });
       }
 
-      return res.json({ path: canonicalPath, isFile: true, size: stats.size, mtimeMs: stats.mtimeMs });
+      // Cheap-path for change polling: when the client sends the exact
+      // revision it already holds and size+mtime are unchanged, skip the
+      // full read+hash a fresh revision would require. A same-size,
+      // same-mtime external write is already undetectable to metadata
+      // polling, so this preserves the polling contract while removing the
+      // per-poll read+hash of large files. The hash-ceiling category must
+      // match too; a size that crossed the ceiling means the content
+      // changed and the real revision must be computed.
+      const known = parseKnownStatRevision(req.query?.knownRevision);
+      if (known
+        && known.size === stats.size
+        && known.mtimeMs === stats.mtimeMs
+        && (known.hash !== null) === (stats.size <= FILE_REVISION_HASH_MAX_BYTES)) {
+        return res.json({
+          path: canonicalPath,
+          isFile: true,
+          size: stats.size,
+          mtimeMs: stats.mtimeMs,
+          revision: req.query.knownRevision,
+          exists: true,
+        });
+      }
+
+      let revision = null;
+      try {
+        const size = typeof stats.size === 'number' ? stats.size : 0;
+        if (size <= FILE_REVISION_HASH_MAX_BYTES && typeof fsPromises.readFile === 'function') {
+          const buffer = await fsPromises.readFile(canonicalPath);
+          const bytes = Buffer.isBuffer(buffer) ? buffer : Buffer.from(typeof buffer === 'string' ? buffer : String(buffer ?? ''), 'utf8');
+          revision = revisionForBufferAndStat(bytes, stats);
+        } else {
+          revision = buildFileRevision({ size, mtimeMs: stats.mtimeMs, hash: null });
+        }
+      } catch {
+        revision = buildFileRevision({ size: stats.size, mtimeMs: stats.mtimeMs, hash: null });
+      }
+
+      return res.json({ path: canonicalPath, isFile: true, size: stats.size, mtimeMs: stats.mtimeMs, revision, exists: true });
     } catch (error) {
       const err = error;
       if (err && typeof err === 'object' && err.code === 'ENOENT') {
@@ -851,11 +1038,16 @@ export const registerFsRoutes = (app, dependencies) => {
           console.warn(`Read retry exhausted for ${canonicalPath}: stat reported ${stats.size} bytes but content is empty`);
         }
       }
+      const revision = revisionForContentAndStat(content, stats);
+      res.setHeader(FILE_REVISION_HEADER, revision);
+      res.setHeader('Cache-Control', 'no-store');
       return res.type('text/plain').send(content);
     } catch (error) {
       const err = error;
       if (err && typeof err === 'object' && err.code === 'ENOENT') {
         if (optional) {
+          res.setHeader('x-pichamber-file-exists', 'false');
+          res.setHeader('Cache-Control', 'no-store');
           return res.type('text/plain').send('');
         }
         return res.status(404).json({ error: 'File not found' });
@@ -1015,13 +1207,18 @@ export const registerFsRoutes = (app, dependencies) => {
   });
 
   app.post('/api/fs/write', async (req, res) => {
-    const { path: filePath, content } = req.body || {};
+    const { path: filePath, content, expectedRevision, overwrite } = req.body || {};
     if (!filePath || typeof filePath !== 'string') {
       return res.status(400).json({ error: 'Path is required' });
     }
     if (typeof content !== 'string') {
       return res.status(400).json({ error: 'Content is required' });
     }
+    const expectation = normalizeExpectedRevision(expectedRevision);
+    if (expectation.mode === 'invalid') {
+      return res.status(400).json({ error: 'Invalid expectedRevision' });
+    }
+    const forceOverwrite = overwrite === true;
 
     try {
       const resolved = await resolveWorkspacePathFromContext({
@@ -1037,35 +1234,131 @@ export const registerFsRoutes = (app, dependencies) => {
         return res.status(400).json({ error: resolved.error });
       }
 
-      const writePath = await fsPromises.realpath(resolved.resolved).catch((error) => {
-        if (error && typeof error === 'object' && error.code === 'ENOENT') {
-          return resolved.resolved;
+      // Serialize cooperating writers by canonical (realpath-resolved) path
+      // so two saves with the same base revision cannot interleave
+      // check+replace, including writes that arrive through different
+      // symlink spellings of the same file.
+      let lockKey = await canonicalFileWriteLockKey(fsPromises, path, resolved.resolved);
+      let outcome = null;
+      for (let attempt = 0; attempt < 3; attempt++) {
+        outcome = await withFileWriteLock(lockKey, async () => {
+          const writePath = await fsPromises.realpath(resolved.resolved).catch((error) => {
+            if (error && typeof error === 'object' && error.code === 'ENOENT') {
+              return resolved.resolved;
+            }
+            throw error;
+          });
+          // The target may have been created or re-pointed between lock-key
+          // resolution and lock acquisition (delete/recreate races). Re-key
+          // onto the canonical path so the compare+replace below still runs
+          // under the lock other writers of the same file will observe.
+          if (writePath !== lockKey && attempt < 2) {
+            return { __rekey: writePath };
+          }
+          const canonicalBase = await fsPromises.realpath(resolved.base).catch(() => path.resolve(resolved.base));
+        if (!isPathWithinRoot(writePath, canonicalBase, path, os)) {
+          return res.status(403).json({ error: 'Access denied' });
         }
-        throw error;
-      });
-      const canonicalBase = await fsPromises.realpath(resolved.base).catch(() => path.resolve(resolved.base));
-      if (!isPathWithinRoot(writePath, canonicalBase, path, os)) {
-        return res.status(403).json({ error: 'Access denied' });
-      }
 
-      const existing = await fsPromises.readFile(writePath, 'utf8').catch(() => null);
-      if (existing === content) {
-        return res.json({ success: true, path: resolved.resolved });
-      }
+        let existing = null;
+        let existingStats = null;
+        let exists = false;
+        try {
+          const stats = await fsPromises.stat(writePath);
+          if (!stats.isFile()) {
+            // Preserve existing behavior for directory targets: read as text
+            // fails, so treat as missing content for comparison. Stat
+            // already proved the path exists but is not a file; writing
+            // through rename would replace it, which must stay an error.
+            // Fall through to the write attempt so the filesystem reports
+            // the real failure instead of inventing a revision.
+            exists = true;
+            existingStats = stats;
+            existing = null;
+          } else {
+            exists = true;
+            existingStats = stats;
+            existing = await fsPromises.readFile(writePath, 'utf8').catch(() => null);
+          }
+        } catch (error) {
+          if (error && typeof error === 'object' && error.code === 'ENOENT') {
+            exists = false;
+          } else {
+            throw error;
+          }
+        }
 
-      await fsPromises.mkdir(path.dirname(writePath), { recursive: true });
+        let currentRevision = null;
+        if (exists && existing !== null && existingStats) {
+          currentRevision = revisionForContentAndStat(existing, existingStats);
+        } else if (exists && existingStats) {
+          currentRevision = buildFileRevision({ size: existingStats.size, mtimeMs: existingStats.mtimeMs, hash: null });
+        }
 
-      // Atomic write: write to temp then rename to avoid concurrent readers
-      // seeing an empty file during the O_TRUNC window of direct writeFile.
-      const tmp = `${writePath}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-      try {
-        await fsPromises.writeFile(tmp, content, 'utf8');
-        await fsPromises.rename(tmp, writePath);
-      } catch (error) {
-        await fsPromises.unlink(tmp).catch(() => {});
-        throw error;
+        // Idempotent no-op: identical content never conflicts and never
+        // rewrites, preserving mtime/mode and avoiding spurious 409s when
+        // two writers converge on the same bytes.
+        if (exists && existing === content) {
+          return res.json({ success: true, path: resolved.resolved, revision: currentRevision, noop: true });
+        }
+
+        if (!forceOverwrite && expectation.mode !== 'legacy') {
+          if (expectation.mode === 'missing') {
+            if (exists) {
+              return sendFileRevisionConflict(res, { path: resolved.resolved, currentRevision, exists: true });
+            }
+          } else if (expectation.mode === 'revision') {
+            if (!exists) {
+              return sendFileRevisionConflict(res, { path: resolved.resolved, currentRevision: null, exists: false });
+            }
+            if (currentRevision !== expectation.revision) {
+              return sendFileRevisionConflict(res, { path: resolved.resolved, currentRevision, exists: true });
+            }
+          }
+        }
+
+        await fsPromises.mkdir(path.dirname(writePath), { recursive: true });
+
+        // Preserve access mode across atomic replace; rename creates a new
+        // inode with default permissions, so copy the existing mode onto the
+        // temp file first. New files keep the process default.
+        const existingMode = exists && existingStats && typeof existingStats.mode === 'number'
+          ? existingStats.mode & 0o777
+          : null;
+
+        // Atomic write: write to temp then rename to avoid concurrent readers
+        // seeing an empty file during the O_TRUNC window of direct writeFile.
+        // Bytes are written exactly as received; line-ending normalization
+        // stays in the editor serializer, symlinks stay intact because
+        // writePath is the realpath target, and binary content is never
+        // decoded here.
+        const tmp = `${writePath}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        try {
+          await fsPromises.writeFile(tmp, content, 'utf8');
+          if (existingMode !== null && typeof fsPromises.chmod === 'function') {
+            await fsPromises.chmod(tmp, existingMode).catch(() => {});
+          }
+          await fsPromises.rename(tmp, writePath);
+        } catch (error) {
+          await fsPromises.unlink(tmp).catch(() => {});
+          throw error;
+        }
+        let newRevision = null;
+        try {
+          const nextStats = await fsPromises.stat(writePath);
+          newRevision = revisionForContentAndStat(content, nextStats);
+        } catch {
+          newRevision = revisionForContentAndStat(content, { size: Buffer.byteLength(content, 'utf8'), mtimeMs: Date.now() });
+        }
+        return res.json({ success: true, path: resolved.resolved, revision: newRevision });
+        });
+        if (outcome && typeof outcome === 'object' && outcome.__rekey) {
+          lockKey = outcome.__rekey;
+          continue;
+        }
+        return outcome;
       }
-      return res.json({ success: true, path: resolved.resolved });
+      return outcome;
     } catch (error) {
       const err = error;
       if (isOsPermissionError(err)) {

--- a/packages/web/server/lib/fs/routes.test.js
+++ b/packages/web/server/lib/fs/routes.test.js
@@ -286,6 +286,7 @@ const callReveal = async (handler, body) => {
 describe('fs write', () => {
   it('does not rewrite a file when content is unchanged', async () => {
     const fsPromises = {
+      stat: vi.fn(async () => ({ isFile: () => true, size: 4, mtimeMs: 1000 })),
       readFile: vi.fn(async () => 'same'),
       mkdir: vi.fn(async () => undefined),
       writeFile: vi.fn(async () => undefined),
@@ -294,12 +295,15 @@ describe('fs write', () => {
 
     const res = await callWrite(handler, { path: '/repo/file.txt', content: 'same' });
 
-    expect(res.body).toEqual({ success: true, path: '/repo/file.txt' });
+    expect(res.body).toMatchObject({ success: true, path: '/repo/file.txt', noop: true });
+    expect(typeof res.body.revision).toBe('string');
+    expect(res.body.revision.startsWith('v1:')).toBe(true);
     expect(fsPromises.writeFile).not.toHaveBeenCalled();
   });
 
   it('writes a file when content changed', async () => {
     const fsPromises = {
+      stat: vi.fn(async () => ({ isFile: () => true, size: 3, mtimeMs: 1000 })),
       readFile: vi.fn(async () => 'old'),
       mkdir: vi.fn(async () => undefined),
       writeFile: vi.fn(async () => undefined),
@@ -310,7 +314,8 @@ describe('fs write', () => {
 
     const res = await callWrite(handler, { path: '/repo/file.txt', content: 'new' });
 
-    expect(res.body).toEqual({ success: true, path: '/repo/file.txt' });
+    expect(res.body).toMatchObject({ success: true, path: '/repo/file.txt' });
+    expect(typeof res.body.revision).toBe('string');
     expect(fsPromises.mkdir).toHaveBeenCalledWith('/repo', { recursive: true });
     const tmp = fsPromises.writeFile.mock.calls[0][0];
     expect(tmp).toMatch(/^\/repo\/file\.txt\.tmp-/);
@@ -325,6 +330,7 @@ describe('fs write', () => {
         if (targetPath === '/repo/link.txt') return '/repo/target.txt';
         return targetPath;
       }),
+      stat: vi.fn(async () => ({ isFile: () => true, size: 3, mtimeMs: 1000 })),
       readFile: vi.fn(async () => 'old'),
       mkdir: vi.fn(async () => undefined),
       writeFile: vi.fn(async () => undefined),
@@ -335,7 +341,7 @@ describe('fs write', () => {
 
     const res = await callWrite(handler, { path: '/repo/link.txt', content: 'new' });
 
-    expect(res.body).toEqual({ success: true, path: '/repo/link.txt' });
+    expect(res.body).toMatchObject({ success: true, path: '/repo/link.txt' });
     expect(fsPromises.readFile).toHaveBeenCalledWith('/repo/target.txt', 'utf8');
     const tmp = fsPromises.writeFile.mock.calls[0][0];
     expect(tmp).toMatch(/^\/repo\/target\.txt\.tmp-/);
@@ -349,6 +355,7 @@ describe('fs write', () => {
         if (targetPath === '/repo/link.txt') return '/outside/target.txt';
         return targetPath;
       }),
+      stat: vi.fn(async () => ({ isFile: () => true, size: 3, mtimeMs: 1000 })),
       readFile: vi.fn(async () => 'old'),
       mkdir: vi.fn(async () => undefined),
       writeFile: vi.fn(async () => undefined),
@@ -363,6 +370,336 @@ describe('fs write', () => {
     expect(res.body).toEqual({ error: 'Access denied' });
     expect(fsPromises.writeFile).not.toHaveBeenCalled();
     expect(fsPromises.rename).not.toHaveBeenCalled();
+  });
+});
+
+describe('fs file-save revisions (finding #8)', () => {
+  const createMemoryFs = (initial = {}) => {
+    const store = new Map(Object.entries(initial));
+    let mtimeSeq = 1000;
+    const calls = { chmod: [] };
+    const enoent = () => Object.assign(new Error('not found'), { code: 'ENOENT' });
+    const fsPromises = {
+      realpath: vi.fn(async (targetPath) => targetPath),
+      stat: vi.fn(async (targetPath) => {
+        if (!store.has(targetPath)) throw enoent();
+        const content = store.get(targetPath) ?? '';
+        return {
+          isFile: () => true,
+          size: Buffer.byteLength(content, 'utf8'),
+          mtimeMs: 1000 + (store.get(`${targetPath}:mtime`) ?? 0),
+          mode: 0o100600,
+        };
+      }),
+      readFile: vi.fn(async (targetPath, encoding) => {
+        if (!store.has(targetPath)) throw enoent();
+        const content = store.get(targetPath) ?? '';
+        if (encoding === undefined || Buffer.isBuffer(content)) return Buffer.from(content, 'utf8');
+        return content;
+      }),
+      mkdir: vi.fn(async () => undefined),
+      writeFile: vi.fn(async (targetPath, content) => {
+        store.set(targetPath, typeof content === 'string' ? content : String(content));
+      }),
+      chmod: vi.fn(async (targetPath, mode) => {
+        calls.chmod.push([targetPath, mode]);
+      }),
+      rename: vi.fn(async (tmp, dest) => {
+        if (!store.has(tmp)) throw enoent();
+        store.set(dest, store.get(tmp));
+        store.delete(tmp);
+        store.set(`${dest}:mtime`, (store.get(`${dest}:mtime`) ?? 0) + 1);
+        mtimeSeq += 1;
+      }),
+      unlink: vi.fn(async (targetPath) => {
+        store.delete(targetPath);
+      }),
+      rm: vi.fn(async (targetPath) => {
+        store.delete(targetPath);
+        store.delete(`${targetPath}:mtime`);
+      }),
+    };
+    const externalWrite = (targetPath, content) => {
+      store.set(targetPath, content);
+      store.set(`${targetPath}:mtime`, (store.get(`${targetPath}:mtime`) ?? 0) + 7);
+    };
+    const externalDelete = (targetPath) => {
+      store.delete(targetPath);
+      store.delete(`${targetPath}:mtime`);
+    };
+    return { store, fsPromises, calls, externalWrite, externalDelete };
+  };
+
+  const registerReadWrite = (fsPromises) => {
+    const { app, getRoute } = createRouteRegistry();
+    registerFsRoutes(app, {
+      os: { homedir: () => '/home/user' },
+      path: path.posix,
+      fsPromises: { realpath: async (p) => p, ...fsPromises },
+      spawn: vi.fn(),
+      crypto: { randomUUID: () => 'job-0' },
+      normalizeDirectoryPath: (p) => p,
+      resolveProjectDirectory: async () => ({ directory: '/repo' }),
+      buildAugmentedPath: () => '/usr/bin',
+      resolveGitBinaryForSpawn: () => 'git',
+      pichamberUserConfigRoot: '/home/user/.config',
+    });
+    return {
+      read: getRoute('GET', '/api/fs/read'),
+      write: getRoute('POST', '/api/fs/write'),
+      stat: getRoute('GET', '/api/fs/stat'),
+    };
+  };
+
+  it('two readers observe the same opaque revision', async () => {
+    const mem = createMemoryFs({ '/repo/a.txt': 'hello' });
+    const { read } = registerReadWrite(mem.fsPromises);
+    const first = createMockResponse();
+    await read({ query: { path: '/repo/a.txt' } }, first);
+    const second = createMockResponse();
+    await read({ query: { path: '/repo/a.txt' } }, second);
+    expect(first.body).toBe('hello');
+    expect(second.body).toBe('hello');
+    const revA = first.getHeader('x-pichamber-file-revision');
+    const revB = second.getHeader('x-pichamber-file-revision');
+    expect(typeof revA).toBe('string');
+    expect(revA).toBe(revB);
+    expect(revA.startsWith('v1:')).toBe(true);
+  });
+
+  it('serializes simultaneous same-revision writes: first wins, second conflicts', async () => {
+    const mem = createMemoryFs({ '/repo/a.txt': 'base' });
+    const { read, write } = registerReadWrite(mem.fsPromises);
+    const readRes = createMockResponse();
+    await read({ query: { path: '/repo/a.txt' } }, readRes);
+    const baseRev = readRes.getHeader('x-pichamber-file-revision');
+    const [firstRes, secondRes] = await Promise.all([
+      (async () => { const r = createMockResponse(); await write({ body: { path: '/repo/a.txt', content: 'writer-one', expectedRevision: baseRev } }, r); return r; })(),
+      (async () => { const r = createMockResponse(); await write({ body: { path: '/repo/a.txt', content: 'writer-two', expectedRevision: baseRev } }, r); return r; })(),
+    ]);
+    const successes = [firstRes, secondRes].filter((r) => r.statusCode === 200);
+    const conflicts = [firstRes, secondRes].filter((r) => r.statusCode === 409);
+    expect(successes).toHaveLength(1);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].body.reason).toBe('file-revision-conflict');
+    expect(typeof conflicts[0].body.currentRevision).toBe('string');
+    expect(conflicts[0].body.exists).toBe(true);
+  });
+
+  it('rejects stale revisions after an external change with the current revision', async () => {
+    const mem = createMemoryFs({ '/repo/a.txt': 'v1' });
+    const { read, write } = registerReadWrite(mem.fsPromises);
+    const readRes = createMockResponse();
+    await read({ query: { path: '/repo/a.txt' } }, readRes);
+    const stale = readRes.getHeader('x-pichamber-file-revision');
+    mem.externalWrite('/repo/a.txt', 'external');
+    const writeRes = createMockResponse();
+    await write({ body: { path: '/repo/a.txt', content: 'stale-write', expectedRevision: stale } }, writeRes);
+    expect(writeRes.statusCode).toBe(409);
+    expect(writeRes.body).toMatchObject({ reason: 'file-revision-conflict', exists: true });
+    expect(typeof writeRes.body.currentRevision).toBe('string');
+    expect(writeRes.body.currentRevision).not.toBe(stale);
+  });
+
+  it('conflicts with exists:false after external delete', async () => {
+    const mem = createMemoryFs({ '/repo/a.txt': 'v1' });
+    const { read, write } = registerReadWrite(mem.fsPromises);
+    const readRes = createMockResponse();
+    await read({ query: { path: '/repo/a.txt' } }, readRes);
+    const stale = readRes.getHeader('x-pichamber-file-revision');
+    mem.externalDelete('/repo/a.txt');
+    const writeRes = createMockResponse();
+    await write({ body: { path: '/repo/a.txt', content: 'resurrect', expectedRevision: stale } }, writeRes);
+    expect(writeRes.statusCode).toBe(409);
+    expect(writeRes.body).toMatchObject({ reason: 'file-revision-conflict', exists: false, currentRevision: null });
+  });
+
+  it('detects delete+recreate as a conflict for diverging writes', async () => {
+    const mem = createMemoryFs({ '/repo/a.txt': 'v1' });
+    const { read, write } = registerReadWrite(mem.fsPromises);
+    const readRes = createMockResponse();
+    await read({ query: { path: '/repo/a.txt' } }, readRes);
+    const stale = readRes.getHeader('x-pichamber-file-revision');
+    mem.externalDelete('/repo/a.txt');
+    mem.externalWrite('/repo/a.txt', 'recreated');
+    const writeRes = createMockResponse();
+    await write({ body: { path: '/repo/a.txt', content: 'diverged', expectedRevision: stale } }, writeRes);
+    expect(writeRes.statusCode).toBe(409);
+    expect(writeRes.body.exists).toBe(true);
+  });
+
+  it('serializes the new-file race: second create-only writer conflicts', async () => {
+    const mem = createMemoryFs({});
+    const { write } = registerReadWrite(mem.fsPromises);
+    const [firstRes, secondRes] = await Promise.all([
+      (async () => { const r = createMockResponse(); await write({ body: { path: '/repo/new.txt', content: 'first', expectedRevision: null } }, r); return r; })(),
+      (async () => { const r = createMockResponse(); await write({ body: { path: '/repo/new.txt', content: 'second', expectedRevision: null } }, r); return r; })(),
+    ]);
+    const successes = [firstRes, secondRes].filter((r) => r.statusCode === 200);
+    const conflicts = [firstRes, secondRes].filter((r) => r.statusCode === 409);
+    expect(successes).toHaveLength(1);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].body.reason).toBe('file-revision-conflict');
+  });
+
+  it('treats identical-content saves as no-ops without conflict', async () => {
+    const mem = createMemoryFs({ '/repo/a.txt': 'same' });
+    const { read, write } = registerReadWrite(mem.fsPromises);
+    const readRes = createMockResponse();
+    await read({ query: { path: '/repo/a.txt' } }, readRes);
+    const stale = readRes.getHeader('x-pichamber-file-revision');
+    mem.externalWrite('/repo/a.txt', 'same');
+    const writeRes = createMockResponse();
+    await write({ body: { path: '/repo/a.txt', content: 'same', expectedRevision: stale } }, writeRes);
+    expect(writeRes.statusCode).toBe(200);
+    expect(writeRes.body.success).toBe(true);
+    expect(mem.fsPromises.rename).not.toHaveBeenCalled();
+  });
+
+  it('honors explicit overwrite over stale revisions and recreates deleted files', async () => {
+    const mem = createMemoryFs({ '/repo/a.txt': 'v1' });
+    const { read, write } = registerReadWrite(mem.fsPromises);
+    const readRes = createMockResponse();
+    await read({ query: { path: '/repo/a.txt' } }, readRes);
+    const stale = readRes.getHeader('x-pichamber-file-revision');
+    mem.externalWrite('/repo/a.txt', 'external');
+    const overwriteRes = createMockResponse();
+    await write({ body: { path: '/repo/a.txt', content: 'forced', expectedRevision: stale, overwrite: true } }, overwriteRes);
+    expect(overwriteRes.statusCode).toBe(200);
+    expect(overwriteRes.body.success).toBe(true);
+    mem.externalDelete('/repo/a.txt');
+    const recreate = createMockResponse();
+    await write({ body: { path: '/repo/a.txt', content: 'recreated', expectedRevision: stale, overwrite: true } }, recreate);
+    expect(recreate.statusCode).toBe(200);
+  });
+
+  it('preserves CRLF bytes and file mode across atomic replace', async () => {
+    const mem = createMemoryFs({ '/repo/a.txt': 'one\r\ntwo\r\n' });
+    const { write } = registerReadWrite(mem.fsPromises);
+    const writeRes = createMockResponse();
+    await write({ body: { path: '/repo/a.txt', content: 'a\r\nb\r\n' } }, writeRes);
+    expect(writeRes.statusCode).toBe(200);
+    expect(mem.store.get('/repo/a.txt')).toBe('a\r\nb\r\n');
+    expect(mem.calls.chmod.length).toBeGreaterThan(0);
+    expect(mem.calls.chmod[0][1] & 0o777).toBe(0o600);
+  });
+
+  it('exposes revisions on stat and read for guarded saves', async () => {
+    const mem = createMemoryFs({ '/repo/a.txt': 'hello' });
+    const { read, stat } = registerReadWrite(mem.fsPromises);
+    const readRes = createMockResponse();
+    await read({ query: { path: '/repo/a.txt' } }, readRes);
+    const statRes = createMockResponse();
+    await stat({ query: { path: '/repo/a.txt' } }, statRes);
+    expect(typeof readRes.getHeader('x-pichamber-file-revision')).toBe('string');
+    expect(typeof statRes.body.revision).toBe('string');
+    expect(statRes.body.revision).toBe(readRes.getHeader('x-pichamber-file-revision'));
+  });
+
+  it('serializes concurrent guarded writes through a symlink alias and the canonical path', async () => {
+    const mem = createMemoryFs({ '/repo/a.txt': 'base' });
+    // /repo/link.txt is a symlink alias of /repo/a.txt: realpath maps it even
+    // though the store only knows the canonical entry.
+    mem.fsPromises.realpath = vi.fn(async (targetPath) =>
+      targetPath === '/repo/link.txt' ? '/repo/a.txt' : targetPath);
+    const { read, write } = registerReadWrite(mem.fsPromises);
+    const readRes = createMockResponse();
+    await read({ query: { path: '/repo/link.txt' } }, readRes);
+    const baseRev = readRes.getHeader('x-pichamber-file-revision');
+    const [viaAlias, viaCanonical] = await Promise.all([
+      (async () => { const r = createMockResponse(); await write({ body: { path: '/repo/link.txt', content: 'alias-writer', expectedRevision: baseRev } }, r); return r; })(),
+      (async () => { const r = createMockResponse(); await write({ body: { path: '/repo/a.txt', content: 'canonical-writer', expectedRevision: baseRev } }, r); return r; })(),
+    ]);
+    const successes = [viaAlias, viaCanonical].filter((r) => r.statusCode === 200);
+    const conflicts = [viaAlias, viaCanonical].filter((r) => r.statusCode === 409);
+    expect(successes).toHaveLength(1);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].body.reason).toBe('file-revision-conflict');
+    expect(typeof conflicts[0].body.currentRevision).toBe('string');
+  });
+
+  it('serializes create-only writes through a dangling symlink alias and its target', async () => {
+    const mem = createMemoryFs({});
+    // Dangling symlink: realpath resolves the alias name to the missing target.
+    mem.fsPromises.realpath = vi.fn(async (targetPath) =>
+      targetPath === '/repo/link.txt' ? '/repo/a.txt' : targetPath);
+    const { write } = registerReadWrite(mem.fsPromises);
+    const [viaAlias, viaTarget] = await Promise.all([
+      (async () => { const r = createMockResponse(); await write({ body: { path: '/repo/link.txt', content: 'alias-create', expectedRevision: null } }, r); return r; })(),
+      (async () => { const r = createMockResponse(); await write({ body: { path: '/repo/a.txt', content: 'target-create', expectedRevision: null } }, r); return r; })(),
+    ]);
+    const successes = [viaAlias, viaTarget].filter((r) => r.statusCode === 200);
+    const conflicts = [viaAlias, viaTarget].filter((r) => r.statusCode === 409);
+    expect(successes).toHaveLength(1);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].body.reason).toBe('file-revision-conflict');
+    expect(conflicts[0].body.exists).toBe(true);
+  });
+
+  it('skips read+hash on stat when knownRevision still matches', async () => {
+    const mem = createMemoryFs({ '/repo/a.txt': 'hello' });
+    const { read, stat } = registerReadWrite(mem.fsPromises);
+    const readRes = createMockResponse();
+    await read({ query: { path: '/repo/a.txt' } }, readRes);
+    const baseRev = readRes.getHeader('x-pichamber-file-revision');
+    // The initial read consumes one readFile call; stat must add none.
+    const readCallsAfterRead = mem.fsPromises.readFile.mock.calls.length;
+    const statRes = createMockResponse();
+    await stat({ query: { path: '/repo/a.txt', knownRevision: baseRev } }, statRes);
+    expect(statRes.statusCode).toBe(200);
+    expect(statRes.body.revision).toBe(baseRev);
+    expect(statRes.body.exists).toBe(true);
+    // The cheap path must not read the file again.
+    expect(mem.fsPromises.readFile.mock.calls.length).toBe(readCallsAfterRead);
+  });
+
+  it('recomputes the revision when knownRevision no longer matches', async () => {
+    const mem = createMemoryFs({ '/repo/a.txt': 'hello' });
+    const { read, stat } = registerReadWrite(mem.fsPromises);
+    const readRes = createMockResponse();
+    await read({ query: { path: '/repo/a.txt' } }, readRes);
+    const baseRev = readRes.getHeader('x-pichamber-file-revision');
+    mem.externalWrite('/repo/a.txt', 'changed');
+    const statRes = createMockResponse();
+    await stat({ query: { path: '/repo/a.txt', knownRevision: baseRev } }, statRes);
+    expect(statRes.statusCode).toBe(200);
+    expect(statRes.body.revision).not.toBe(baseRev);
+    expect(typeof statRes.body.revision).toBe('string');
+  });
+
+  it('does not shortcut a hand-crafted revision whose hash contradicts the ceiling', async () => {
+    const mem = createMemoryFs({ '/repo/a.txt': 'tiny' });
+    const { stat } = registerReadWrite(mem.fsPromises);
+    // A revision claiming a hash for a size above the hash ceiling is
+    // inconsistent (clients must only echo server revisions). Size+mtime
+    // match, but the server must still recompute instead of echoing it back.
+    const fakeHash = 'a'.repeat(64);
+    const craftedRevision = `v1:${5 * 1024 * 1024 + 1}:1000:${fakeHash}`;
+    const statRes = createMockResponse();
+    await stat({ query: { path: '/repo/a.txt', knownRevision: craftedRevision } }, statRes);
+    expect(statRes.body.revision).not.toBe(craftedRevision);
+    expect(statRes.body.revision).toMatch(/^v1:4:1000:[0-9a-f]{64}$/);
+  });
+
+  it('serializes concurrent guarded writes through two symlink aliases of one file', async () => {
+    const mem = createMemoryFs({ '/repo/a.txt': 'base' });
+    mem.fsPromises.realpath = vi.fn(async (targetPath) => {
+      if (targetPath === '/repo/link-one.txt' || targetPath === '/repo/link-two.txt') return '/repo/a.txt';
+      return targetPath;
+    });
+    const { read, write } = registerReadWrite(mem.fsPromises);
+    const readRes = createMockResponse();
+    await read({ query: { path: '/repo/link-two.txt' } }, readRes);
+    const baseRev = readRes.getHeader('x-pichamber-file-revision');
+    const [first, second] = await Promise.all([
+      (async () => { const r = createMockResponse(); await write({ body: { path: '/repo/link-one.txt', content: 'one', expectedRevision: baseRev } }, r); return r; })(),
+      (async () => { const r = createMockResponse(); await write({ body: { path: '/repo/link-two.txt', content: 'two', expectedRevision: baseRev } }, r); return r; })(),
+    ]);
+    const successes = [first, second].filter((r) => r.statusCode === 200);
+    const conflicts = [first, second].filter((r) => r.statusCode === 409);
+    expect(successes).toHaveLength(1);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].body.reason).toBe('file-revision-conflict');
   });
 });
 

--- a/packages/web/server/lib/server/cors.js
+++ b/packages/web/server/lib/server/cors.js
@@ -26,6 +26,11 @@ const DEFAULT_ALLOWED_CORS_HEADERS = [
   'x-pichamber-mime',
 ].join(',');
 
+const EXPOSED_UI_CORS_HEADERS = [
+  'x-pichamber-file-revision',
+  'x-pichamber-file-exists',
+].join(',');
+
 export const isAllowedUiCorsOrigin = (origin) => (
   typeof origin === 'string'
   && (ALLOWED_UI_CORS_ORIGINS.has(origin) || LOOPBACK_HTTP_ORIGIN.test(origin))
@@ -48,6 +53,7 @@ export const applyUiCorsHeaders = (req, res) => {
   res.setHeader('Access-Control-Allow-Credentials', 'true');
   res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PUT,PATCH,DELETE,OPTIONS');
   res.setHeader('Access-Control-Allow-Headers', resolveAllowedCorsHeaders(req.headers?.['access-control-request-headers']));
+  res.setHeader('Access-Control-Expose-Headers', EXPOSED_UI_CORS_HEADERS);
   res.setHeader('Vary', 'Origin');
   return req.method === 'OPTIONS';
 };

--- a/packages/web/server/lib/server/cors.test.js
+++ b/packages/web/server/lib/server/cors.test.js
@@ -36,5 +36,8 @@ describe('packaged UI CORS', () => {
     expect(ended).toBe(true);
     expect(headers['Access-Control-Allow-Origin']).toBe('pichamber-ui://app');
     expect(headers['Access-Control-Allow-Headers']).toBe('x-pichamber-directory,x-pichamber-filename,x-pichamber-mime,authorization');
+    expect(headers['Access-Control-Expose-Headers']).toBe(
+      'x-pichamber-file-revision,x-pichamber-file-exists',
+    );
   });
 });

--- a/packages/web/server/lib/workspace/host.js
+++ b/packages/web/server/lib/workspace/host.js
@@ -13,7 +13,11 @@ import { createTerminalRuntime } from '../terminal/runtime.js';
 import { createSttRuntime } from '../stt/runtime.js';
 import { getExecutableSearchDirectories } from '../tunnels/executable-search.js';
 
-const normalizeDirectoryPath = (value) => (typeof value === 'string' ? path.resolve(value.trim()) : '');
+export const normalizeDirectoryPath = (value) => {
+  if (typeof value !== 'string') return '';
+  const requested = value.trim();
+  return path.resolve(requested === '~' ? os.homedir() : requested);
+};
 
 const buildAugmentedPath = () => mergePathValues(process.env.PATH || '', process.env.Path || '', path.delimiter);
 
@@ -40,7 +44,7 @@ const resolveProjectDirectory = async (req) => {
   const requested = typeof query === 'string' && query.trim() ? query.trim() : (typeof header === 'string' ? header.trim() : '');
   if (!requested) return { directory: process.cwd(), error: null };
   try {
-    const resolved = path.resolve(requested);
+    const resolved = normalizeDirectoryPath(requested);
     const stats = await fs.promises.stat(resolved);
     if (!stats.isDirectory()) return { directory: null, error: 'Specified path is not a directory' };
     return { directory: await fs.promises.realpath(resolved), error: null };

--- a/packages/web/server/lib/workspace/host.test.js
+++ b/packages/web/server/lib/workspace/host.test.js
@@ -1,0 +1,15 @@
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { normalizeDirectoryPath } from './host.js';
+
+describe('workspace directory normalization', () => {
+  it('expands the global-session home sentinel', () => {
+    expect(normalizeDirectoryPath('~')).toBe(path.resolve(os.homedir()));
+  });
+
+  it('keeps ordinary path resolution behavior', () => {
+    expect(normalizeDirectoryPath('./workspace')).toBe(path.resolve('./workspace'));
+  });
+});

--- a/packages/web/src/api/files.test.ts
+++ b/packages/web/src/api/files.test.ts
@@ -75,6 +75,31 @@ describe('createWebFilesAPI', () => {
     });
   });
 
+  it('forwards guarded write options and knownRevision on stat', async () => {
+    const { createWebFilesAPI } = await import('./files');
+    const api = createWebFilesAPI({ urls, getDirectory: () => '/workspace' });
+
+    runtimeFetchMock.mockResolvedValueOnce(Response.json({ path: '/workspace/a.txt', isFile: true, size: 2 }));
+    await api.statFile?.('/workspace/a.txt', { knownRevision: 'v1:2:10:abc' });
+    const statCall = runtimeFetchMock.mock.calls.at(-1);
+    expect(statCall?.[0]).toBe('/api/fs/stat');
+    expect((statCall?.[1] as { query: URLSearchParams }).query.get('knownRevision')).toBe('v1:2:10:abc');
+
+    runtimeFetchMock.mockResolvedValueOnce(Response.json({ path: '/workspace/a.txt', isFile: true, size: 2 }));
+    await api.statFile?.('/workspace/a.txt', {});
+    const statCallNoRevision = runtimeFetchMock.mock.calls.at(-1);
+    expect((statCallNoRevision?.[1] as { query: URLSearchParams }).query.has('knownRevision')).toBe(false);
+
+    runtimeFetchMock.mockResolvedValueOnce(Response.json({ success: true, path: '/workspace/a.txt', revision: 'v1:2:11:def' }));
+    await api.writeFile?.('/workspace/a.txt', 'next', { expectedRevision: 'v1:2:10:abc' });
+    const writeCall = runtimeFetchMock.mock.calls.at(-1);
+    expect(JSON.parse((writeCall?.[1] as { body: string }).body)).toEqual({
+      path: '/workspace/a.txt',
+      content: 'next',
+      expectedRevision: 'v1:2:10:abc',
+    });
+  });
+
   it('sends the workspace directory header for downloads', async () => {
     const { createWebFilesAPI } = await import('./files');
     const api = createWebFilesAPI({ urls, getDirectory: () => '/current-workspace' });
@@ -86,5 +111,77 @@ describe('createWebFilesAPI', () => {
       query: { path: '/current-workspace/file.txt', download: true },
       headers: { 'x-pichamber-directory': '/current-workspace' },
     });
+  });
+
+  it('retains the opaque read revision exact', async () => {
+    const { createWebFilesAPI } = await import('./files');
+    const api = createWebFilesAPI({ urls, getDirectory: () => '/workspace' });
+    const revision = 'v1:5:1000:abc123';
+    runtimeFetchMock.mockResolvedValueOnce(new Response('hello', {
+      headers: { 'x-pichamber-file-revision': revision },
+    }));
+    const result = await api.readFile?.('/workspace/a.txt');
+    expect(result?.content).toBe('hello');
+    expect(result?.revision).toBe(revision);
+    expect(result?.exists).toBe(true);
+  });
+
+  it('maps missing optional reads to a null revision', async () => {
+    const { createWebFilesAPI } = await import('./files');
+    const api = createWebFilesAPI({ urls, getDirectory: () => '/workspace' });
+    runtimeFetchMock.mockResolvedValueOnce(new Response('', {
+      headers: { 'x-pichamber-file-exists': 'false' },
+    }));
+    const result = await api.readFile?.('/workspace/missing.txt', { optional: true });
+    expect(result?.content).toBe('');
+    expect(result?.revision).toBeNull();
+    expect(result?.exists).toBe(false);
+  });
+
+  it('sends expectedRevision and maps typed revision conflicts', async () => {
+    const { createWebFilesAPI } = await import('./files');
+    const api = createWebFilesAPI({ urls, getDirectory: () => '/workspace' });
+    runtimeFetchMock.mockResolvedValueOnce(Response.json(
+      { error: 'File has changed on disk', reason: 'file-revision-conflict', currentRevision: 'v1:8:2000:def', exists: true, path: '/workspace/a.txt' },
+      { status: 409 },
+    ));
+    const error = await api.writeFile?.('/workspace/a.txt', 'stale', { expectedRevision: 'v1:5:1000:abc' }).catch((caught) => caught);
+    expect(error).toMatchObject({
+      name: 'FileRevisionConflictError',
+      reason: 'file-revision-conflict',
+      status: 409,
+      currentRevision: 'v1:8:2000:def',
+      exists: true,
+    });
+    expect(runtimeFetchMock).toHaveBeenLastCalledWith('/api/fs/write', expect.objectContaining({
+      method: 'POST',
+    }));
+    const lastBody = JSON.parse((runtimeFetchMock.mock.lastCall?.[1] as { body?: string }).body ?? '{}');
+    expect(lastBody).toMatchObject({ path: '/workspace/a.txt', content: 'stale', expectedRevision: 'v1:5:1000:abc' });
+  });
+
+  it('sends create-only and explicit overwrite markers', async () => {
+    const { createWebFilesAPI } = await import('./files');
+    const api = createWebFilesAPI({ urls, getDirectory: () => '/workspace' });
+    runtimeFetchMock.mockResolvedValueOnce(Response.json({ success: true, path: '/workspace/new.txt', revision: 'v1:0:1000:hash' }));
+    await api.writeFile?.('/workspace/new.txt', '', { expectedRevision: null });
+    expect(JSON.parse((runtimeFetchMock.mock.lastCall?.[1] as { body?: string }).body ?? '{}')).toMatchObject({
+      expectedRevision: null,
+    });
+    runtimeFetchMock.mockResolvedValueOnce(Response.json({ success: true, path: '/workspace/a.txt', revision: 'v1:6:3000:hash2' }));
+    const forced = await api.writeFile?.('/workspace/a.txt', 'forced', { expectedRevision: 'v1:5:1000:abc', overwrite: true });
+    expect(forced?.revision).toBe('v1:6:3000:hash2');
+    expect(JSON.parse((runtimeFetchMock.mock.lastCall?.[1] as { body?: string }).body ?? '{}')).toMatchObject({
+      overwrite: true,
+    });
+  });
+
+  it('returns stat revisions for guarded saves', async () => {
+    const { createWebFilesAPI } = await import('./files');
+    const api = createWebFilesAPI({ urls, getDirectory: () => '/workspace' });
+    runtimeFetchMock.mockResolvedValueOnce(Response.json({ path: '/workspace/a.txt', isFile: true, size: 5, mtimeMs: 1000, revision: 'v1:5:1000:abc', exists: true }));
+    const stat = await api.statFile?.('/workspace/a.txt');
+    expect(stat?.revision).toBe('v1:5:1000:abc');
+    expect(stat?.exists).toBe(true);
   });
 });

--- a/packages/web/src/api/files.ts
+++ b/packages/web/src/api/files.ts
@@ -5,6 +5,7 @@ import type {
   FilesAPI,
 } from '@pichamber/ui/lib/api/types';
 import {
+  FileRevisionConflictError,
   FilesystemError,
   parseFilesystemErrorReason,
 } from '@pichamber/ui/lib/api/files-errors';
@@ -147,7 +148,7 @@ export const createWebFilesAPI = ({ getDirectory }: WebFilesAPIOptions): FilesAP
     };
   },
 
-  async statFile(path: string, options): Promise<{ path: string; isFile: boolean; size: number; mtimeMs?: number }> {
+  async statFile(path: string, options): Promise<{ path: string; isFile: boolean; size: number; mtimeMs?: number; revision?: string | null; exists?: boolean }> {
     const target = normalizePath(path);
     const params = new URLSearchParams({ path: target });
     if (options?.allowOutsideWorkspace) {
@@ -155,6 +156,11 @@ export const createWebFilesAPI = ({ getDirectory }: WebFilesAPIOptions): FilesAP
     }
     if (options?.outsideFileGrant) {
       params.set('outsideFileGrant', options.outsideFileGrant);
+    }
+    // Exact known revision: lets the server skip read+hash when metadata is
+    // unchanged. Never modified; the server echoes it back verbatim.
+    if (typeof options?.knownRevision === 'string' && options.knownRevision.length > 0) {
+      params.set('knownRevision', options.knownRevision);
     }
     const response = await runtimeFetch('/api/fs/stat', {
       query: params,
@@ -167,15 +173,20 @@ export const createWebFilesAPI = ({ getDirectory }: WebFilesAPIOptions): FilesAP
     }
 
     const result = await response.json().catch(() => ({}));
+    const exists = (result as { exists?: boolean }).exists !== false;
     return {
       path: typeof (result as { path?: string }).path === 'string' ? normalizePath((result as { path: string }).path) : target,
       isFile: Boolean((result as { isFile?: boolean }).isFile),
       size: typeof (result as { size?: number }).size === 'number' ? (result as { size: number }).size : 0,
       mtimeMs: typeof (result as { mtimeMs?: number }).mtimeMs === 'number' ? (result as { mtimeMs: number }).mtimeMs : undefined,
+      revision: typeof (result as { revision?: unknown }).revision === 'string'
+        ? (result as { revision: string }).revision
+        : (exists ? undefined : null),
+      exists,
     };
   },
 
-  async readFile(path: string, options): Promise<{ content: string; path: string }> {
+  async readFile(path: string, options): Promise<{ content: string; path: string; revision?: string | null; exists?: boolean }> {
     const target = normalizePath(path);
     const params = new URLSearchParams({ path: target });
     if (options?.allowOutsideWorkspace) {
@@ -199,26 +210,60 @@ export const createWebFilesAPI = ({ getDirectory }: WebFilesAPIOptions): FilesAP
     }
 
     const content = await response.text();
-    return { content, path: target };
+    // Opaque revision: retain exact, never trim or normalize. Missing
+    // optional reads surface as `null`; legacy servers without the header
+    // surface as `undefined` and must not be used for guarded saves.
+    const rawRevision = response.headers?.get?.('x-pichamber-file-revision');
+    const existsHeader = response.headers?.get?.('x-pichamber-file-exists');
+    const exists = existsHeader === 'false' ? false : true;
+    const revision = typeof rawRevision === 'string' && rawRevision.length > 0
+      ? rawRevision
+      : (exists ? undefined : null);
+    return { content, path: target, revision, exists };
   },
 
-  async writeFile(path: string, content: string): Promise<{ success: boolean; path: string }> {
+  async writeFile(path: string, content: string, options): Promise<{ success: boolean; path: string; revision?: string | null; noop?: boolean }> {
     const target = normalizePath(path);
+    const body: Record<string, unknown> = { path: target, content };
+    if (options && 'expectedRevision' in options) {
+      body.expectedRevision = options.expectedRevision ?? null;
+    }
+    if (options?.overwrite === true) {
+      body.overwrite = true;
+    }
     const response = await runtimeFetch('/api/fs/write', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...directoryHeaders(getDirectory) },
-      body: JSON.stringify({ path: target, content }),
+      body: JSON.stringify(body),
     });
 
     if (!response.ok) {
-      const error = await response.json().catch(() => ({ error: response.statusText }));
-      throw new Error((error as { error?: string }).error || 'Failed to write file');
+      const error = await response.json().catch(() => ({ error: response.statusText })) as {
+        error?: string;
+        reason?: unknown;
+        currentRevision?: unknown;
+        exists?: unknown;
+        path?: unknown;
+      };
+      if (response.status === 409 && parseFilesystemErrorReason(error.reason) === 'file-revision-conflict') {
+        throw new FileRevisionConflictError(error.error || 'File has changed on disk', {
+          currentRevision: typeof error.currentRevision === 'string' ? error.currentRevision : null,
+          exists: typeof error.exists === 'boolean' ? error.exists : undefined,
+          path: typeof error.path === 'string' ? error.path : target,
+          status: response.status,
+        });
+      }
+      throw new Error(error.error || 'Failed to write file');
     }
 
     const result = await response.json().catch(() => ({}));
     return {
       success: Boolean((result as { success?: boolean }).success),
       path: typeof (result as { path?: string }).path === 'string' ? normalizePath((result as { path: string }).path) : target,
+      revision: typeof (result as { revision?: unknown }).revision === 'string'
+        ? (result as { revision: string }).revision
+        : undefined,
+      noop: Boolean((result as { noop?: boolean }).noop) || undefined,
     };
   },
 


### PR DESCRIPTION
## Intent

Guards file editor saves with opaque revisions to prevent silent overwrites:

- Server issues opaque revisions (`v1:<size>:<mtimeMs>[:<sha256}]`, 5 MiB hash ceiling) on `GET /api/fs/read` (`x-pichamber-file-revision` + `Cache-Control: no-store`) and `GET /api/fs/stat` (`{ revision, exists }` + `?knownRevision=` fast-path).
- `POST /api/fs/write` accepts `{ expectedRevision, overwrite }`; mismatches return HTTP 409 `{ reason: 'file-revision-conflict', currentRevision, exists, path }`. Identical content returns idempotent `{ noop: true }` without rewrite. Omitting `expectedRevision` preserves legacy unconditional writes.
- UI adds explicit conflict recovery via `FileSaveConflictDialog` (reload / overwrite / compare) that preserves dirty buffers; failed reloads keep edits intact.
- Drops stale save/conflict completions across file/runtime/selection switches and standalone `DiagramView` recovery without losing edits; preserves line endings and file mode across atomic temp+rename writes with per-file serialization.
- Follow-up edge cases: expose revision headers via CORS for HMR/packaged-desktop/Capacitor, resolve exact `~` home sentinel before workspace validation in `normalizeDirectoryPath`/`resolveProjectDirectory`, and gate Git history divider on `branchScopeAvailable` so absent `main` fallback never reaches Git log.

## Non-goals

- Unrelated PR #119 findings outside finding #8.
- CHANGELOG aggregation.
- Changing legacy unconditional-write behavior when `expectedRevision` is omitted.

## Affected surfaces

- **packages/web**: `server/lib/fs/routes.js` (`/api/fs/read|stat|write`), `server/lib/workspace/host.js` (home sentinel), `server/lib/server/cors.js` (expose headers), `src/api/files.ts` client.
- **packages/ui**: `FilesView`, `DiagramView`, `FileSaveConflictDialog`, `useFileEditorSave`, `useFileViewerModes`, `useFileStatReconciliation`, `useFileOperations`, `fileRevisionCache`, `content-cache-owner`, `lib/api/files-errors|types`, `GitView` divider gate.
- **Runtimes**: web, desktop (packaged `pichamber-ui://` + loopback API), hosted mobile, Capacitor mobile — all consume the same `/api/fs/*` contract via `runtimeFetch`; CORS expose fix specifically retains revision authority across origins. No Electron-main/preload or Capacitor-native changes.
- **Persisted/external contracts**: new optional wire fields only (`expectedRevision`, `overwrite`, revision headers, 409 reason). No stored-data migration.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md instruction order + docs discovery | Source + contract change across ui/web | Read CONTRIBUTING.md + PR template; read owning docs `packages/web/server/lib/fs/DOCUMENTATION.md` and `packages/ui/src/apps/DOCUMENTATION.md`; kept domain logic in owning modules (fs routes, file-save hooks), entrypoints thin |
| pichamber-change-discipline | Source/export/route/persisted-contract change | Smallest complete finding-#8 port; preserved legacy-write compat; no new dependencies; explicit failure/rollback (409, noop, atomic write, stale-drop); updated owning DOCUMENTATION.md files |
| ui-api-decoupling | Server `/api/fs/*` + shared UI data access | Contract stays in fs routes + typed client (`src/api/files.ts`, `lib/api/types|files-errors`); UI uses `runtimeFetch` helpers, no Pi-session logic touched |
| sync-state-invariants | Revision cache, stat reconciliation, content-cache, stale completions | Authoritative revision over heuristics; exact scope (runtime/root/path/generation) invalidation; stat failures never masquerade as missing; one failed dir never clears unrelated buckets |
| locale-ui-patterns | New user-facing conflict dialog copy | Explicit reload/overwrite/compare labels, dirty-preservation messaging (covered by existing component copy) |
| theme-system | New dialog component states | Reuses existing semantic tokens/shared buttons (no ad-hoc colors) |

## Validation

| Check | Result |
|---|---|
| `git diff --check origin/main...HEAD` | Pass, no whitespace errors |
| Web focused: `bun run --cwd packages/web test -- server/lib/fs/routes.test.js server/lib/server/cors.test.js server/lib/workspace/host.test.js src/api/files.test.ts` | 4 files, 73 tests pass |
| UI focused: `bun test --isolate fileRevisionCache, fileLineEndings, useFileEditorSave, useFileStatReconciliation, useFileViewerModes, files-errors, content-cache-owner` | 39 pass, 0 fail |
| UI focused: `DiagramView.test.tsx` | 15 pass, 0 fail |
| `bun run type-check:ui`, `bun run --cwd packages/web type-check` | Pass |
| `bun run lint:ui`, `bun run --cwd packages/web lint` | Pass |
| `bun run dead-code` | Non-blocking; only new-flagged export is `CachedFileRevision` type (used as helper signature, no runtime consumer) plus pre-existing list |
| `bun run test` (full web+ui+electron) | NOT green: `test:web` 748 pass / 2 fail — `supervisor.test.js > keeps per-profile daemons independent` (Pi daemon unavailable) and `ipc-client.test.js > parses complete frames` (10s hook timeout). Both in `server/lib/pi/session-daemon/`, unrelated to fs/ui diff; focused fs/ui suites above pass |

## Visual evidence

User-visible change (conflict dialog + Diagram/Files save flows). No before/after screenshots or recordings captured in this PR run — behavior is covered by current interaction tests (`useFileEditorSave.test.tsx`, `useFileViewerModes.test.tsx`, `DiagramView.test.tsx` stale/conflict/overwrite/reload cases). Manual HMR/desktop/Capacitor visual pass not performed.

## Risks and failure behavior

- **Conflict path**: stale writer gets explicit 409 with `currentRevision`; no silent overwrite. External non-cooperating writers: last-writer-wins on disk, next cooperating save conflicts.
- **Idempotency**: identical-content saves noop without rewrite/mtime churn.
- **Atomicity**: per-canonical-file serialization with re-keying for create/re-point races; temp+rename preserves mode; line endings never normalized.
- **Stale async**: file/runtime/selection switches drop late completions; never clobbers newly selected document.
- **Compat/rollback**: legacy writes (no `expectedRevision`) unchanged; safe to roll back to pre-revision server (clients fall back to unguarded saves) and pre-revision client (server still accepts unguarded writes).
- **Security**: workspace-boundary checks retained; `optional=true` only maps missing-file to empty success; `~` expands only for exact sentinel via `os.homedir()`.
- **Performance**: stat `knownRevision` short-circuit skips read+hash on match; no new polling.
