### PR TITLE
fix(terminal): reattach streams after transport switches

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -7,6 +7,7 @@ import { RuntimeAPIProvider } from '@/contexts/RuntimeAPIProvider';
 import { getRegisteredRuntimeAPIs, registerRuntimeAPIs } from '@/contexts/runtimeAPIRegistry';
 import { SyncAppEffects } from '@/apps/AppEffects';
 import { resetAppForRuntimeEndpointChange } from '@/apps/runtimeEndpointReset';
+import { resetTerminalTransport } from '@/lib/terminalApi';
 import { useAppFontEffects } from '@/apps/useAppFontEffects';
 import { PiSessionProvider } from '@/sync/pi-session-context';
 import { FireworksProvider } from '@/contexts/FireworksContext';
@@ -42,9 +43,16 @@ function App({ apis }: { apis?: RuntimeAPIs }) {
   React.useEffect(() => {
     return subscribeRuntimeEndpointChanged((detail) => {
       // A LAN↔relay change for the same instance only changes transport. The
-      // session store reconnects in place; a different runtime needs a full
-      // store reset so paths, sessions, and provider state cannot cross hosts.
-      if (detail.runtimeKey === detail.previousRuntimeKey) return;
+      // session store reconnects in place; terminal reattaches the same PTYs
+      // in place via the terminal generation (tabs/scrollback/dims/selection
+      // preserved, no PTY restart). A different runtime needs a full store
+      // reset so paths, sessions, and provider state cannot cross hosts.
+      if (detail.runtimeKey === detail.previousRuntimeKey) {
+        // Terminal-only: Pi/streaming reconnect in place on web/desktop, so
+        // only the terminal singleton needs an explicit generation bump.
+        resetTerminalTransport();
+        return;
+      }
       resetAppForRuntimeEndpointChange(detail);
       setRuntimeEndpointEpoch((epoch) => epoch + 1);
     });

--- a/packages/ui/src/apps/runtimeEndpointReset.ts
+++ b/packages/ui/src/apps/runtimeEndpointReset.ts
@@ -1,5 +1,5 @@
 import type { RuntimeEndpointChangedDetail } from '@/lib/runtime-switch';
-import { disposeTerminalInputTransport } from '@/lib/terminalApi';
+import { resetTerminalTransport } from '@/lib/terminalApi';
 import { useConfigStore } from '@/stores/useConfigStore';
 import { useProjectsStore } from '@/stores/useProjectsStore';
 import { useUIStore } from '@/stores/useUIStore';
@@ -30,15 +30,30 @@ import { updateBrowserURL } from '@/lib/router';
 // reconnect over the new transport IN PLACE. Message-pagination refs, the open
 // session, and the whole view are preserved — no reconnecting screen, no flash,
 // no bounce back to the draft.
+//
+// Terminal: resetting the transport bumps the explicit terminal generation
+// (see terminalApi). Mounted terminal consumers reattach the SAME runtime's
+// SAME PTY IDs once per generation — never recreating or killing the PTY.
+// Tabs, scrollback buffers, viewport dims, and xterm selection stay owned by
+// the terminal store/viewport refs and are preserved here. Auth/URL/relay
+// routing is unchanged (shared runtime-auth + resolver + openRuntimeWebSocket).
+// Pending input sent while the socket is down is dropped, not replayed.
 export const reconnectAppForTransportSwitch = (): void => {
-  disposeTerminalInputTransport();
+  resetTerminalTransport();
 };
 
 export const resetAppForRuntimeEndpointChange = (detail: RuntimeEndpointChangedDetail): void => {
   useSessionUIStore.getState().prepareForRuntimeSwitch(detail.previousRuntimeKey);
   useUIStore.getState().prepareForRuntimeSwitch(detail.previousRuntimeKey);
-  disposeTerminalInputTransport();
+  // Different runtime: never reuse old PTY IDs. Clear tabs/buffers BEFORE
+  // bumping the terminal generation: the generation handler checks store
+  // ownership synchronously, so clearing first prevents reattaching old IDs
+  // on the new runtime. Resetting then bumps the generation (rejecting late
+  // callbacks/data from the old transport). A same-ID PTY on the new runtime
+  // is a different PTY. Listeners/timers of the old transport are released
+  // by dispose().
   useTerminalStore.getState().clearAll();
+  resetTerminalTransport();
   // The previous runtime's cwd is not meaningful on the new host (for
   // example, a Windows path must never be sent to a WSL daemon). Clear it
   // before the new runtime's settings/project snapshot is applied.

--- a/packages/ui/src/components/views/terminal/__tests__/terminalReattach.test.tsx
+++ b/packages/ui/src/components/views/terminal/__tests__/terminalReattach.test.tsx
@@ -1,0 +1,638 @@
+/**
+ * Terminal reattach: mounted TerminalView pane behavior.
+ *
+ * Replaces the former source-string assertions in this file with real mounted
+ * behavior. The productionKeys under test live in the actual render tree:
+ * TerminalView maps one TerminalTabPane per tab (key={tab.id},
+ * sessionKey={`${directory}::${tab.id}`) and TerminalTabPane keeps every pane
+ * mounted while hidden (block/hidden CSS + aria-hidden) with its viewport
+ * keyed by the tab-stable sessionKey.
+ *
+ * Coverage replaced (old source-string tests in this file):
+ * - "panes stay mounted while hidden" -> now mounted: both panes in the DOM,
+ *   inactive pane hidden via CSS but still mounted with preserved instance
+ *   state across tab toggles.
+ * - "viewport identity is tab-stable, never PTY-keyed" -> now mounted:
+ *   assigning a PTY id to the same tab keeps the same sessionKey and does not
+ *   remount the viewport (mount count + local marker stable).
+ * - "transport switch reattaches via connect, creation only for null IDs",
+ *   "shared auth/URL/relay routing stays centralized", and "renamed transport
+ *   reset" string checks were removed here: they are proven behaviorally by
+ *   useTerminalSessionStream.transportSwitch.test.tsx (hook reattach exactly
+ *   once, stale rejection, different-runtime isolation, pending/input gating)
+ *   and terminalTransportSwitch.test.ts + terminalApi.test.ts (generation
+ *   bump, centralized auth refresh, stale disposal, no replay).
+ *
+ * Strategy: mount the real TerminalView with only its heavy leaf mocked
+ * (TerminalViewport -> lightweight probe). The real TerminalTabPane wrapper
+ * (hidden CSS, sessionKey key) and TerminalView mapping (key={tab.id}) stay
+ * under test. Runtime/theme/device/directory are test controls, not behavior
+ * under test.
+ */
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+
+import type { TerminalAPI } from '@/lib/api/types';
+import type { Theme } from '@/types/theme';
+
+// --- Test controls (not behavior under test) -------------------------------
+
+let fakeTerminal: TerminalAPI = {
+  async createSession() {
+    return { sessionId: 'created-1', cols: 80, rows: 24, status: 'running' };
+  },
+  connect() {
+    return { close: () => undefined };
+  },
+  async sendInput() {},
+  async resize() {},
+  async close() {},
+} as unknown as TerminalAPI;
+
+const fakeTheme = {
+  metadata: {
+    id: 'test-dark',
+    name: 'Test Dark',
+    description: 'Test theme',
+    version: '1',
+    variant: 'dark',
+    tags: [],
+  },
+  colors: {
+    primary: { base: '#ffffff' },
+    surface: {
+      background: '#000000',
+      foreground: '#ffffff',
+      muted: '#111111',
+      mutedForeground: '#aaaaaa',
+      elevated: '#111111',
+      elevatedForeground: '#ffffff',
+      overlay: '#000000',
+      subtle: '#111111',
+    },
+    interactive: {
+      border: '#333333',
+      borderHover: '#444444',
+      borderFocus: '#555555',
+      selection: '#333333',
+      selectionForeground: '#ffffff',
+      focus: '#ffffff',
+      focusRing: '#ffffff',
+      cursor: '#ffffff',
+      hover: '#222222',
+      active: '#222222',
+    },
+    status: {
+      error: '#ff0000',
+      errorForeground: '#ffcccc',
+      errorBackground: '#330000',
+      errorBorder: '#ff0000',
+      warning: '#ffff00',
+      warningForeground: '#333300',
+      warningBackground: '#333300',
+      warningBorder: '#ffff00',
+      success: '#00ff00',
+      successForeground: '#003300',
+      successBackground: '#003300',
+      successBorder: '#00ff00',
+      info: '#0000ff',
+      infoForeground: '#ffffff',
+      infoBackground: '#000033',
+      infoBorder: '#0000ff',
+    },
+    syntax: {
+      base: {
+        background: '#000000',
+        foreground: '#ffffff',
+        comment: '#888888',
+        keyword: '#ff00ff',
+        string: '#00ff00',
+        number: '#ff0000',
+        function: '#00ffff',
+        variable: '#ffffff',
+        type: '#ffff00',
+        operator: '#ffffff',
+      },
+    },
+  },
+} as unknown as Theme;
+
+const desktopDeviceInfo = {
+  isMobile: false,
+  isTablet: false,
+  isDesktop: true,
+  deviceType: 'desktop' as const,
+  screenWidth: 1280,
+  breakpoint: 'xl' as const,
+  hasTouchInput: false,
+  hasTouchOnlyPointer: false,
+};
+
+// Viewport probe state: one lightweight leaf per sessionKey. Mount counts and
+// a per-instance marker prove whether React remounted the viewport.
+const viewportMounts = new Map<string, number>();
+const viewportUnmounts = new Map<string, number>();
+const viewportLatestProps = new Map<string, { sessionKey: string; isVisible: boolean }>();
+let viewportInstanceSeq = 0;
+
+mock.module('@/components/icon/Icon', () => ({
+  Icon: () => null,
+}));
+
+mock.module('@/components/terminal/TerminalViewport', () => ({
+  TerminalViewport: React.forwardRef((props: Record<string, unknown>, ref: React.Ref<unknown>) => {
+    const sessionKey = props['sessionKey'] as string;
+    const isVisible = props['isVisible'] as boolean;
+    const [marker] = React.useState(() => {
+      viewportInstanceSeq += 1;
+      return `instance-${viewportInstanceSeq}`;
+    });
+    React.useEffect(() => {
+      viewportMounts.set(sessionKey, (viewportMounts.get(sessionKey) ?? 0) + 1);
+      return () => {
+        viewportUnmounts.set(sessionKey, (viewportUnmounts.get(sessionKey) ?? 0) + 1);
+      };
+    }, [sessionKey]);
+    viewportLatestProps.set(sessionKey, { sessionKey, isVisible });
+    React.useImperativeHandle(
+      ref,
+      () => ({
+        focus: () => undefined,
+        fit: () => undefined,
+        getSelection: () => null,
+      }),
+      [],
+    );
+    return React.createElement('div', {
+      'data-testid': `viewport-${sessionKey}`,
+      'data-session-key': sessionKey,
+      'data-visible': String(isVisible),
+      'data-marker': marker,
+    });
+  }),
+}));
+
+mock.module('@/hooks/useRuntimeAPIs', () => ({
+  useRuntimeAPIs: () => ({
+    terminal: fakeTerminal,
+    runtime: { platform: 'web', isDesktop: true },
+  }),
+}));
+
+mock.module('@/contexts/useThemeSystem', () => ({
+  useThemeSystem: () => ({ currentTheme: fakeTheme }),
+  useOptionalThemeSystem: () => ({ currentTheme: fakeTheme }),
+}));
+
+mock.module('@/lib/device', () => ({
+  useDeviceInfo: () => desktopDeviceInfo,
+  useTabletLayout: () => ({ enabled: false, roomyForPanels: false }),
+  useOrientation: () => 'landscape' as const,
+  useTabletStandalonePwaRuntime: () => false,
+  isMobileDeviceViaCSS: () => false,
+  getDeviceInfo: () => desktopDeviceInfo,
+  readTabletLayout: () => ({ enabled: false, roomyForPanels: false }),
+}));
+
+mock.module('@/hooks/useEffectiveDirectory', () => ({
+  useEffectiveDirectory: () => '/repo',
+}));
+
+const { TerminalView } = await import('@/components/views/TerminalView');
+const { useTerminalStore } = await import('@/stores/useTerminalStore');
+const { useSessionUIStore } = await import('@/sync/session-ui-store');
+
+// --- Minimal DOM stub (proven DiagramView/number-input pattern) -------------
+
+interface FakeNode {
+  nodeType: number;
+  nodeName: string;
+  tagName: string;
+  ownerDocument: FakeDocument | null;
+  parentNode: FakeNode | null;
+  childNodes: FakeNode[];
+  style: Record<string, unknown>;
+  classList: { add(...c: string[]): void; remove(...c: string[]): void; contains(c: string): boolean };
+  [key: string]: unknown;
+}
+
+interface FakeDocument extends FakeNode {
+  defaultView: FakeWindow;
+  body: FakeNode;
+  head: FakeNode;
+  documentElement: FakeNode;
+  createElement(tag: string): FakeNode;
+  createElementNS(_ns: string, tag: string): FakeNode;
+  createTextNode(text: string): FakeNode;
+  createDocumentFragment(): FakeNode;
+  getElementById(_id: string): FakeNode | null;
+  activeElement: FakeNode | null;
+}
+
+interface FakeWindow {
+  document: FakeDocument;
+  navigator: { userAgent: string; platform: string; maxTouchPoints: number };
+  location: { search: string; protocol: string; hostname: string };
+  innerWidth: number;
+  innerHeight: number;
+  matchMedia(query: string): { matches: boolean; addEventListener(): void; removeEventListener(): void };
+  getComputedStyle(_elt: unknown): { getPropertyValue(_name: string): string };
+  requestAnimationFrame(cb: () => void): number;
+  cancelAnimationFrame(_id: number): void;
+  setTimeout: typeof setTimeout;
+  clearTimeout: typeof clearTimeout;
+  addEventListener(): void;
+  removeEventListener(): void;
+  dispatchEvent(): boolean;
+  [key: string]: unknown;
+}
+
+function makeNode(tag: string, owner: FakeDocument | null): FakeNode {
+  const node = {
+    nodeType: 1,
+    nodeName: tag.toUpperCase(),
+    tagName: tag.toUpperCase(),
+    ownerDocument: owner,
+    parentNode: null,
+    childNodes: [] as FakeNode[],
+    style: {
+      setProperty() {},
+      getPropertyValue() { return ''; },
+      removeProperty() {},
+    },
+    classList: {
+      add() {},
+      remove() {},
+      contains() { return false; },
+    },
+    setAttribute() {},
+    removeAttribute() {},
+    hasAttribute() { return false; },
+    getAttribute() { return null; },
+    addEventListener() {},
+    removeEventListener() {},
+    appendChild(c: FakeNode) {
+      (this as FakeNode).childNodes.push(c);
+      c.parentNode = this as unknown as FakeNode;
+      return c;
+    },
+    insertBefore(c: FakeNode, ref: FakeNode) {
+      const list = (this as FakeNode).childNodes;
+      const i = list.indexOf(ref);
+      if (i < 0) list.push(c);
+      else list.splice(i, 0, c);
+      c.parentNode = this as unknown as FakeNode;
+      return c;
+    },
+    removeChild(c: FakeNode) {
+      const list = (this as FakeNode).childNodes;
+      const i = list.indexOf(c);
+      if (i >= 0) list.splice(i, 1);
+      c.parentNode = null;
+      return c;
+    },
+    contains() { return false; },
+    focus() {},
+    blur() {},
+    click() {},
+    hasPointerCapture() { return false; },
+    setPointerCapture() {},
+    releasePointerCapture() {},
+    getBoundingClientRect() { return { width: 800, height: 600, left: 0, top: 0, right: 800, bottom: 600 }; },
+    querySelector() { return null; },
+    closest() { return null; },
+    textContent: '',
+    innerHTML: '',
+  } as unknown as FakeNode;
+  return node;
+}
+
+function installDomStub(): { restore: () => void; container: FakeNode } {
+  const document = {
+    nodeType: 9,
+    nodeName: '#document',
+    tagName: '#document',
+    parentNode: null,
+    childNodes: [] as FakeNode[],
+    style: {},
+    classList: { add() {}, remove() {}, contains() { return false; } },
+    setAttribute() {},
+    getAttribute() { return null; },
+    addEventListener() {},
+    removeEventListener() {},
+    hasFocus() { return true; },
+    getElementById() { return null; },
+    querySelector() { return null; },
+    createTextNode(text: string) {
+      return { nodeType: 3, nodeName: '#text', textContent: text, parentNode: null } as unknown as FakeNode;
+    },
+    createElement(tag: string) { return makeNode(tag, document as unknown as FakeDocument); },
+    createElementNS(_ns: string, tag: string) { return makeNode(tag, document as unknown as FakeDocument); },
+    createDocumentFragment() { return makeNode('#fragment', document as unknown as FakeDocument); },
+    visibilityState: 'visible',
+    activeElement: null,
+  } as unknown as FakeDocument;
+
+  const win = {
+    document,
+    navigator: { userAgent: 'test', platform: 'test', maxTouchPoints: 0 },
+    location: { search: '', protocol: 'http:', hostname: 'localhost' },
+    innerWidth: 1280,
+    innerHeight: 800,
+    matchMedia() { return { matches: false, addEventListener() {}, removeEventListener() {} }; },
+    getComputedStyle() { return { getPropertyValue() { return ''; } }; },
+    requestAnimationFrame(cb: () => void) { return setTimeout(cb, 0) as unknown as number; },
+    cancelAnimationFrame(id: number) { clearTimeout(id); },
+    setTimeout,
+    clearTimeout,
+    addEventListener() {},
+    removeEventListener() {},
+    dispatchEvent() { return true; },
+    Element: class {},
+    HTMLElement: class {},
+    HTMLIFrameElement: class {},
+    HTMLInputElement: class {},
+    HTMLTextAreaElement: class {},
+    ResizeObserver: class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+    IntersectionObserver: class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  } as unknown as FakeWindow;
+  document.defaultView = win;
+  document.body = makeNode('body', document);
+  document.head = makeNode('head', document);
+  document.documentElement = makeNode('html', document);
+
+  const g = globalThis as unknown as Record<string, unknown>;
+  const previous = {
+    document: g['document'],
+    window: g['window'],
+    navigator: g['navigator'],
+    Element: g['Element'],
+    HTMLElement: g['HTMLElement'],
+    HTMLIFrameElement: g['HTMLIFrameElement'],
+    requestAnimationFrame: g['requestAnimationFrame'],
+    cancelAnimationFrame: g['cancelAnimationFrame'],
+    getComputedStyle: g['getComputedStyle'],
+    ResizeObserver: g['ResizeObserver'],
+    IntersectionObserver: g['IntersectionObserver'],
+    localStorage: g['localStorage'],
+    sessionStorage: g['sessionStorage'],
+    IS_REACT_ACT_ENVIRONMENT: g['IS_REACT_ACT_ENVIRONMENT'],
+  };
+  g['IS_REACT_ACT_ENVIRONMENT'] = true;
+  g['document'] = document;
+  g['window'] = win;
+  g['navigator'] = win.navigator;
+  g['Element'] = win['Element'];
+  g['HTMLElement'] = win['HTMLElement'];
+  g['HTMLIFrameElement'] = win['HTMLIFrameElement'];
+  g['requestAnimationFrame'] = win.requestAnimationFrame.bind(win);
+  g['cancelAnimationFrame'] = win.cancelAnimationFrame.bind(win);
+  g['getComputedStyle'] = win.getComputedStyle.bind(win);
+  g['ResizeObserver'] = win['ResizeObserver'];
+  g['IntersectionObserver'] = win['IntersectionObserver'];
+  if (!g['localStorage']) {
+    const store = new Map<string, string>();
+    g['localStorage'] = {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => { store.set(k, String(v)); },
+      removeItem: (k: string) => { store.delete(k); },
+      clear: () => { store.clear(); },
+    };
+  }
+  if (!g['sessionStorage']) {
+    const store = new Map<string, string>();
+    g['sessionStorage'] = {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => { store.set(k, String(v)); },
+      removeItem: (k: string) => { store.delete(k); },
+      clear: () => { store.clear(); },
+    };
+  }
+  const container = document.createElement('div');
+  return {
+    container,
+    restore() {
+      g['document'] = previous['document'];
+      g['window'] = previous['window'];
+      g['navigator'] = previous['navigator'];
+      g['Element'] = previous['Element'];
+      g['HTMLElement'] = previous['HTMLElement'];
+      g['HTMLIFrameElement'] = previous['HTMLIFrameElement'];
+      g['requestAnimationFrame'] = previous['requestAnimationFrame'];
+      g['cancelAnimationFrame'] = previous['cancelAnimationFrame'];
+      g['getComputedStyle'] = previous['getComputedStyle'];
+      g['ResizeObserver'] = previous['ResizeObserver'];
+      g['IntersectionObserver'] = previous['IntersectionObserver'];
+      g['localStorage'] = previous['localStorage'];
+      g['sessionStorage'] = previous['sessionStorage'];
+      g['IS_REACT_ACT_ENVIRONMENT'] = previous['IS_REACT_ACT_ENVIRONMENT'];
+    },
+  };
+}
+
+const roots: Root[] = [];
+const restores: Array<() => void> = [];
+
+const flush = async () => {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await Promise.resolve();
+  });
+};
+
+const reactPropsOf = (node: FakeNode): Record<string, unknown> | null => {
+  const key = Object.keys(node).find((k) => k.startsWith('__reactProps'));
+  if (!key) return null;
+  return (node as unknown as Record<string, Record<string, unknown>>)[key] ?? null;
+};
+
+const collectViewports = (container: FakeNode): Array<{ node: FakeNode; props: Record<string, unknown> }> => {
+  const found: Array<{ node: FakeNode; props: Record<string, unknown> }> = [];
+  const visit = (node: FakeNode) => {
+    const props = reactPropsOf(node);
+    if (props && typeof props['data-testid'] === 'string' && (props['data-testid'] as string).startsWith('viewport-')) {
+      found.push({ node, props });
+    }
+    for (const child of node.childNodes) visit(child);
+  };
+  visit(container);
+  return found;
+};
+
+const wrapperHiddenState = (viewportNode: FakeNode): { className: string; ariaHidden: unknown } => {
+  // The real TerminalTabPane wrapper is the direct parent of the viewport
+  // probe: <div className="h-full w-full block|hidden" aria-hidden>.
+  const parent = viewportNode.parentNode;
+  if (!parent) return { className: '', ariaHidden: undefined };
+  const props = reactPropsOf(parent);
+  return {
+    className: typeof props?.['className'] === 'string' ? (props['className'] as string) : '',
+    ariaHidden: props?.['aria-hidden'],
+  };
+};
+
+afterEach(async () => {
+  for (const root of roots.splice(0)) {
+    await act(async () => root.unmount());
+  }
+  restores.splice(0).forEach((restore) => restore());
+  viewportMounts.clear();
+  viewportUnmounts.clear();
+  viewportLatestProps.clear();
+  viewportInstanceSeq = 0;
+  fakeTerminal = {
+    async createSession() {
+      return { sessionId: 'created-1', cols: 80, rows: 24, status: 'running' };
+    },
+    connect() {
+      return { close: () => undefined };
+    },
+    async sendInput() {},
+    async resize() {},
+    async close() {},
+  } as unknown as TerminalAPI;
+  useTerminalStore.getState().clearAll();
+  useSessionUIStore.setState({ currentSessionId: null, newSessionDraft: { open: false } as never });
+});
+
+const renderTerminalView = async () => {
+  const stub = installDomStub();
+  restores.push(stub.restore);
+  useSessionUIStore.setState({ currentSessionId: 'sess-1' });
+  const root = createRoot(stub.container as unknown as Element);
+  roots.push(root);
+  await act(async () => {
+    root.render(React.createElement(TerminalView, { visible: true }));
+  });
+  await flush();
+  await flush();
+  return stub.container;
+};
+
+const setupTwoTabs = () => {
+  useTerminalStore.getState().clearAll();
+  useTerminalStore.getState().ensureDirectory('/repo');
+  const first = useTerminalStore.getState().getDirectoryState('/repo')!.tabs[0]!.id;
+  const second = useTerminalStore.getState().createTab('/repo');
+  useTerminalStore.getState().setTabSessionId('/repo', first, 'pty-a');
+  useTerminalStore.getState().setTabSessionId('/repo', second, 'pty-b');
+  useTerminalStore.getState().setActiveTab('/repo', first);
+  return { first, second };
+};
+
+describe('terminal reattach preserves viewport identity (mounted)', () => {
+  test('tab toggle keeps both panes mounted; hidden pane preserves instance state', async () => {
+    const { first, second } = setupTwoTabs();
+    const container = await renderTerminalView();
+
+    const keyFor = (tabId: string) => `/repo::${tabId}`;
+    let viewports = collectViewports(container);
+    // Both tabs render a pane even though only one is active: no unmount on
+    // tab switch, so VT state and xterm selection survive.
+    expect(viewports).toHaveLength(2);
+
+    const byKey = new Map(viewports.map((v) => [v.props['data-session-key'], v]));
+    expect([...byKey.keys()].sort()).toEqual([keyFor(first), keyFor(second)].sort());
+    for (const v of viewports) {
+      expect(viewportMounts.get(v.props['data-session-key'] as string)).toBe(1);
+    }
+    const markerBefore = new Map(viewports.map((v) => [v.props['data-session-key'], v.props['data-marker']]));
+
+    const activeBefore = byKey.get(keyFor(first))!;
+    const hiddenBefore = byKey.get(keyFor(second))!;
+    expect(wrapperHiddenState(activeBefore.node).className).toContain('block');
+    expect(wrapperHiddenState(activeBefore.node).className).not.toContain('hidden');
+    expect(wrapperHiddenState(activeBefore.node).ariaHidden).toBe(false);
+    expect(wrapperHiddenState(hiddenBefore.node).className).toContain('hidden');
+    expect(wrapperHiddenState(hiddenBefore.node).ariaHidden).toBe(true);
+
+    // Toggle the active tab. The switch only flips visibility: both viewport
+    // instances stay mounted with identical local markers.
+    await act(async () => {
+      useTerminalStore.getState().setActiveTab('/repo', second);
+    });
+    await flush();
+
+    viewports = collectViewports(container);
+    expect(viewports).toHaveLength(2);
+    const byKeyAfter = new Map(viewports.map((v) => [v.props['data-session-key'], v]));
+    expect([...byKeyAfter.keys()].sort()).toEqual([keyFor(first), keyFor(second)].sort());
+    for (const v of viewports) {
+      expect(v.props['data-marker']).toBe(markerBefore.get(v.props['data-session-key']));
+      expect(viewportMounts.get(v.props['data-session-key'] as string)).toBe(1);
+      expect(viewportUnmounts.get(v.props['data-session-key'] as string) ?? 0).toBe(0);
+    }
+
+    const nowActive = byKeyAfter.get(keyFor(second))!;
+    const nowHidden = byKeyAfter.get(keyFor(first))!;
+    expect(wrapperHiddenState(nowActive.node).className).toContain('block');
+    expect(wrapperHiddenState(nowActive.node).ariaHidden).toBe(false);
+    expect(wrapperHiddenState(nowHidden.node).className).toContain('hidden');
+    expect(wrapperHiddenState(nowHidden.node).ariaHidden).toBe(true);
+
+    // Toggling back still preserves both instances.
+    await act(async () => {
+      useTerminalStore.getState().setActiveTab('/repo', first);
+    });
+    await flush();
+    viewports = collectViewports(container);
+    expect(viewports).toHaveLength(2);
+    for (const v of viewports) {
+      expect(v.props['data-marker']).toBe(markerBefore.get(v.props['data-session-key']));
+      expect(viewportMounts.get(v.props['data-session-key'] as string)).toBe(1);
+    }
+  });
+
+  test('assigning a PTY id to the same tab keeps the stable sessionKey without remounting', async () => {
+    useTerminalStore.getState().clearAll();
+    useTerminalStore.getState().ensureDirectory('/repo');
+    const tabId = useTerminalStore.getState().getDirectoryState('/repo')!.tabs[0]!.id;
+    const container = await renderTerminalView();
+
+    const sessionKey = `/repo::${tabId}`;
+    let viewports = collectViewports(container);
+    expect(viewports).toHaveLength(1);
+    expect(viewports[0]!.props['data-session-key']).toBe(sessionKey);
+    const markerBefore = viewports[0]!.props['data-marker'];
+    expect(viewportMounts.get(sessionKey)).toBe(1);
+
+    // Fresh PTY assignment for the same tab: the viewport identity is
+    // directory+tab, never the PTY id, so the xterm instance (dims/selection)
+    // survives instead of remounting.
+    await act(async () => {
+      useTerminalStore.getState().setTabSessionId('/repo', tabId, 'pty-a');
+    });
+    await flush();
+    await flush();
+
+    viewports = collectViewports(container);
+    expect(viewports).toHaveLength(1);
+    expect(viewports[0]!.props['data-session-key']).toBe(sessionKey);
+    expect(viewports[0]!.props['data-marker']).toBe(markerBefore);
+    expect(viewportMounts.get(sessionKey)).toBe(1);
+    expect(viewportUnmounts.get(sessionKey) ?? 0).toBe(0);
+
+    // Reassigning to another PTY id on the same tab is still the same pane.
+    await act(async () => {
+      useTerminalStore.getState().setTabSessionId('/repo', tabId, 'pty-b');
+    });
+    await flush();
+    await flush();
+
+    viewports = collectViewports(container);
+    expect(viewports).toHaveLength(1);
+    expect(viewports[0]!.props['data-session-key']).toBe(sessionKey);
+    expect(viewports[0]!.props['data-marker']).toBe(markerBefore);
+    expect(viewportMounts.get(sessionKey)).toBe(1);
+    expect(viewportUnmounts.get(sessionKey) ?? 0).toBe(0);
+  });
+});

--- a/packages/ui/src/components/views/terminal/useTerminalSessionStream.transportSwitch.test.tsx
+++ b/packages/ui/src/components/views/terminal/useTerminalSessionStream.transportSwitch.test.tsx
@@ -1,0 +1,455 @@
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { useTerminalStore } from '@/stores/useTerminalStore';
+import type { TerminalAPI, TerminalHandlers, TerminalStreamEvent } from '@/lib/api/types';
+import { getTerminalTransportGeneration, resetTerminalTransport } from '@/lib/terminalApi';
+
+const { useTerminalSessionStream } = await import('./useTerminalSessionStream');
+const { useTerminalInputHandling } = await import('./useTerminalInputHandling');
+
+type StreamProps = Parameters<typeof useTerminalSessionStream>[0];
+type StreamResult = ReturnType<typeof useTerminalSessionStream>;
+
+let latest: StreamResult | null = null;
+const Probe = (props: StreamProps) => {
+  latest = useTerminalSessionStream(props);
+  return null;
+};
+
+const installMinimalDom = () => {
+  const descriptors = new Map<string, PropertyDescriptor | undefined>();
+  const setGlobal = (name: string, value: unknown) => {
+    descriptors.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
+    Object.defineProperty(globalThis, name, { configurable: true, writable: true, value });
+  };
+  class ElementStub {}
+  const documentStub: Record<string, unknown> = {
+    nodeType: 9,
+    defaultView: globalThis,
+    activeElement: null,
+    hasFocus: () => true,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+  };
+  const container = {
+    nodeType: 1,
+    tagName: 'DIV',
+    nodeName: 'DIV',
+    namespaceURI: 'http://www.w3.org/1999/xhtml',
+    ownerDocument: documentStub,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+  };
+  documentStub.documentElement = container;
+  documentStub.body = container;
+  setGlobal('document', documentStub);
+  setGlobal('window', globalThis);
+  setGlobal('Element', ElementStub);
+  setGlobal('HTMLElement', ElementStub);
+  setGlobal('HTMLIFrameElement', ElementStub);
+  setGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  return {
+    container: container as unknown as Element,
+    restore: () => {
+      for (const [name, descriptor] of descriptors) {
+        if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+        else Reflect.deleteProperty(globalThis, name);
+      }
+    },
+  };
+};
+
+const roots: Root[] = [];
+const restoreFns: Array<() => void> = [];
+
+const renderStream = async (props: StreamProps) => {
+  const dom = installMinimalDom();
+  restoreFns.push(dom.restore);
+  const root = createRoot(dom.container);
+  roots.push(root);
+  await act(async () => {
+    root.render(<Probe {...props} />);
+  });
+};
+
+afterEach(async () => {
+  for (const root of roots.splice(0)) {
+    await act(async () => root.unmount());
+  }
+  restoreFns.splice(0).forEach((restore) => restore());
+  latest = null;
+  useTerminalStore.getState().clearAll();
+});
+
+type FakeConnection = {
+  sessionId: string;
+  handlers: TerminalHandlers;
+  closed: boolean;
+};
+
+const createFakeTerminal = (options: { autoSnapshot?: boolean } = {}) => {
+  const autoSnapshot = options.autoSnapshot ?? true;
+  const connections: FakeConnection[] = [];
+  const created: Array<{ cwd: string }> = [];
+  const resized: Array<{ sessionId: string; cols: number; rows: number }> = [];
+  const terminal: TerminalAPI = {
+    async createSession(options) {
+      created.push({ cwd: options.cwd });
+      return { sessionId: `created-${created.length}`, cols: 80, rows: 24, status: 'running' };
+    },
+    connect(sessionId, handlers) {
+      const conn: FakeConnection = { sessionId, handlers, closed: false };
+      connections.push(conn);
+      // Authoritative snapshot on attach (same PTY, same history).
+      if (autoSnapshot) {
+        queueMicrotask(() => {
+          if (!conn.closed) handlers.onEvent({ type: 'snapshot', sequence: 10, data: 'prompt$ ', status: 'running' });
+        });
+      }
+      return { close: () => { conn.closed = true; } };
+    },
+    async sendInput() {},
+    async resize(payload) { resized.push(payload); },
+    async close() {},
+  };
+  const connectsFor = (id: string) => connections.filter((c) => c.sessionId === id);
+  const emit = (sessionId: string, event: TerminalStreamEvent) => {
+    for (const conn of connectsFor(sessionId)) {
+      if (!conn.closed) conn.handlers.onEvent(event);
+    }
+  };
+  return { terminal, connections, created, resized, connectsFor, emit };
+};
+
+const appearanceRef = () => ({ current: { themeMode: 'dark' as const, terminalBackground: '', terminalForeground: '' } });
+
+const setupTwoTabs = () => {
+  const store = useTerminalStore.getState();
+  store.clearAll();
+  store.ensureDirectory('/repo');
+  const first = store.getDirectoryState('/repo')!.tabs[0]!.id;
+  const second = store.createTab('/repo');
+  useTerminalStore.getState().setTabSessionId('/repo', first, 'pty-a');
+  useTerminalStore.getState().setTabSessionId('/repo', second, 'pty-b');
+  useTerminalStore.getState().appendToBuffer('/repo', first, 'prompt$ ', 10);
+  useTerminalStore.getState().appendToBuffer('/repo', second, 'prompt$ ', 10);
+  return { first, second };
+};
+
+const streamProps = (fake: ReturnType<typeof createFakeTerminal>, tabs: Array<{ id: string; terminalSessionId: string | null; label: string }>, overrides: Partial<StreamProps> = {}): StreamProps => ({
+  terminal: fake.terminal,
+  effectiveDirectory: '/repo',
+  activeTabId: tabs[0]!.id,
+  terminalSessionId: tabs[0]!.terminalSessionId,
+  terminalLifecycle: 'running',
+  hasOpenedTerminalViewport: true,
+  terminalHydrated: true,
+  terminalShell: 'auto',
+  terminalLoginShell: false,
+  terminalAppearanceRef: appearanceRef(),
+  enableTabs: true,
+  hasActiveContext: true,
+  focusTerminalWhenWindowActive: () => {},
+  tabs,
+  ...overrides,
+});
+
+describe('useTerminalSessionStream transport switch', () => {
+  test('mounted multiple tabs reattach same PTYs exactly once, preserving scrollback/dims', async () => {
+    const fake = createFakeTerminal();
+    const { first, second } = setupTwoTabs();
+    const tabs = [
+      { id: first, terminalSessionId: 'pty-a', label: 'Terminal' },
+      { id: second, terminalSessionId: 'pty-b', label: 'Terminal 2' },
+    ];
+    await renderStream(streamProps(fake, tabs));
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    expect(fake.connectsFor('pty-a')).toHaveLength(1);
+    expect(fake.connectsFor('pty-b')).toHaveLength(1);
+    expect(fake.created).toHaveLength(0);
+
+    const bufferBeforeA = useTerminalStore.getState().getBuffer('/repo', first);
+    latest!.lastViewportSizeRef.current = { cols: 100, rows: 30 };
+
+    const generationBefore = getTerminalTransportGeneration();
+    await act(async () => { resetTerminalTransport(); });
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    expect(getTerminalTransportGeneration()).toBe(generationBefore + 1);
+    // Exactly one reattach per PTY, same IDs, no new PTY creation.
+    expect(fake.connectsFor('pty-a')).toHaveLength(2);
+    expect(fake.connectsFor('pty-b')).toHaveLength(2);
+    expect(fake.created).toHaveLength(0);
+    // Tab IDs preserved, scrollback not duplicated (snapshot sequence 10 deduped).
+    const bufferAfterA = useTerminalStore.getState().getBuffer('/repo', first);
+    expect(bufferAfterA.lastSequence).toBe(10);
+    expect(bufferAfterA.chunks.map((c) => c.data).join('')).toBe(bufferBeforeA.chunks.map((c) => c.data).join(''));
+    // Dims preserved and re-asserted on the reattached PTYs.
+    expect(latest!.lastViewportSizeRef.current).toEqual({ cols: 100, rows: 30 });
+    expect(fake.resized.filter((r) => r.sessionId === 'pty-a' || r.sessionId === 'pty-b').length).toBeGreaterThanOrEqual(2);
+    // Reconnect pending cleared by the active tab snapshot.
+    expect(latest!.isReconnectPending).toBe(false);
+  });
+
+  test('old late events after replacement are rejected', async () => {
+    const fake = createFakeTerminal();
+    const { first } = setupTwoTabs();
+    const tabs = [
+      { id: first, terminalSessionId: 'pty-a', label: 'Terminal' },
+      { id: useTerminalStore.getState().getDirectoryState('/repo')!.tabs[1]!.id, terminalSessionId: 'pty-b', label: 'Terminal 2' },
+    ];
+    await renderStream(streamProps(fake, tabs));
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    const oldConns = [...fake.connections];
+    await act(async () => { resetTerminalTransport(); });
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    const bufferBefore = useTerminalStore.getState().getBuffer('/repo', first).chunks.map((c) => c.data).join('');
+    // Late data on the old generation must not append.
+    await act(async () => {
+      for (const conn of oldConns) {
+        if (conn.sessionId === 'pty-a') conn.handlers.onEvent({ type: 'data', sequence: 99, data: 'STALE' });
+      }
+    });
+    const bufferAfter = useTerminalStore.getState().getBuffer('/repo', first).chunks.map((c) => c.data).join('');
+    expect(bufferAfter).toBe(bufferBefore);
+    expect(bufferAfter).not.toContain('STALE');
+  });
+
+  test('different runtime same ID never attaches old PTYs', async () => {
+    const fake = createFakeTerminal();
+    const { first } = setupTwoTabs();
+    const tabs = [{ id: first, terminalSessionId: 'pty-a', label: 'Terminal' }];
+    await renderStream(streamProps(fake, tabs));
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    expect(fake.connectsFor('pty-a')).toHaveLength(1);
+
+    // Different-runtime reset clears the store; the hook must not reattach old IDs.
+    await act(async () => {
+      useTerminalStore.getState().clearAll();
+      resetTerminalTransport();
+    });
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    // No additional attach for the old ID after the store was cleared.
+    expect(fake.connectsFor('pty-a')).toHaveLength(1);
+  });
+
+  test('no resize on stale/unowned tabs during a different-runtime switch', async () => {
+    const fake = createFakeTerminal();
+    const { first, second } = setupTwoTabs();
+    const tabs = [
+      { id: first, terminalSessionId: 'pty-a', label: 'Terminal' },
+      { id: second, terminalSessionId: 'pty-b', label: 'Terminal 2' },
+    ];
+    await renderStream(streamProps(fake, tabs));
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    expect(fake.connectsFor('pty-a')).toHaveLength(1);
+    expect(fake.connectsFor('pty-b')).toHaveLength(1);
+    // Viewport dims are known, so the reattach path would resize owned PTYs.
+    latest!.lastViewportSizeRef.current = { cols: 100, rows: 30 };
+    fake.resized.length = 0;
+
+    // Stale close/reassign raced the switch: the store no longer owns pty-b
+    // while the hook props (tabsRef) still hold it. Only the owned PTY may
+    // reattach and resize; the stale ID must never reach the new transport.
+    await act(async () => {
+      useTerminalStore.getState().setTabSessionId('/repo', second, null);
+    });
+    await act(async () => { resetTerminalTransport(); });
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    expect(fake.connectsFor('pty-a')).toHaveLength(2);
+    expect(fake.connectsFor('pty-b')).toHaveLength(1);
+    expect(fake.resized.filter((r) => r.sessionId === 'pty-a')).toHaveLength(1);
+    expect(fake.resized.filter((r) => r.sessionId === 'pty-b')).toHaveLength(0);
+
+    // Different-runtime switch with a stale tabsRef: clearAll() runs before
+    // the synchronous generation bump without a re-render, so tabsRef still
+    // holds the old IDs. No old PTY may be resized on the new runtime.
+    fake.resized.length = 0;
+    const connectsBefore = fake.connections.length;
+    await act(async () => {
+      useTerminalStore.getState().clearAll();
+      resetTerminalTransport();
+    });
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    expect(fake.connections.length).toBe(connectsBefore);
+    expect(fake.resized).toHaveLength(0);
+  });
+
+  test('unmount cleans up generation listeners; no reattach after unmount', async () => {
+    const fake = createFakeTerminal();
+    const { first, second } = setupTwoTabs();
+    const tabs = [
+      { id: first, terminalSessionId: 'pty-a', label: 'Terminal' },
+      { id: second, terminalSessionId: 'pty-b', label: 'Terminal 2' },
+    ];
+    await renderStream(streamProps(fake, tabs));
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    expect(fake.connections).toHaveLength(2);
+    for (const root of roots.splice(0)) {
+      await act(async () => root.unmount());
+    }
+    restoreFns.splice(0).forEach((restore) => restore());
+    latest = null;
+    await act(async () => { resetTerminalTransport(); });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(fake.connections).toHaveLength(2);
+  });
+
+  test('reattach raises pending until the fresh snapshot arrives (input gate window)', async () => {
+    // Manual snapshots so the test can observe the pending window before the
+    // fresh snapshot clears it. Auto snapshots would flush inside act and
+    // hide the synchronous pending=true set by the generation handler.
+    const fake = createFakeTerminal({ autoSnapshot: false });
+    const { first, second } = setupTwoTabs();
+    const tabs = [
+      { id: first, terminalSessionId: 'pty-a', label: 'Terminal' },
+      { id: second, terminalSessionId: 'pty-b', label: 'Terminal 2' },
+    ];
+    await renderStream(streamProps(fake, tabs));
+    await act(async () => {
+      fake.emit('pty-a', { type: 'snapshot', sequence: 10, data: 'prompt$ ', status: 'running' });
+      fake.emit('pty-b', { type: 'snapshot', sequence: 10, data: 'prompt$ ', status: 'running' });
+    });
+    expect(latest!.isReconnectPending).toBe(false);
+    // Reset raises pending synchronously; the fresh snapshot clears it.
+    // Input typed in this window must be dropped, never replayed (the
+    // viewport input handler early-returns while pending, and the transport
+    // write guard rejects writes straddling the generation bump).
+    // Render without awaiting the snapshot flush: act without the 10ms wait
+    // keeps the manual snapshot from arriving, so pending stays observable.
+    await act(async () => { resetTerminalTransport(); });
+    expect(latest!.isReconnectPending).toBe(true);
+    await act(async () => {
+      fake.emit('pty-a', { type: 'snapshot', sequence: 10, data: 'prompt$ ', status: 'running' });
+      fake.emit('pty-b', { type: 'snapshot', sequence: 10, data: 'prompt$ ', status: 'running' });
+    });
+    expect(latest!.isReconnectPending).toBe(false);
+    expect(fake.connectsFor('pty-a')).toHaveLength(2);
+    expect(fake.connectsFor('pty-b')).toHaveLength(2);
+  });
+
+  test('old late snapshot/open and reconnecting/backoff are rejected after replacement', async () => {
+    const fake = createFakeTerminal();
+    const { first } = setupTwoTabs();
+    const tabs = [
+      { id: first, terminalSessionId: 'pty-a', label: 'Terminal' },
+      { id: useTerminalStore.getState().getDirectoryState('/repo')!.tabs[1]!.id, terminalSessionId: 'pty-b', label: 'Terminal 2' },
+    ];
+    await renderStream(streamProps(fake, tabs));
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    const oldConns = [...fake.connections];
+    const bufferBefore = useTerminalStore.getState().getBuffer('/repo', first).chunks.map((c) => c.data).join('');
+    await act(async () => { resetTerminalTransport(); });
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    // Fresh snapshot arrived and cleared pending.
+    expect(latest!.isReconnectPending).toBe(false);
+    // Old late snapshot/open with a newer sequence must not overwrite.
+    await act(async () => {
+      for (const conn of oldConns) {
+        if (conn.sessionId === 'pty-a') conn.handlers.onEvent({ type: 'snapshot', sequence: 99, data: 'STALE-SNAPSHOT', status: 'running' });
+      }
+    });
+    const afterStaleSnapshot = useTerminalStore.getState().getBuffer('/repo', first).chunks.map((c) => c.data).join('');
+    expect(afterStaleSnapshot).toBe(bufferBefore);
+    expect(afterStaleSnapshot).not.toContain('STALE-SNAPSHOT');
+    // Old late reconnecting/backoff must not raise pending after it cleared.
+    await act(async () => {
+      for (const conn of oldConns) {
+        if (conn.sessionId === 'pty-a') conn.handlers.onEvent({ type: 'reconnecting', attempt: 7, maxAttempts: Number.POSITIVE_INFINITY });
+      }
+    });
+    expect(latest!.isReconnectPending).toBe(false);
+    // Old late non-fatal error must not surface.
+    await act(async () => {
+      for (const conn of oldConns) {
+        if (conn.sessionId === 'pty-a') conn.handlers.onError?.(Object.assign(new Error('stale'), { code: 'STALE' }), false);
+      }
+    });
+    expect(latest!.isReconnectPending).toBe(false);
+  });
+
+  test('ordinary reconnect still works after a switch (later reconnect)', async () => {
+    const fake = createFakeTerminal();
+    const { first, second } = setupTwoTabs();
+    const tabs = [
+      { id: first, terminalSessionId: 'pty-a', label: 'Terminal' },
+      { id: second, terminalSessionId: 'pty-b', label: 'Terminal 2' },
+    ];
+    await renderStream(streamProps(fake, tabs));
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    await act(async () => { resetTerminalTransport(); });
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    expect(latest!.isReconnectPending).toBe(false);
+    const attachesBefore = fake.connectsFor('pty-a').length + fake.connectsFor('pty-b').length;
+    // Later ordinary reconnect on the CURRENT generation still signals pending
+    // (hidden/offline backoff lives in the transport; the hook surfaces it).
+    await act(async () => {
+      fake.emit('pty-a', { type: 'reconnecting', attempt: 1, maxAttempts: Number.POSITIVE_INFINITY });
+    });
+    expect(latest!.isReconnectPending).toBe(true);
+    await act(async () => {
+      fake.emit('pty-a', { type: 'snapshot', sequence: 10, data: 'prompt$ ', status: 'running' });
+    });
+    expect(latest!.isReconnectPending).toBe(false);
+    // No extra PTY creation or reattach from the later reconnect.
+    expect(fake.created).toHaveLength(0);
+    expect(fake.connectsFor('pty-a').length + fake.connectsFor('pty-b').length).toBe(attachesBefore);
+    // Scrollback still deduped by sequence after the later cycle.
+    const buffer = useTerminalStore.getState().getBuffer('/repo', first).chunks.map((c) => c.data).join('');
+    expect(buffer).toBe('prompt$ ');
+  });
+
+  test('input is dropped while reattach pending, sent after snapshot (no replay)', async () => {
+    const sent: Array<{ sessionId: string; data: string }> = [];
+    const fakeTerminal = {
+      async createSession() { throw new Error('unreachable'); },
+      connect() { return { close: () => {} }; },
+      async sendInput(sessionId: string, data: string) { sent.push({ sessionId, data }); },
+      async resize() {},
+      async close() {},
+    } as unknown as TerminalAPI;
+    let latestInput: ReturnType<typeof useTerminalInputHandling> | null = null;
+    const InputProbe = ({ pending }: { pending: boolean }) => {
+      const terminalIdRef = React.useRef<string | null>('pty-a');
+      const lastViewportSizeRef = React.useRef<{ cols: number; rows: number } | null>(null);
+      const [, setError] = React.useState<string | null>(null);
+      latestInput = useTerminalInputHandling({
+        terminal: fakeTerminal,
+        terminalIdRef,
+        isReconnectPending: pending,
+        setConnectionError: setError,
+        showQuickKeys: false,
+        isTerminalVisible: true,
+        lastViewportSizeRef,
+        terminalSessionId: 'pty-a',
+        useTouchTerminalInput: false,
+      });
+      return null;
+    };
+    const dom = installMinimalDom();
+    restoreFns.push(dom.restore);
+    const root = createRoot(dom.container);
+    roots.push(root);
+    await act(async () => { root.render(<InputProbe pending />); });
+    latestInput!.handleViewportInput('typed-during-gap');
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    expect(sent).toHaveLength(0);
+    // After the fresh snapshot clears pending, the same input sends once.
+    await act(async () => { root.render(<InputProbe pending={false} />); });
+    latestInput!.handleViewportInput('typed-after-snapshot');
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    expect(sent).toEqual([{ sessionId: 'pty-a', data: 'typed-after-snapshot' }]);
+  });
+
+  test('ambiguous tabs without session IDs never connect', async () => {
+    const fake = createFakeTerminal();
+    useTerminalStore.getState().clearAll();
+    useTerminalStore.getState().ensureDirectory('/repo');
+    const tabId = useTerminalStore.getState().getDirectoryState('/repo')!.tabs[0]!.id;
+    const tabs = [{ id: tabId, terminalSessionId: null, label: 'Terminal' }];
+    await renderStream(streamProps(fake, tabs));
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    expect(fake.connections).toHaveLength(0);
+  });
+});

--- a/packages/ui/src/components/views/terminal/useTerminalSessionStream.ts
+++ b/packages/ui/src/components/views/terminal/useTerminalSessionStream.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useTerminalStore } from '@/stores/useTerminalStore';
 import type { TerminalStreamEvent, TerminalAPI, TerminalError, TerminalShell } from '@/lib/api/types';
+import { getTerminalTransportGeneration, subscribeTerminalTransportGeneration } from '@/lib/terminalApi';
 import { TerminalPreviewScanner, FALLBACK_TERMINAL_SIZE } from './terminalStreamHelpers';
 
 type TabIdentity = {
@@ -60,6 +61,18 @@ export function useTerminalSessionStream({
   const lastViewportSizeRef = React.useRef<{ cols: number; rows: number } | null>(null);
   const pendingTerminalCreatesRef = React.useRef(new Set<string>());
   const previewScannersRef = React.useRef(new Map<string, TerminalPreviewScanner>());
+  // Latest mount inputs for the transport-generation handler below. The
+  // handler must reattach the CURRENT tabs once per generation — never a
+  // stale closure — while tabs/scrollback/dims/selection stay owned by the
+  // store and viewport refs (no PTY restart, no buffer clear, no remount).
+  const tabsRef = React.useRef(tabs);
+  const hydratedRef = React.useRef(terminalHydrated);
+  const viewportOpenRef = React.useRef(hasOpenedTerminalViewport);
+  const terminalRef = React.useRef(terminal);
+  tabsRef.current = tabs;
+  hydratedRef.current = terminalHydrated;
+  viewportOpenRef.current = hasOpenedTerminalViewport;
+  terminalRef.current = terminal;
 
   const resetTerminalPreviewScan = React.useCallback(() => {
     const tabId = activeTabIdRef.current;
@@ -123,9 +136,19 @@ export function useTerminalSessionStream({
         return;
       }
 
+      // Explicit generation: reject old data/open/connect after a transport
+      // replacement. Events from the previous transport (same PTY ID, old
+      // socket) are dropped; only the current generation may write buffers.
+      const streamGeneration = getTerminalTransportGeneration();
+      const isCurrentStream = (): boolean =>
+        getTerminalTransportGeneration() === streamGeneration &&
+        directoryRef.current === directory &&
+        useTerminalStore.getState().getDirectoryState(directory)?.tabs.find((t) => t.id === tabId)
+          ?.terminalSessionId === terminalId;
+
       const subscription = terminal.connect(terminalId, {
         onEvent: (event: TerminalStreamEvent) => {
-          if (directoryRef.current !== directory) return;
+          if (!isCurrentStream()) return;
 
           switch (event.type) {
             case 'snapshot': {
@@ -189,7 +212,7 @@ export function useTerminalSessionStream({
           }
         },
         onError: (error: TerminalError, fatal?: boolean) => {
-          if (directoryRef.current !== directory) return;
+          if (!isCurrentStream()) return;
           const isActive = activeTabIdRef.current === tabId;
 
           if (!fatal) {
@@ -268,6 +291,75 @@ export function useTerminalSessionStream({
       }
     }
   }, [tabsKey, tabs, effectiveDirectory, terminalHydrated, hasOpenedTerminalViewport, startStream]);
+
+  // Same-runtime endpoint/transport switch: reattach existing server PTYs
+  // exactly once per generation. Tabs, scrollback, dims, and xterm selection
+  // stay owned by the store/viewport (no PTY restart, no buffer clear, no
+  // remount). Different-runtime switches cleared the store, so there is
+  // nothing to reattach — same-ID PTYs on the new runtime are never adopted.
+  // Pending input during the gap is dropped via isReconnectPending; ordinary
+  // hidden/offline backoff stays inside the transport. Old data/open/connect
+  // after replacement is rejected by the generation guard in startStream.
+  React.useEffect(() => {
+    const unsubscribeGeneration = subscribeTerminalTransportGeneration(() => {
+      if (!hydratedRef.current || !viewportOpenRef.current) return;
+      const directory = directoryRef.current;
+      if (!directory) return;
+      // Old transport is disposed: its unsubscribes are no-ops, so drop them
+      // without invoking stale closures, then resubscribe the current tabs.
+      subscriptionsRef.current.clear();
+      activeTerminalIdRef.current = null;
+      const currentTabs = tabsRef.current;
+      const currentTerminal = terminalRef.current;
+      if (!currentTerminal) return;
+      let needsReattach = false;
+      const ownedTabs: typeof currentTabs = [];
+      for (const tab of currentTabs) {
+        if (!tab.terminalSessionId) continue;
+        // Never attach IDs the store no longer owns (different-runtime clear
+        // or tab close/reassign raced the switch).
+        const owned = useTerminalStore
+          .getState()
+          .getDirectoryState(directory)
+          ?.tabs.find((t) => t.id === tab.id)?.terminalSessionId;
+        if (owned !== tab.terminalSessionId) continue;
+        ownedTabs.push(tab);
+        needsReattach = true;
+        try {
+          startStream(directory, tab.id, tab.terminalSessionId);
+        } catch {
+          /* reattach is best-effort; snapshot arrival clears the pending flag */
+        }
+      }
+      if (needsReattach) {
+        // Drop input typed during the disconnected interval; the active tab's
+        // snapshot clears this. Scrollback is not duplicated: replaceBuffer
+        // deduplicates by sequence and the store ignores stale sequences.
+        setIsReconnectPending(true);
+        setConnectionError(null);
+        setIsFatalError(false);
+        // Re-assert the last known viewport dims on the reattached PTYs. The
+        // server kept the PTY; this only repairs dims that changed mid-gap.
+        // Resize rides runtimeFetch (centralized auth), not the WS.
+        const size = lastViewportSizeRef.current;
+        if (size) {
+          // Resize only PTYs the store still owns. currentTabs may be stale
+          // (clearAll() ran before this synchronous bump without a
+          // re-render), so reusing it here would send old IDs to a different
+          // runtime. ownedTabs passed the same ownership check as reattach.
+          for (const tab of ownedTabs) {
+            if (!tab.terminalSessionId) continue;
+            void currentTerminal
+              .resize({ sessionId: tab.terminalSessionId, ...size })
+              .catch(() => {});
+          }
+        }
+      }
+    });
+    return () => {
+      unsubscribeGeneration();
+    };
+  }, [startStream]);
 
   React.useEffect(() => {
     let cancelled = false;

--- a/packages/ui/src/lib/terminalApi.ts
+++ b/packages/ui/src/lib/terminalApi.ts
@@ -137,10 +137,20 @@ export class TerminalTransport {
 
   async write(sessionId: string, data: string): Promise<void> {
     if (!data) return;
+    // Drop pending input across a transport replacement instead of replaying
+    // it on the new socket: capture the generation and reject the write when
+    // a same-runtime switch (or different-runtime reset) intervened while the
+    // dial was in flight. Ordinary hidden/offline reconnect keeps its backoff
+    // in scheduleReconnect; this guard only rejects writes that straddled a
+    // replacement.
+    const writeGeneration = this.generation;
+    const isReplaced = (): boolean => this.disposed || writeGeneration !== this.generation;
     await this.ensureConnected();
+    if (isReplaced()) throw new Error('Terminal runtime changed');
     if (this.send({ t: 'write', v: 3, s: sessionId, d: data })) return;
     this.closeSocket();
     await this.ensureConnected();
+    if (isReplaced()) throw new Error('Terminal runtime changed');
     if (!this.send({ t: 'write', v: 3, s: sessionId, d: data })) throw new Error('Terminal connection is unavailable');
   }
 
@@ -351,6 +361,37 @@ export class TerminalTransport {
 
 let transport = new TerminalTransport();
 
+// Explicit terminal generation: bumped every time the underlying transport is
+// replaced (same-runtime transport switch or different-runtime switch).
+// Mounted consumers reattach same-runtime PTYs once per generation; stale
+// callbacks/connect/data from the previous transport are rejected by
+// generation guards in the UI layer. The generation never recreates or kills
+// PTYs itself — tabs, scrollback, and dims stay owned by the terminal store
+// and viewport refs. Auth/URL/relay routing is unchanged (shared
+// runtime-auth + resolver + openRuntimeWebSocket).
+let terminalTransportGeneration = 0;
+const terminalGenerationListeners = new Set<() => void>();
+
+export const getTerminalTransportGeneration = (): number => terminalTransportGeneration;
+
+export const subscribeTerminalTransportGeneration = (listener: () => void): (() => void) => {
+  terminalGenerationListeners.add(listener);
+  return () => {
+    terminalGenerationListeners.delete(listener);
+  };
+};
+
+const bumpTerminalTransportGeneration = (): void => {
+  terminalTransportGeneration += 1;
+  for (const listener of [...terminalGenerationListeners]) {
+    try {
+      listener();
+    } catch {
+      // A listener throwing must not break transport replacement.
+    }
+  }
+};
+
 export async function createTerminalSession(options: CreateTerminalOptions): Promise<TerminalSession> {
   const response = await runtimeFetch('/api/terminal/create', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(options) });
   if (!response.ok) throw await responseError(response, 'Failed to create terminal session');
@@ -390,4 +431,15 @@ export async function forceKillTerminal(options: { sessionId?: string; cwd?: str
     for (const sessionId of result.killedSessionIds) if (typeof sessionId === 'string') transport.forget(sessionId);
   } else if (options.sessionId) transport.forget(options.sessionId);
 }
-export function disposeTerminalInputTransport(): void { transport.dispose(); transport = new TerminalTransport(); }
+export function resetTerminalTransport(): void {
+  transport.dispose();
+  transport = new TerminalTransport();
+  // Same-runtime reattach and different-runtime reset both observe this:
+  // mounted streams resubscribe once (same runtime, same PTY IDs) while
+  // late callbacks from the disposed transport are ignored. Tabs,
+  // scrollback, and viewport dims are preserved by their owners — this only
+  // swaps the socket. Listeners/timers of the old transport were released
+  // by dispose(). Auth/URL/relay routing stays centralized in the default
+  // transport dependencies (runtime-auth + resolver + openRuntimeWebSocket).
+  bumpTerminalTransportGeneration();
+}

--- a/packages/ui/src/lib/terminalTransportSwitch.test.ts
+++ b/packages/ui/src/lib/terminalTransportSwitch.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, test } from 'bun:test';
+import type { RelayTunnelWebSocket } from './relay/tunnel-client';
+import { TerminalTransport } from './terminalApi';
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+const frame = (message: Record<string, unknown>): Uint8Array => {
+  const body = encoder.encode(JSON.stringify(message));
+  const result = new Uint8Array(body.length + 1);
+  result[0] = 1;
+  result.set(body, 1);
+  return result;
+};
+
+class FakeSocket implements RelayTunnelWebSocket {
+  readyState = 0;
+  binaryType: 'blob' | 'arraybuffer' = 'arraybuffer';
+  onopen: (() => void) | null = null;
+  onmessage: RelayTunnelWebSocket['onmessage'] = null;
+  onerror: (() => void) | null = null;
+  onclose: RelayTunnelWebSocket['onclose'] = null;
+  sent: Record<string, unknown>[] = [];
+  open(): void { this.readyState = 1; this.onopen?.(); }
+  emit(message: Record<string, unknown>): void {
+    const bytes = frame(message);
+    this.onmessage?.({ data: bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer });
+  }
+  send(data: string | ArrayBuffer | ArrayBufferView): void {
+    const bytes = typeof data === 'string'
+      ? encoder.encode(data)
+      : data instanceof ArrayBuffer
+        ? new Uint8Array(data)
+        : new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+    const parsed = JSON.parse(decoder.decode(bytes.subarray(1))) as Record<string, unknown>;
+    this.sent.push(parsed);
+  }
+  close(): void { this.readyState = 3; this.onclose?.({ code: 1000, reason: '' }); }
+}
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('terminal transport switch (same-runtime reattach)', () => {
+  test('generation bumps once per reset and listeners clean up on unmount', async () => {
+    const api = await import('./terminalApi');
+    const before = api.getTerminalTransportGeneration();
+    let calls = 0;
+    const unsubscribe = api.subscribeTerminalTransportGeneration(() => { calls += 1; });
+    api.resetTerminalTransport();
+    expect(api.getTerminalTransportGeneration()).toBe(before + 1);
+    expect(calls).toBe(1);
+    unsubscribe();
+    api.resetTerminalTransport();
+    expect(calls).toBe(1);
+  });
+
+  test('mounted multiple tabs reattach exactly once; old late open/connect rejected', async () => {
+    const oldSocket = new FakeSocket();
+    const oldTransport = new TerminalTransport({ refreshAuth: async () => 'old-token', openSocket: () => oldSocket });
+    const oldEvents: string[] = [];
+    const unsubs = [
+      oldTransport.subscribe('pty-a', { onEvent: (e) => oldEvents.push(`a:${e.type}`) }),
+      oldTransport.subscribe('pty-b', { onEvent: (e) => oldEvents.push(`b:${e.type}`) }),
+    ];
+    await tick();
+    oldSocket.open();
+    await tick();
+    expect(oldSocket.sent.filter((m) => m.t === 'attach')).toHaveLength(2);
+
+    oldTransport.dispose();
+    oldSocket.emit({ t: 'output', v: 3, s: 'pty-a', q: 99, d: 'stale' });
+    await tick();
+    expect(oldEvents).toEqual([]);
+    for (const unsub of unsubs) {
+      try { unsub(); } catch { /* disposed */ }
+    }
+
+    const newSockets: FakeSocket[] = [];
+    const newTransport = new TerminalTransport({
+      refreshAuth: async () => 'fresh-token',
+      openSocket: () => { const s = new FakeSocket(); newSockets.push(s); return s; },
+    });
+    newTransport.subscribe('pty-a', { onEvent: () => {} });
+    newTransport.subscribe('pty-b', { onEvent: () => {} });
+    await tick();
+    expect(newSockets).toHaveLength(1);
+    newSockets[0]!.open();
+    await tick();
+    const attaches = newSockets[0]!.sent.filter((m) => m.t === 'attach');
+    expect(attaches).toHaveLength(2);
+    expect(new Set(attaches.map((m) => m.s))).toEqual(new Set(['pty-a', 'pty-b']));
+    newTransport.dispose();
+  });
+
+  test('old late data after replacement is dropped; scrollback never duplicates', async () => {
+    const socket = new FakeSocket();
+    const transport = new TerminalTransport({ refreshAuth: async () => '', openSocket: () => socket });
+    const events: Array<{ type: string; sequence?: number }> = [];
+    transport.subscribe('pty-1', { onEvent: (e) => events.push({ type: e.type, sequence: e.sequence }) });
+    await tick();
+    socket.open();
+    await tick();
+    socket.emit({ t: 'snapshot', v: 3, s: 'pty-1', q: 5, history: 'prompt$ ', status: 'running' });
+    await tick();
+    socket.emit({ t: 'output', v: 3, s: 'pty-1', q: 6, d: 'ls', r: 'ls' });
+    await tick();
+    expect(events.map((e) => `${e.type}:${e.sequence}`)).toEqual(['snapshot:5', 'data:6']);
+
+    transport.dispose();
+    const replacement = new FakeSocket();
+    const next = new TerminalTransport({ refreshAuth: async () => '', openSocket: () => replacement });
+    const nextEvents: string[] = [];
+    next.subscribe('pty-1', { onEvent: (e) => nextEvents.push(`${e.type}:${e.sequence ?? ''}`) });
+    expect(nextEvents).toEqual([]);
+    await tick();
+    replacement.open();
+    await tick();
+    socket.emit({ t: 'output', v: 3, s: 'pty-1', q: 7, d: 'stale' });
+    await tick();
+    expect(events).toHaveLength(2);
+    replacement.emit({ t: 'snapshot', v: 3, s: 'pty-1', q: 6, history: 'prompt$ ls', status: 'running' });
+    await tick();
+    replacement.emit({ t: 'output', v: 3, s: 'pty-1', q: 6, d: 'duplicate' });
+    await tick();
+    expect(nextEvents).toEqual(['snapshot:6']);
+    next.dispose();
+  });
+
+  test('backoff restarts fresh after a switch instead of inheriting the cap', async () => {
+    if (typeof document !== 'undefined') Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' });
+    if (typeof navigator !== 'undefined') Object.defineProperty(navigator, 'onLine', { configurable: true, value: true });
+    const firstAttempts: number[] = [];
+    const failing = new TerminalTransport({
+      refreshAuth: async () => '',
+      openSocket: () => { throw new Error('offline'); },
+    });
+    failing.subscribe('pty-1', {
+      onEvent: (e) => { if (e.type === 'reconnecting' && typeof e.attempt === 'number') firstAttempts.push(e.attempt); },
+    });
+    await tick();
+    await tick();
+    expect(firstAttempts).toEqual([1]);
+    failing.dispose();
+
+    const secondAttempts: number[] = [];
+    const replacement = new TerminalTransport({
+      refreshAuth: async () => '',
+      openSocket: () => { throw new Error('offline'); },
+    });
+    replacement.subscribe('pty-1', {
+      onEvent: (e) => { if (e.type === 'reconnecting' && typeof e.attempt === 'number') secondAttempts.push(e.attempt); },
+    });
+    await tick();
+    await tick();
+    expect(secondAttempts).toEqual([1]);
+    replacement.dispose();
+  });
+
+  test('unmount clears reconnect timers; no dial after detach+dispose', async () => {
+    let openCalls = 0;
+    const transport = new TerminalTransport({
+      refreshAuth: async () => '',
+      openSocket: () => { openCalls += 1; throw new Error('offline'); },
+    });
+    const unsubscribe = transport.subscribe('pty-1', { onEvent: () => {} });
+    await tick();
+    await tick();
+    expect(openCalls).toBe(1);
+    unsubscribe();
+    transport.dispose();
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    expect(openCalls).toBe(1);
+  });
+
+  test('ambiguous input is dropped, never sent', async () => {
+    const socket = new FakeSocket();
+    let authCalls = 0;
+    const transport = new TerminalTransport({
+      refreshAuth: async () => { authCalls += 1; return ''; },
+      openSocket: () => socket,
+    });
+    transport.subscribe('pty-1', { onEvent: () => {} });
+    await tick();
+    socket.open();
+    await tick();
+    const sentBefore = socket.sent.length;
+    await transport.write('pty-1', '');
+    expect(socket.sent.length).toBe(sentBefore);
+    expect(authCalls).toBe(1);
+    transport.dispose();
+  });
+
+  test('pending write straddling a replacement is dropped, not replayed', async () => {
+    let releaseAuth!: (token: string) => void;
+    const authGate = new Promise<string>((resolve) => { releaseAuth = resolve; });
+    const socket = new FakeSocket();
+    const transport = new TerminalTransport({
+      refreshAuth: () => authGate,
+      openSocket: () => socket,
+    });
+    transport.subscribe('pty-1', { onEvent: () => {} });
+    const pending = transport.write('pty-1', 'typed-during-gap');
+    transport.dispose();
+    releaseAuth('late-token');
+    await expect(pending).rejects.toThrow('Terminal runtime changed');
+    expect(socket.sent.filter((m) => m.t === 'write')).toEqual([]);
+  });
+
+  test('old late open/connect after dispose is rejected (no attach, no projection)', async () => {
+    let releaseAuth!: (token: string) => void;
+    const authGate = new Promise<string>((resolve) => { releaseAuth = resolve; });
+    const staleSocket = new FakeSocket();
+    let openedSockets = 0;
+    const staleTransport = new TerminalTransport({
+      refreshAuth: () => authGate,
+      openSocket: () => { openedSockets += 1; return staleSocket; },
+    });
+    const staleEvents: string[] = [];
+    staleTransport.subscribe('pty-stale', { onEvent: (e) => staleEvents.push(e.type) });
+    await tick();
+    // Replacement intervenes while the old dial is still waiting on auth.
+    staleTransport.dispose();
+    releaseAuth('late-token');
+    await tick();
+    await tick();
+    // Old open must not attach, must not deliver, must not schedule backoff.
+    expect(openedSockets).toBe(0);
+    expect(staleSocket.sent.filter((m) => m.t === 'attach')).toHaveLength(0);
+    expect(staleEvents).toEqual([]);
+    // Fresh transport still dials exactly once and attaches.
+    const freshSocket = new FakeSocket();
+    const fresh = new TerminalTransport({ refreshAuth: async () => 'fresh', openSocket: () => freshSocket });
+    fresh.subscribe('pty-stale', { onEvent: () => {} });
+    await tick();
+    freshSocket.open();
+    await tick();
+    expect(freshSocket.sent.filter((m) => m.t === 'attach')).toHaveLength(1);
+    fresh.dispose();
+  });
+
+  test('auth is minted fresh on reattach via centralized refresh (direct/relay fixture)', async () => {
+    const seenTokens: string[] = [];
+    const directSockets: FakeSocket[] = [];
+    const direct = new TerminalTransport({
+      refreshAuth: async () => { seenTokens.push('direct-token'); return 'direct-token'; },
+      openSocket: (token) => {
+        expect(token).toBe('direct-token');
+        const s = new FakeSocket();
+        directSockets.push(s);
+        queueMicrotask(() => s.open());
+        return s;
+      },
+    });
+    direct.subscribe('pty-1', { onEvent: () => {} });
+    await tick();
+    await tick();
+    expect(directSockets).toHaveLength(1);
+    direct.dispose();
+
+    const relaySockets: FakeSocket[] = [];
+    const relay = new TerminalTransport({
+      refreshAuth: async () => { seenTokens.push('relay-token'); return 'relay-token'; },
+      openSocket: (token) => {
+        expect(token).toBe('relay-token');
+        const s = new FakeSocket();
+        relaySockets.push(s);
+        queueMicrotask(() => s.open());
+        return s;
+      },
+    });
+    relay.subscribe('pty-1', { onEvent: () => {} });
+    await tick();
+    await tick();
+    expect(relaySockets).toHaveLength(1);
+    expect(seenTokens).toEqual(['direct-token', 'relay-token']);
+    relay.dispose();
+  });
+
+  test('disposable PTY forget clears replay so close never resurrects output', async () => {
+    const socket = new FakeSocket();
+    const transport = new TerminalTransport({ refreshAuth: async () => '', openSocket: () => socket });
+    transport.subscribe('pty-disposable', { onEvent: () => {} });
+    await tick();
+    socket.open();
+    await tick();
+    socket.emit({ t: 'snapshot', v: 3, s: 'pty-disposable', q: 3, history: 'ephemeral', status: 'running' });
+    await tick();
+    transport.forget('pty-disposable');
+    const events: string[] = [];
+    transport.subscribe('pty-disposable', { onEvent: (e) => events.push(e.type) });
+    expect(events).toEqual([]);
+    transport.dispose();
+  });
+});


### PR DESCRIPTION
## Intent

Fixes #11.

This is stacked on #128 because terminal reattachment must coexist with the server's live credential revocation behavior.

When a connection switches between LAN and relay for the same PiChamber runtime, the terminal transport now replaces its socket and explicitly advances a terminal transport generation. Mounted terminal views observe that generation and reattach their existing server PTY IDs. Tabs, scrollback, viewport dimensions, and xterm selection remain in their existing owners, so a transport switch does not recreate the PTY, clear the terminal, or remount the view.

The replacement path rejects stale connection attempts, callbacks, data, and writes from the old transport. Input that straddles a transport replacement fails instead of being replayed against the new socket. Fresh snapshots and monotonic terminal sequence numbers reconcile output after reattachment without duplicating bytes.

A switch to a different runtime keeps the stronger isolation behavior. It clears terminal tabs and buffers before advancing the generation, then refuses to attach or resize stale PTY IDs even if React refs have not rerendered yet.

## Non-goals

- This does not retain terminals across different PiChamber runtimes or hosts.
- This does not recreate, restart, or kill server PTYs during a same-runtime transport switch.
- Ordinary hidden, offline, or transient socket reconnect behavior keeps its existing backoff path.
- This does not include mobile retention work from the earlier combined PR or unrelated PR #119 changes.

## Affected surfaces

- `packages/ui/src/lib/terminalApi.ts`: owns terminal transport replacement, generation subscriptions, stale-write rejection, and transport disposal.
- `packages/ui/src/components/views/terminal/useTerminalSessionStream.ts`: reattaches only terminal IDs still owned by the current runtime and restores their last viewport dimensions.
- `packages/ui/src/App.tsx`: same-runtime endpoint changes reset only the terminal transport instead of clearing runtime-owned terminal state.
- `packages/ui/src/apps/runtimeEndpointReset.ts`: shared mobile/desktop transport switching reuses the same reattach path; different-runtime switching clears terminal state before advancing the generation.
- Web, Electron, hosted mobile, and Capacitor continue to use `openRuntimeWebSocket`, `runtimeFetch`, and shared runtime auth. URL-token and relay routing behavior are unchanged.
- No persistence format, API route, protocol frame, dependency, or server PTY lifecycle contract changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` and `pichamber-change-discipline` | This changes shared UI runtime lifecycle and terminal transport behavior. | The change stays in the terminal transport and mounted stream owners, preserves runtime boundaries, adds lifecycle regression tests, and does not add dependencies. |
| `relay-transport` | The terminal uses a WebSocket that may move between direct LAN and private relay transport. | Replacement still opens sockets through `openRuntimeWebSocket`; auth, URL resolution, origin handling, allowlists, and relay framing are untouched. |
| `ui-api-decoupling` and its implementation map | Runtime switching and authenticated realtime access must remain transport-owned. | Callers do not construct URLs or credentials. Socket and resize traffic continue through shared runtime helpers resolved at call time. |
| `sync-state-invariants` and sync documentation | Reattachment uses generation guards and must reject stale work across runtime changes. | Each stream captures its generation and runtime ownership. Old callbacks are ignored, different-runtime state clears before the generation bump, and stale IDs cannot attach or resize. |
| `performance-engineering` | Terminal output and stream callbacks are high-frequency paths. | The change adds one bounded generation notification per transport replacement. It does not add work to each output frame or broaden store subscriptions. |
| Terminal subsystem documentation and `packages/web/README.md` | These define PTY identity, snapshots, sequence ordering, and shared runtime transport. | Existing PTY IDs are reattached through the v3 protocol; authoritative snapshots and sequences remain the reconciliation mechanism. |

## Validation

| Check | Result |
|---|---|
| `bun run test` | Passed: web 84 files/813 tests; UI 2374 tests; Electron architecture 47 tests; Electron updater 29 tests. |
| Focused terminal transport and reattach tests | Passed: 22 tests covering generation replacement, same-runtime reattach, stale callbacks and output, input rejection, listener cleanup, state preservation, and stale/unowned resize prevention. |
| `bun run lint` | Passed for UI, web, Electron, and mobile. |
| `bun run --cwd packages/ui type-check` | Passed after the final change. |
| `bun run type-check` | UI, web, and Electron passed. Mobile could not resolve the already-declared `@capacitor/cli` from this worktree's installation, so the workspace command exited 2. No mobile source or dependency files changed. |
| `bun run dead-code` | Completed. Existing findings remain; none match files or exports introduced by this PR. |
| `git diff --check fix/revoke-live-client-connections...HEAD` | Passed. |

No deployed LAN-to-relay or Capacitor runtime switch was manually exercised. Unit tests drive the transport-generation and mounted-stream lifecycle directly.

## Visual evidence

No screenshot applies. This PR does not change terminal styling or controls. Its visible result is continuity: the same terminal contents, tabs, dimensions, and selection remain in place while the underlying transport changes. That runtime transition was covered by automated lifecycle tests rather than a recording.

## Risks and failure behavior

- Input awaiting a socket when replacement occurs rejects with `Terminal runtime changed`. It is never replayed, which avoids sending a command twice or to the wrong runtime.
- The disposed transport releases its socket, timers, wake listeners, subscribers, and projections. Late callbacks cannot publish into the replacement generation.
- Reattachment checks the terminal store's current directory/tab ownership before attaching or resizing. A stale React ref cannot send an old PTY ID to a new runtime, including an ID that collides with a different PTY on that runtime.
- A failed reattach leaves the existing tab and scrollback intact and reports the connection failure through the existing terminal stream error path. A later transport generation can retry.
- Sequence checks deduplicate overlap between the authoritative reattach snapshot and live output.
- Reverting the terminal commit restores the former behavior without migration. The stacked server revocation commit remains independently revertible in #128.
