### PR TITLE
fix(terminal): reattach streams after transport switches

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -7,6 +7,7 @@ import { RuntimeAPIProvider } from '@/contexts/RuntimeAPIProvider';
 import { getRegisteredRuntimeAPIs, registerRuntimeAPIs } from '@/contexts/runtimeAPIRegistry';
 import { SyncAppEffects } from '@/apps/AppEffects';
 import { resetAppForRuntimeEndpointChange } from '@/apps/runtimeEndpointReset';
+import { resetTerminalTransport } from '@/lib/terminalApi';
 import { useAppFontEffects } from '@/apps/useAppFontEffects';
 import { PiSessionProvider } from '@/sync/pi-session-context';
 import { FireworksProvider } from '@/contexts/FireworksContext';
@@ -41,10 +42,12 @@ function App({ apis }: { apis?: RuntimeAPIs }) {
 
   React.useEffect(() => {
     return subscribeRuntimeEndpointChanged((detail) => {
-      // A LAN↔relay change for the same instance only changes transport. The
-      // session store reconnects in place; a different runtime needs a full
-      // store reset so paths, sessions, and provider state cannot cross hosts.
-      if (detail.runtimeKey === detail.previousRuntimeKey) return;
+      // A same-runtime LAN↔relay change keeps session and terminal state.
+      // A different runtime clears state so IDs and paths cannot cross hosts.
+      if (detail.runtimeKey === detail.previousRuntimeKey) {
+        resetTerminalTransport();
+        return;
+      }
       resetAppForRuntimeEndpointChange(detail);
       setRuntimeEndpointEpoch((epoch) => epoch + 1);
     });

--- a/packages/ui/src/apps/runtimeEndpointReset.ts
+++ b/packages/ui/src/apps/runtimeEndpointReset.ts
@@ -1,5 +1,5 @@
 import type { RuntimeEndpointChangedDetail } from '@/lib/runtime-switch';
-import { disposeTerminalInputTransport } from '@/lib/terminalApi';
+import { resetTerminalTransport } from '@/lib/terminalApi';
 import { useConfigStore } from '@/stores/useConfigStore';
 import { useProjectsStore } from '@/stores/useProjectsStore';
 import { useUIStore } from '@/stores/useUIStore';
@@ -22,23 +22,19 @@ import { resetSessionOrdering } from '@/sync/session-ordering';
 import { resetSessionActivityTiming } from '@/sync/session-activity-timing';
 import { updateBrowserURL } from '@/lib/router';
 
-// Same-device transport switch (LAN⇄relay for one paired device): rebind the Pi transport
-// to the new transport WITHOUT tearing down connection/session state or remounting
-// the sync layer. `reconnectToRuntimeBaseUrl` swaps in a fresh Pi transport; the
-// caller then forces a re-render so PiSessionProvider receives it as a new `sdk` prop,
-// which re-runs its event-pipeline + bootstrap effects (keyed on `sdk`) to
-// reconnect over the new transport IN PLACE. Message-pagination refs, the open
-// session, and the whole view are preserved — no reconnecting screen, no flash,
-// no bounce back to the draft.
+// A same-device LAN⇄relay switch preserves the mounted sync and terminal state.
+// Resetting the terminal transport prompts mounted views to reattach their PTYs.
 export const reconnectAppForTransportSwitch = (): void => {
-  disposeTerminalInputTransport();
+  resetTerminalTransport();
 };
 
 export const resetAppForRuntimeEndpointChange = (detail: RuntimeEndpointChangedDetail): void => {
   useSessionUIStore.getState().prepareForRuntimeSwitch(detail.previousRuntimeKey);
   useUIStore.getState().prepareForRuntimeSwitch(detail.previousRuntimeKey);
-  disposeTerminalInputTransport();
+  // Clear ownership before the generation bump so mounted views cannot attach
+  // an old PTY ID on the new runtime.
   useTerminalStore.getState().clearAll();
+  resetTerminalTransport();
   // The previous runtime's cwd is not meaningful on the new host (for
   // example, a Windows path must never be sent to a WSL daemon). Clear it
   // before the new runtime's settings/project snapshot is applied.

--- a/packages/ui/src/components/views/terminal/__tests__/terminalReattach.test.tsx
+++ b/packages/ui/src/components/views/terminal/__tests__/terminalReattach.test.tsx
@@ -1,0 +1,706 @@
+/**
+ * Mounted TerminalView coverage for transport reattach and stable viewport
+ * identity. TerminalViewport is the only heavy leaf mocked here.
+ */
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+
+import type { TerminalAPI, TerminalHandlers } from '@/lib/api/types';
+import type { Theme } from '@/types/theme';
+
+// --- Test controls (not behavior under test) -------------------------------
+
+type FakeConnection = {
+  sessionId: string;
+  handlers: TerminalHandlers;
+  closed: boolean;
+};
+
+let fakeConnections: FakeConnection[] = [];
+let sentInput: Array<{ sessionId: string; data: string }> = [];
+let resized: Array<{ sessionId: string; cols: number; rows: number }> = [];
+
+const createFakeTerminal = (): TerminalAPI => ({
+  async createSession() {
+    return { sessionId: 'created-1', cols: 80, rows: 24, status: 'running' };
+  },
+  connect(sessionId, handlers) {
+    const connection = { sessionId, handlers, closed: false };
+    fakeConnections.push(connection);
+    return { close: () => { connection.closed = true; } };
+  },
+  async sendInput(sessionId, data) {
+    sentInput.push({ sessionId, data });
+  },
+  async resize(payload) {
+    resized.push(payload);
+  },
+  async close() {},
+});
+
+let fakeTerminal = createFakeTerminal();
+
+const fakeTheme = {
+  metadata: {
+    id: 'test-dark',
+    name: 'Test Dark',
+    description: 'Test theme',
+    version: '1',
+    variant: 'dark',
+    tags: [],
+  },
+  colors: {
+    primary: { base: '#ffffff' },
+    surface: {
+      background: '#000000',
+      foreground: '#ffffff',
+      muted: '#111111',
+      mutedForeground: '#aaaaaa',
+      elevated: '#111111',
+      elevatedForeground: '#ffffff',
+      overlay: '#000000',
+      subtle: '#111111',
+    },
+    interactive: {
+      border: '#333333',
+      borderHover: '#444444',
+      borderFocus: '#555555',
+      selection: '#333333',
+      selectionForeground: '#ffffff',
+      focus: '#ffffff',
+      focusRing: '#ffffff',
+      cursor: '#ffffff',
+      hover: '#222222',
+      active: '#222222',
+    },
+    status: {
+      error: '#ff0000',
+      errorForeground: '#ffcccc',
+      errorBackground: '#330000',
+      errorBorder: '#ff0000',
+      warning: '#ffff00',
+      warningForeground: '#333300',
+      warningBackground: '#333300',
+      warningBorder: '#ffff00',
+      success: '#00ff00',
+      successForeground: '#003300',
+      successBackground: '#003300',
+      successBorder: '#00ff00',
+      info: '#0000ff',
+      infoForeground: '#ffffff',
+      infoBackground: '#000033',
+      infoBorder: '#0000ff',
+    },
+    syntax: {
+      base: {
+        background: '#000000',
+        foreground: '#ffffff',
+        comment: '#888888',
+        keyword: '#ff00ff',
+        string: '#00ff00',
+        number: '#ff0000',
+        function: '#00ffff',
+        variable: '#ffffff',
+        type: '#ffff00',
+        operator: '#ffffff',
+      },
+    },
+  },
+} as unknown as Theme;
+
+const desktopDeviceInfo = {
+  isMobile: false,
+  isTablet: false,
+  isDesktop: true,
+  deviceType: 'desktop' as const,
+  screenWidth: 1280,
+  breakpoint: 'xl' as const,
+  hasTouchInput: false,
+  hasTouchOnlyPointer: false,
+};
+
+// Viewport probe state: one lightweight leaf per sessionKey. Mount counts and
+// a per-instance marker prove whether React remounted the viewport.
+const viewportMounts = new Map<string, number>();
+const viewportUnmounts = new Map<string, number>();
+type ViewportProbeProps = {
+  sessionKey: string;
+  isVisible: boolean;
+  onInput: (data: string) => void;
+  onResize: (cols: number, rows: number) => void;
+};
+const viewportLatestProps = new Map<string, ViewportProbeProps>();
+let viewportInstanceSeq = 0;
+
+mock.module('@/components/icon/Icon', () => ({
+  Icon: () => null,
+}));
+
+mock.module('@/components/terminal/TerminalViewport', () => ({
+  TerminalViewport: React.forwardRef((props: Record<string, unknown>, ref: React.Ref<unknown>) => {
+    const sessionKey = props['sessionKey'] as string;
+    const isVisible = props['isVisible'] as boolean;
+    const [marker] = React.useState(() => {
+      viewportInstanceSeq += 1;
+      return `instance-${viewportInstanceSeq}`;
+    });
+    React.useEffect(() => {
+      viewportMounts.set(sessionKey, (viewportMounts.get(sessionKey) ?? 0) + 1);
+      return () => {
+        viewportUnmounts.set(sessionKey, (viewportUnmounts.get(sessionKey) ?? 0) + 1);
+      };
+    }, [sessionKey]);
+    viewportLatestProps.set(sessionKey, {
+      sessionKey,
+      isVisible,
+      onInput: props['onInput'] as ViewportProbeProps['onInput'],
+      onResize: props['onResize'] as ViewportProbeProps['onResize'],
+    });
+    React.useImperativeHandle(
+      ref,
+      () => ({
+        focus: () => undefined,
+        fit: () => undefined,
+        getSelection: () => null,
+      }),
+      [],
+    );
+    return React.createElement('div', {
+      'data-testid': `viewport-${sessionKey}`,
+      'data-session-key': sessionKey,
+      'data-visible': String(isVisible),
+      'data-marker': marker,
+    });
+  }),
+}));
+
+mock.module('@/hooks/useRuntimeAPIs', () => ({
+  useRuntimeAPIs: () => ({
+    terminal: fakeTerminal,
+    runtime: { platform: 'web', isDesktop: true },
+  }),
+}));
+
+mock.module('@/contexts/useThemeSystem', () => ({
+  useThemeSystem: () => ({ currentTheme: fakeTheme }),
+  useOptionalThemeSystem: () => ({ currentTheme: fakeTheme }),
+}));
+
+mock.module('@/lib/device', () => ({
+  useDeviceInfo: () => desktopDeviceInfo,
+  useTabletLayout: () => ({ enabled: false, roomyForPanels: false }),
+  useOrientation: () => 'landscape' as const,
+  useTabletStandalonePwaRuntime: () => false,
+  isMobileDeviceViaCSS: () => false,
+  getDeviceInfo: () => desktopDeviceInfo,
+  readTabletLayout: () => ({ enabled: false, roomyForPanels: false }),
+}));
+
+mock.module('@/hooks/useEffectiveDirectory', () => ({
+  useEffectiveDirectory: () => '/repo',
+}));
+
+const { TerminalView } = await import('@/components/views/TerminalView');
+const { useTerminalStore } = await import('@/stores/useTerminalStore');
+const { useSessionUIStore } = await import('@/sync/session-ui-store');
+const { resetTerminalTransport } = await import('@/lib/terminalApi');
+
+// --- Minimal DOM stub (proven DiagramView/number-input pattern) -------------
+
+interface FakeNode {
+  nodeType: number;
+  nodeName: string;
+  tagName: string;
+  ownerDocument: FakeDocument | null;
+  parentNode: FakeNode | null;
+  childNodes: FakeNode[];
+  style: Record<string, unknown>;
+  classList: { add(...c: string[]): void; remove(...c: string[]): void; contains(c: string): boolean };
+  [key: string]: unknown;
+}
+
+interface FakeDocument extends FakeNode {
+  defaultView: FakeWindow;
+  body: FakeNode;
+  head: FakeNode;
+  documentElement: FakeNode;
+  createElement(tag: string): FakeNode;
+  createElementNS(_ns: string, tag: string): FakeNode;
+  createTextNode(text: string): FakeNode;
+  createDocumentFragment(): FakeNode;
+  getElementById(_id: string): FakeNode | null;
+  activeElement: FakeNode | null;
+}
+
+interface FakeWindow {
+  document: FakeDocument;
+  navigator: { userAgent: string; platform: string; maxTouchPoints: number };
+  location: { search: string; protocol: string; hostname: string };
+  innerWidth: number;
+  innerHeight: number;
+  matchMedia(query: string): { matches: boolean; addEventListener(): void; removeEventListener(): void };
+  getComputedStyle(_elt: unknown): { getPropertyValue(_name: string): string };
+  requestAnimationFrame(cb: () => void): number;
+  cancelAnimationFrame(_id: number): void;
+  setTimeout: typeof setTimeout;
+  clearTimeout: typeof clearTimeout;
+  addEventListener(): void;
+  removeEventListener(): void;
+  dispatchEvent(): boolean;
+  [key: string]: unknown;
+}
+
+function makeNode(tag: string, owner: FakeDocument | null): FakeNode {
+  const node = {
+    nodeType: 1,
+    nodeName: tag.toUpperCase(),
+    tagName: tag.toUpperCase(),
+    ownerDocument: owner,
+    parentNode: null,
+    childNodes: [] as FakeNode[],
+    style: {
+      setProperty() {},
+      getPropertyValue() { return ''; },
+      removeProperty() {},
+    },
+    classList: {
+      add() {},
+      remove() {},
+      contains() { return false; },
+    },
+    setAttribute() {},
+    removeAttribute() {},
+    hasAttribute() { return false; },
+    getAttribute() { return null; },
+    addEventListener() {},
+    removeEventListener() {},
+    appendChild(c: FakeNode) {
+      (this as FakeNode).childNodes.push(c);
+      c.parentNode = this as unknown as FakeNode;
+      return c;
+    },
+    insertBefore(c: FakeNode, ref: FakeNode) {
+      const list = (this as FakeNode).childNodes;
+      const i = list.indexOf(ref);
+      if (i < 0) list.push(c);
+      else list.splice(i, 0, c);
+      c.parentNode = this as unknown as FakeNode;
+      return c;
+    },
+    removeChild(c: FakeNode) {
+      const list = (this as FakeNode).childNodes;
+      const i = list.indexOf(c);
+      if (i >= 0) list.splice(i, 1);
+      c.parentNode = null;
+      return c;
+    },
+    contains() { return false; },
+    focus() {},
+    blur() {},
+    click() {},
+    hasPointerCapture() { return false; },
+    setPointerCapture() {},
+    releasePointerCapture() {},
+    getBoundingClientRect() { return { width: 800, height: 600, left: 0, top: 0, right: 800, bottom: 600 }; },
+    querySelector() { return null; },
+    closest() { return null; },
+    textContent: '',
+    innerHTML: '',
+  } as unknown as FakeNode;
+  return node;
+}
+
+function installDomStub(): { restore: () => void; container: FakeNode } {
+  const document = {
+    nodeType: 9,
+    nodeName: '#document',
+    tagName: '#document',
+    parentNode: null,
+    childNodes: [] as FakeNode[],
+    style: {},
+    classList: { add() {}, remove() {}, contains() { return false; } },
+    setAttribute() {},
+    getAttribute() { return null; },
+    addEventListener() {},
+    removeEventListener() {},
+    hasFocus() { return true; },
+    getElementById() { return null; },
+    querySelector() { return null; },
+    createTextNode(text: string) {
+      return { nodeType: 3, nodeName: '#text', textContent: text, parentNode: null } as unknown as FakeNode;
+    },
+    createElement(tag: string) { return makeNode(tag, document as unknown as FakeDocument); },
+    createElementNS(_ns: string, tag: string) { return makeNode(tag, document as unknown as FakeDocument); },
+    createDocumentFragment() { return makeNode('#fragment', document as unknown as FakeDocument); },
+    visibilityState: 'visible',
+    activeElement: null,
+  } as unknown as FakeDocument;
+
+  const win = {
+    document,
+    navigator: { userAgent: 'test', platform: 'test', maxTouchPoints: 0 },
+    location: { search: '', protocol: 'http:', hostname: 'localhost' },
+    innerWidth: 1280,
+    innerHeight: 800,
+    matchMedia() { return { matches: false, addEventListener() {}, removeEventListener() {} }; },
+    getComputedStyle() { return { getPropertyValue() { return ''; } }; },
+    requestAnimationFrame(cb: () => void) { return setTimeout(cb, 0) as unknown as number; },
+    cancelAnimationFrame(id: number) { clearTimeout(id); },
+    setTimeout,
+    clearTimeout,
+    addEventListener() {},
+    removeEventListener() {},
+    dispatchEvent() { return true; },
+    Element: class {},
+    HTMLElement: class {},
+    HTMLIFrameElement: class {},
+    HTMLInputElement: class {},
+    HTMLTextAreaElement: class {},
+    ResizeObserver: class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+    IntersectionObserver: class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  } as unknown as FakeWindow;
+  document.defaultView = win;
+  document.body = makeNode('body', document);
+  document.head = makeNode('head', document);
+  document.documentElement = makeNode('html', document);
+
+  const g = globalThis as unknown as Record<string, unknown>;
+  const previous = {
+    document: g['document'],
+    window: g['window'],
+    navigator: g['navigator'],
+    Element: g['Element'],
+    HTMLElement: g['HTMLElement'],
+    HTMLIFrameElement: g['HTMLIFrameElement'],
+    requestAnimationFrame: g['requestAnimationFrame'],
+    cancelAnimationFrame: g['cancelAnimationFrame'],
+    getComputedStyle: g['getComputedStyle'],
+    ResizeObserver: g['ResizeObserver'],
+    IntersectionObserver: g['IntersectionObserver'],
+    localStorage: g['localStorage'],
+    sessionStorage: g['sessionStorage'],
+    IS_REACT_ACT_ENVIRONMENT: g['IS_REACT_ACT_ENVIRONMENT'],
+  };
+  g['IS_REACT_ACT_ENVIRONMENT'] = true;
+  g['document'] = document;
+  g['window'] = win;
+  g['navigator'] = win.navigator;
+  g['Element'] = win['Element'];
+  g['HTMLElement'] = win['HTMLElement'];
+  g['HTMLIFrameElement'] = win['HTMLIFrameElement'];
+  g['requestAnimationFrame'] = win.requestAnimationFrame.bind(win);
+  g['cancelAnimationFrame'] = win.cancelAnimationFrame.bind(win);
+  g['getComputedStyle'] = win.getComputedStyle.bind(win);
+  g['ResizeObserver'] = win['ResizeObserver'];
+  g['IntersectionObserver'] = win['IntersectionObserver'];
+  if (!g['localStorage']) {
+    const store = new Map<string, string>();
+    g['localStorage'] = {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => { store.set(k, String(v)); },
+      removeItem: (k: string) => { store.delete(k); },
+      clear: () => { store.clear(); },
+    };
+  }
+  if (!g['sessionStorage']) {
+    const store = new Map<string, string>();
+    g['sessionStorage'] = {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => { store.set(k, String(v)); },
+      removeItem: (k: string) => { store.delete(k); },
+      clear: () => { store.clear(); },
+    };
+  }
+  const container = document.createElement('div');
+  return {
+    container,
+    restore() {
+      g['document'] = previous['document'];
+      g['window'] = previous['window'];
+      g['navigator'] = previous['navigator'];
+      g['Element'] = previous['Element'];
+      g['HTMLElement'] = previous['HTMLElement'];
+      g['HTMLIFrameElement'] = previous['HTMLIFrameElement'];
+      g['requestAnimationFrame'] = previous['requestAnimationFrame'];
+      g['cancelAnimationFrame'] = previous['cancelAnimationFrame'];
+      g['getComputedStyle'] = previous['getComputedStyle'];
+      g['ResizeObserver'] = previous['ResizeObserver'];
+      g['IntersectionObserver'] = previous['IntersectionObserver'];
+      g['localStorage'] = previous['localStorage'];
+      g['sessionStorage'] = previous['sessionStorage'];
+      g['IS_REACT_ACT_ENVIRONMENT'] = previous['IS_REACT_ACT_ENVIRONMENT'];
+    },
+  };
+}
+
+const roots: Root[] = [];
+const restores: Array<() => void> = [];
+
+const flush = async () => {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await Promise.resolve();
+  });
+};
+
+const reactPropsOf = (node: FakeNode): Record<string, unknown> | null => {
+  const key = Object.keys(node).find((k) => k.startsWith('__reactProps'));
+  if (!key) return null;
+  return (node as unknown as Record<string, Record<string, unknown>>)[key] ?? null;
+};
+
+const collectViewports = (container: FakeNode): Array<{ node: FakeNode; props: Record<string, unknown> }> => {
+  const found: Array<{ node: FakeNode; props: Record<string, unknown> }> = [];
+  const visit = (node: FakeNode) => {
+    const props = reactPropsOf(node);
+    if (props && typeof props['data-testid'] === 'string' && (props['data-testid'] as string).startsWith('viewport-')) {
+      found.push({ node, props });
+    }
+    for (const child of node.childNodes) visit(child);
+  };
+  visit(container);
+  return found;
+};
+
+const wrapperHiddenState = (viewportNode: FakeNode): { className: string; ariaHidden: unknown } => {
+  // The real TerminalTabPane wrapper is the direct parent of the viewport
+  // probe: <div className="h-full w-full block|hidden" aria-hidden>.
+  const parent = viewportNode.parentNode;
+  if (!parent) return { className: '', ariaHidden: undefined };
+  const props = reactPropsOf(parent);
+  return {
+    className: typeof props?.['className'] === 'string' ? (props['className'] as string) : '',
+    ariaHidden: props?.['aria-hidden'],
+  };
+};
+
+afterEach(async () => {
+  for (const root of roots.splice(0)) {
+    await act(async () => root.unmount());
+  }
+  restores.splice(0).forEach((restore) => restore());
+  viewportMounts.clear();
+  viewportUnmounts.clear();
+  viewportLatestProps.clear();
+  viewportInstanceSeq = 0;
+  fakeConnections = [];
+  sentInput = [];
+  resized = [];
+  fakeTerminal = createFakeTerminal();
+  useTerminalStore.getState().clearAll();
+  useSessionUIStore.setState({ currentSessionId: null, newSessionDraft: { open: false } as never });
+});
+
+const renderTerminalView = async () => {
+  const stub = installDomStub();
+  restores.push(stub.restore);
+  useSessionUIStore.setState({ currentSessionId: 'sess-1' });
+  const root = createRoot(stub.container as unknown as Element);
+  roots.push(root);
+  await act(async () => {
+    root.render(React.createElement(TerminalView, { visible: true }));
+  });
+  await flush();
+  await flush();
+  return stub.container;
+};
+
+const setupTwoTabs = () => {
+  useTerminalStore.getState().clearAll();
+  useTerminalStore.getState().ensureDirectory('/repo');
+  const first = useTerminalStore.getState().getDirectoryState('/repo')!.tabs[0]!.id;
+  const second = useTerminalStore.getState().createTab('/repo');
+  useTerminalStore.getState().setTabSessionId('/repo', first, 'pty-a');
+  useTerminalStore.getState().setTabSessionId('/repo', second, 'pty-b');
+  useTerminalStore.getState().setActiveTab('/repo', first);
+  return { first, second };
+};
+
+describe('terminal reattach preserves viewport identity (mounted)', () => {
+  test('tab toggle keeps both panes mounted; hidden pane preserves instance state', async () => {
+    const { first, second } = setupTwoTabs();
+    const container = await renderTerminalView();
+
+    const keyFor = (tabId: string) => `/repo::${tabId}`;
+    let viewports = collectViewports(container);
+    // Both tabs render a pane even though only one is active: no unmount on
+    // tab switch, so VT state and xterm selection survive.
+    expect(viewports).toHaveLength(2);
+
+    const byKey = new Map(viewports.map((v) => [v.props['data-session-key'], v]));
+    expect([...byKey.keys()].sort()).toEqual([keyFor(first), keyFor(second)].sort());
+    for (const v of viewports) {
+      expect(viewportMounts.get(v.props['data-session-key'] as string)).toBe(1);
+    }
+    const markerBefore = new Map(viewports.map((v) => [v.props['data-session-key'], v.props['data-marker']]));
+
+    const activeBefore = byKey.get(keyFor(first))!;
+    const hiddenBefore = byKey.get(keyFor(second))!;
+    expect(wrapperHiddenState(activeBefore.node).className).toContain('block');
+    expect(wrapperHiddenState(activeBefore.node).className).not.toContain('hidden');
+    expect(wrapperHiddenState(activeBefore.node).ariaHidden).toBe(false);
+    expect(wrapperHiddenState(hiddenBefore.node).className).toContain('hidden');
+    expect(wrapperHiddenState(hiddenBefore.node).ariaHidden).toBe(true);
+
+    // Toggle the active tab. The switch only flips visibility: both viewport
+    // instances stay mounted with identical local markers.
+    await act(async () => {
+      useTerminalStore.getState().setActiveTab('/repo', second);
+    });
+    await flush();
+
+    viewports = collectViewports(container);
+    expect(viewports).toHaveLength(2);
+    const byKeyAfter = new Map(viewports.map((v) => [v.props['data-session-key'], v]));
+    expect([...byKeyAfter.keys()].sort()).toEqual([keyFor(first), keyFor(second)].sort());
+    for (const v of viewports) {
+      expect(v.props['data-marker']).toBe(markerBefore.get(v.props['data-session-key']));
+      expect(viewportMounts.get(v.props['data-session-key'] as string)).toBe(1);
+      expect(viewportUnmounts.get(v.props['data-session-key'] as string) ?? 0).toBe(0);
+    }
+
+    const nowActive = byKeyAfter.get(keyFor(second))!;
+    const nowHidden = byKeyAfter.get(keyFor(first))!;
+    expect(wrapperHiddenState(nowActive.node).className).toContain('block');
+    expect(wrapperHiddenState(nowActive.node).ariaHidden).toBe(false);
+    expect(wrapperHiddenState(nowHidden.node).className).toContain('hidden');
+    expect(wrapperHiddenState(nowHidden.node).ariaHidden).toBe(true);
+
+    // Toggling back still preserves both instances.
+    await act(async () => {
+      useTerminalStore.getState().setActiveTab('/repo', first);
+    });
+    await flush();
+    viewports = collectViewports(container);
+    expect(viewports).toHaveLength(2);
+    for (const v of viewports) {
+      expect(v.props['data-marker']).toBe(markerBefore.get(v.props['data-session-key']));
+      expect(viewportMounts.get(v.props['data-session-key'] as string)).toBe(1);
+    }
+  });
+
+  test('same-runtime switch reattaches owned PTYs and gates input until the snapshot', async () => {
+    const { first } = setupTwoTabs();
+    useTerminalStore.getState().appendToBuffer('/repo', first, 'prompt$ ', 10);
+    const container = await renderTerminalView();
+    const firstKey = `/repo::${first}`;
+    const markersBefore = new Map(
+      collectViewports(container).map((viewport) => [
+        viewport.props['data-session-key'] as string,
+        viewport.props['data-marker'],
+      ]),
+    );
+
+    expect(fakeConnections.map((connection) => connection.sessionId).sort()).toEqual(['pty-a', 'pty-b']);
+    viewportLatestProps.get(firstKey)!.onResize(100, 30);
+    await flush();
+    resized = [];
+    const staleConnections = [...fakeConnections];
+
+    await act(async () => { resetTerminalTransport(); });
+    await flush();
+
+    expect(fakeConnections.filter((connection) => connection.sessionId === 'pty-a')).toHaveLength(2);
+    expect(fakeConnections.filter((connection) => connection.sessionId === 'pty-b')).toHaveLength(2);
+    expect(resized).toEqual([
+      { sessionId: 'pty-a', cols: 100, rows: 30 },
+      { sessionId: 'pty-b', cols: 100, rows: 30 },
+    ]);
+    for (const viewport of collectViewports(container)) {
+      expect(viewport.props['data-marker']).toBe(markersBefore.get(viewport.props['data-session-key'] as string));
+    }
+
+    viewportLatestProps.get(firstKey)!.onInput('typed-during-gap');
+    await flush();
+    expect(sentInput).toEqual([]);
+
+    await act(async () => {
+      staleConnections.find((connection) => connection.sessionId === 'pty-a')!.handlers.onEvent({
+        type: 'data',
+        sequence: 99,
+        data: 'stale',
+      });
+      fakeConnections.filter((connection) => connection.sessionId === 'pty-a').at(-1)!.handlers.onEvent({
+        type: 'snapshot',
+        sequence: 10,
+        data: 'prompt$ ',
+        status: 'running',
+      });
+    });
+    await flush();
+
+    const buffer = useTerminalStore.getState().getBuffer('/repo', first);
+    expect(buffer.lastSequence).toBe(10);
+    expect(buffer.chunks.map((chunk) => chunk.data).join('')).toBe('prompt$ ');
+    viewportLatestProps.get(firstKey)!.onInput('typed-after-snapshot');
+    await flush();
+    expect(sentInput).toEqual([{ sessionId: 'pty-a', data: 'typed-after-snapshot' }]);
+
+    const oldPtyConnectionCount = fakeConnections.filter(
+      (connection) => connection.sessionId === 'pty-a' || connection.sessionId === 'pty-b',
+    ).length;
+    resized = [];
+    await act(async () => {
+      useTerminalStore.getState().clearAll();
+      resetTerminalTransport();
+    });
+    await flush();
+    expect(fakeConnections.filter(
+      (connection) => connection.sessionId === 'pty-a' || connection.sessionId === 'pty-b',
+    )).toHaveLength(oldPtyConnectionCount);
+    expect(resized.filter((entry) => entry.sessionId === 'pty-a' || entry.sessionId === 'pty-b')).toEqual([]);
+  });
+
+  test('assigning a PTY id to the same tab keeps the stable sessionKey without remounting', async () => {
+    useTerminalStore.getState().clearAll();
+    useTerminalStore.getState().ensureDirectory('/repo');
+    const tabId = useTerminalStore.getState().getDirectoryState('/repo')!.tabs[0]!.id;
+    const container = await renderTerminalView();
+
+    const sessionKey = `/repo::${tabId}`;
+    let viewports = collectViewports(container);
+    expect(viewports).toHaveLength(1);
+    expect(viewports[0]!.props['data-session-key']).toBe(sessionKey);
+    const markerBefore = viewports[0]!.props['data-marker'];
+    expect(viewportMounts.get(sessionKey)).toBe(1);
+
+    // Fresh PTY assignment for the same tab: the viewport identity is
+    // directory+tab, never the PTY id, so the xterm instance (dims/selection)
+    // survives instead of remounting.
+    await act(async () => {
+      useTerminalStore.getState().setTabSessionId('/repo', tabId, 'pty-a');
+    });
+    await flush();
+    await flush();
+
+    viewports = collectViewports(container);
+    expect(viewports).toHaveLength(1);
+    expect(viewports[0]!.props['data-session-key']).toBe(sessionKey);
+    expect(viewports[0]!.props['data-marker']).toBe(markerBefore);
+    expect(viewportMounts.get(sessionKey)).toBe(1);
+    expect(viewportUnmounts.get(sessionKey) ?? 0).toBe(0);
+
+    // Reassigning to another PTY id on the same tab is still the same pane.
+    await act(async () => {
+      useTerminalStore.getState().setTabSessionId('/repo', tabId, 'pty-b');
+    });
+    await flush();
+    await flush();
+
+    viewports = collectViewports(container);
+    expect(viewports).toHaveLength(1);
+    expect(viewports[0]!.props['data-session-key']).toBe(sessionKey);
+    expect(viewports[0]!.props['data-marker']).toBe(markerBefore);
+    expect(viewportMounts.get(sessionKey)).toBe(1);
+    expect(viewportUnmounts.get(sessionKey) ?? 0).toBe(0);
+  });
+});

--- a/packages/ui/src/components/views/terminal/useTerminalSessionStream.ts
+++ b/packages/ui/src/components/views/terminal/useTerminalSessionStream.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useTerminalStore } from '@/stores/useTerminalStore';
 import type { TerminalStreamEvent, TerminalAPI, TerminalError, TerminalShell } from '@/lib/api/types';
+import { getTerminalTransportGeneration, subscribeTerminalTransportGeneration } from '@/lib/terminalApi';
 import { TerminalPreviewScanner, FALLBACK_TERMINAL_SIZE } from './terminalStreamHelpers';
 
 type TabIdentity = {
@@ -60,6 +61,14 @@ export function useTerminalSessionStream({
   const lastViewportSizeRef = React.useRef<{ cols: number; rows: number } | null>(null);
   const pendingTerminalCreatesRef = React.useRef(new Set<string>());
   const previewScannersRef = React.useRef(new Map<string, TerminalPreviewScanner>());
+  const tabsRef = React.useRef(tabs);
+  const hydratedRef = React.useRef(terminalHydrated);
+  const viewportOpenRef = React.useRef(hasOpenedTerminalViewport);
+  const terminalRef = React.useRef(terminal);
+  tabsRef.current = tabs;
+  hydratedRef.current = terminalHydrated;
+  viewportOpenRef.current = hasOpenedTerminalViewport;
+  terminalRef.current = terminal;
 
   const resetTerminalPreviewScan = React.useCallback(() => {
     const tabId = activeTabIdRef.current;
@@ -123,9 +132,16 @@ export function useTerminalSessionStream({
         return;
       }
 
+      const streamGeneration = getTerminalTransportGeneration();
+      const isCurrentStream = (): boolean =>
+        getTerminalTransportGeneration() === streamGeneration &&
+        directoryRef.current === directory &&
+        useTerminalStore.getState().getDirectoryState(directory)?.tabs.find((t) => t.id === tabId)
+          ?.terminalSessionId === terminalId;
+
       const subscription = terminal.connect(terminalId, {
         onEvent: (event: TerminalStreamEvent) => {
-          if (directoryRef.current !== directory) return;
+          if (!isCurrentStream()) return;
 
           switch (event.type) {
             case 'snapshot': {
@@ -189,7 +205,7 @@ export function useTerminalSessionStream({
           }
         },
         onError: (error: TerminalError, fatal?: boolean) => {
-          if (directoryRef.current !== directory) return;
+          if (!isCurrentStream()) return;
           const isActive = activeTabIdRef.current === tabId;
 
           if (!fatal) {
@@ -268,6 +284,46 @@ export function useTerminalSessionStream({
       }
     }
   }, [tabsKey, tabs, effectiveDirectory, terminalHydrated, hasOpenedTerminalViewport, startStream]);
+
+  React.useEffect(() => {
+    return subscribeTerminalTransportGeneration(() => {
+      if (!hydratedRef.current || !viewportOpenRef.current) return;
+      const directory = directoryRef.current;
+      if (!directory) return;
+
+      const ownedTabs: Array<{ id: string; terminalSessionId: string }> = [];
+      for (const tab of tabsRef.current) {
+        if (!tab.terminalSessionId) continue;
+        const owned = useTerminalStore
+          .getState()
+          .getDirectoryState(directory)
+          ?.tabs.find((candidate) => candidate.id === tab.id)?.terminalSessionId;
+        if (owned === tab.terminalSessionId) {
+          ownedTabs.push({ id: tab.id, terminalSessionId: tab.terminalSessionId });
+        }
+      }
+
+      // resetTerminalTransport already disposed these subscriptions.
+      subscriptionsRef.current.clear();
+      activeTerminalIdRef.current = null;
+      if (ownedTabs.length === 0) return;
+
+      // Set the input gate before connect can synchronously deliver a snapshot.
+      setIsReconnectPending(true);
+      setConnectionError(null);
+      setIsFatalError(false);
+      for (const tab of ownedTabs) {
+        startStream(directory, tab.id, tab.terminalSessionId);
+      }
+
+      const size = lastViewportSizeRef.current;
+      if (size) {
+        for (const tab of ownedTabs) {
+          void terminalRef.current.resize({ sessionId: tab.terminalSessionId, ...size }).catch(() => {});
+        }
+      }
+    });
+  }, [startStream]);
 
   React.useEffect(() => {
     let cancelled = false;

--- a/packages/ui/src/lib/terminalApi.ts
+++ b/packages/ui/src/lib/terminalApi.ts
@@ -137,10 +137,15 @@ export class TerminalTransport {
 
   async write(sessionId: string, data: string): Promise<void> {
     if (!data) return;
+    // Never replay input when a transport replacement interrupts the write.
+    const writeGeneration = this.generation;
+    const isReplaced = (): boolean => this.disposed || writeGeneration !== this.generation;
     await this.ensureConnected();
+    if (isReplaced()) throw new Error('Terminal runtime changed');
     if (this.send({ t: 'write', v: 3, s: sessionId, d: data })) return;
     this.closeSocket();
     await this.ensureConnected();
+    if (isReplaced()) throw new Error('Terminal runtime changed');
     if (!this.send({ t: 'write', v: 3, s: sessionId, d: data })) throw new Error('Terminal connection is unavailable');
   }
 
@@ -351,6 +356,31 @@ export class TerminalTransport {
 
 let transport = new TerminalTransport();
 
+// Mounted terminal views use this generation to reject stale callbacks and
+// reattach PTYs after the singleton transport is replaced.
+let terminalTransportGeneration = 0;
+const terminalGenerationListeners = new Set<() => void>();
+
+export const getTerminalTransportGeneration = (): number => terminalTransportGeneration;
+
+export const subscribeTerminalTransportGeneration = (listener: () => void): (() => void) => {
+  terminalGenerationListeners.add(listener);
+  return () => {
+    terminalGenerationListeners.delete(listener);
+  };
+};
+
+const bumpTerminalTransportGeneration = (): void => {
+  terminalTransportGeneration += 1;
+  for (const listener of [...terminalGenerationListeners]) {
+    try {
+      listener();
+    } catch {
+      // A listener throwing must not break transport replacement.
+    }
+  }
+};
+
 export async function createTerminalSession(options: CreateTerminalOptions): Promise<TerminalSession> {
   const response = await runtimeFetch('/api/terminal/create', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(options) });
   if (!response.ok) throw await responseError(response, 'Failed to create terminal session');
@@ -390,4 +420,8 @@ export async function forceKillTerminal(options: { sessionId?: string; cwd?: str
     for (const sessionId of result.killedSessionIds) if (typeof sessionId === 'string') transport.forget(sessionId);
   } else if (options.sessionId) transport.forget(options.sessionId);
 }
-export function disposeTerminalInputTransport(): void { transport.dispose(); transport = new TerminalTransport(); }
+export function resetTerminalTransport(): void {
+  transport.dispose();
+  transport = new TerminalTransport();
+  bumpTerminalTransportGeneration();
+}

--- a/packages/ui/src/lib/terminalTransportSwitch.test.ts
+++ b/packages/ui/src/lib/terminalTransportSwitch.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from 'bun:test';
+import type { RelayTunnelWebSocket } from './relay/tunnel-client';
+import { TerminalTransport } from './terminalApi';
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+const frame = (message: Record<string, unknown>): Uint8Array => {
+  const body = encoder.encode(JSON.stringify(message));
+  const result = new Uint8Array(body.length + 1);
+  result[0] = 1;
+  result.set(body, 1);
+  return result;
+};
+
+class FakeSocket implements RelayTunnelWebSocket {
+  readyState = 0;
+  binaryType: 'blob' | 'arraybuffer' = 'arraybuffer';
+  onopen: (() => void) | null = null;
+  onmessage: RelayTunnelWebSocket['onmessage'] = null;
+  onerror: (() => void) | null = null;
+  onclose: RelayTunnelWebSocket['onclose'] = null;
+  sent: Record<string, unknown>[] = [];
+
+  open(): void {
+    this.readyState = 1;
+    this.onopen?.();
+  }
+
+  emit(message: Record<string, unknown>): void {
+    const bytes = frame(message);
+    this.onmessage?.({ data: bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer });
+  }
+
+  send(data: string | ArrayBuffer | ArrayBufferView): void {
+    const bytes = typeof data === 'string'
+      ? encoder.encode(data)
+      : data instanceof ArrayBuffer
+        ? new Uint8Array(data)
+        : new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+    this.sent.push(JSON.parse(decoder.decode(bytes.subarray(1))) as Record<string, unknown>);
+  }
+
+  close(): void {
+    this.readyState = 3;
+    this.onclose?.({ code: 1000, reason: '' });
+  }
+}
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+const attachMessages = (socket: FakeSocket) => socket.sent.filter((message) => message.t === 'attach');
+
+describe('terminal transport switch', () => {
+  test('reset bumps the generation once and supports listener cleanup', async () => {
+    const api = await import('./terminalApi');
+    const before = api.getTerminalTransportGeneration();
+    let calls = 0;
+    const unsubscribe = api.subscribeTerminalTransportGeneration(() => { calls += 1; });
+
+    api.resetTerminalTransport();
+    expect(api.getTerminalTransportGeneration()).toBe(before + 1);
+    expect(calls).toBe(1);
+
+    unsubscribe();
+    api.resetTerminalTransport();
+    expect(calls).toBe(1);
+  });
+
+  test('replacement attaches each PTY once, rejects stale data, and deduplicates sequence replay', async () => {
+    const tokens: string[] = [];
+    const oldSocket = new FakeSocket();
+    const oldTransport = new TerminalTransport({
+      refreshAuth: async () => { tokens.push('old'); return 'old'; },
+      openSocket: () => oldSocket,
+    });
+    const oldEvents: string[] = [];
+    oldTransport.subscribe('pty-a', { onEvent: (event) => oldEvents.push(`a:${event.type}`) });
+    oldTransport.subscribe('pty-b', { onEvent: (event) => oldEvents.push(`b:${event.type}`) });
+    await tick();
+    oldSocket.open();
+    await tick();
+    expect(attachMessages(oldSocket)).toHaveLength(2);
+
+    oldSocket.emit({ t: 'snapshot', v: 3, s: 'pty-a', q: 5, history: 'prompt$ ', status: 'running' });
+    await tick();
+    expect(oldEvents).toEqual(['a:snapshot']);
+    oldTransport.dispose();
+    oldSocket.emit({ t: 'output', v: 3, s: 'pty-a', q: 99, d: 'stale' });
+    await tick();
+    expect(oldEvents).toEqual(['a:snapshot']);
+
+    const newSocket = new FakeSocket();
+    const replacement = new TerminalTransport({
+      refreshAuth: async () => { tokens.push('new'); return 'new'; },
+      openSocket: () => newSocket,
+    });
+    const newEvents: string[] = [];
+    replacement.subscribe('pty-a', { onEvent: (event) => newEvents.push(`${event.type}:${event.sequence ?? ''}`) });
+    replacement.subscribe('pty-b', { onEvent: () => {} });
+    await tick();
+    newSocket.open();
+    await tick();
+
+    const attaches = attachMessages(newSocket);
+    expect(attaches).toHaveLength(2);
+    expect(new Set(attaches.map((message) => message.s))).toEqual(new Set(['pty-a', 'pty-b']));
+    expect(tokens).toEqual(['old', 'new']);
+
+    newSocket.emit({ t: 'snapshot', v: 3, s: 'pty-a', q: 6, history: 'prompt$ ls', status: 'running' });
+    newSocket.emit({ t: 'output', v: 3, s: 'pty-a', q: 6, d: 'duplicate' });
+    await tick();
+    expect(newEvents).toEqual(['snapshot:6']);
+    replacement.dispose();
+  });
+
+  test('a pending write interrupted by replacement is dropped instead of replayed', async () => {
+    let releaseAuth!: (token: string) => void;
+    const authGate = new Promise<string>((resolve) => { releaseAuth = resolve; });
+    const socket = new FakeSocket();
+    const transport = new TerminalTransport({
+      refreshAuth: () => authGate,
+      openSocket: () => socket,
+    });
+
+    transport.subscribe('pty-1', { onEvent: () => {} });
+    const pending = transport.write('pty-1', 'typed-during-gap');
+    transport.dispose();
+    releaseAuth('late-token');
+
+    await expect(pending).rejects.toThrow('Terminal runtime changed');
+    expect(socket.sent.filter((message) => message.t === 'write')).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Intent

Keep existing terminal PTYs attached when the active connection switches between LAN and relay for the same runtime. Replacing the terminal transport now bumps a generation observed by mounted terminal views. Those views reattach each still-owned PTY once, retain tab and viewport identity, preserve scrollback and dimensions, and reject callbacks from the previous transport.

## Non-goals

This PR does not change credential revocation, mobile connection retention, runtime endpoint epochs, general reconnect policy, terminal deletion or creation, send queues, files, server routes, WebSocket framing, or relay authentication. It does not retain terminal state across different runtimes.

## Affected surfaces

- Package: `packages/ui`
- Runtimes: shared web, desktop, hosted-mobile, and Capacitor UI paths that switch transport while keeping the same runtime identity
- User-visible state: mounted terminal tabs remain mounted and reattach to their existing PTY IDs without clearing scrollback, dimensions, or selection. Input entered during the reattach gap is dropped and is not replayed after the fresh snapshot.
- Different-runtime behavior: terminal ownership and buffers clear before the transport generation changes, so an equal PTY ID on another runtime is never adopted.
- Persisted and external contracts: none. No route, wire format, auth, or stored-data contract changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` and `CONTRIBUTING.md` | This changes shared runtime code and tests | The diff is limited to terminal reattach, uses existing dependencies, and includes focused plus workspace validation. |
| `pichamber-change-discipline` | Executable source and exports changed | The implementation stays in terminal/runtime owners, tests observable lifecycle behavior, and `dead-code` was inspected. |
| `ui-api-decoupling` and its implementation map | Runtime switching and shared UI transport are involved | Reattach resolves the active terminal API at use time and keeps HTTP/WebSocket auth and URL handling in existing runtime helpers. |
| `relay-transport` | The terminal uses the shared WebSocket transport | No endpoint, allowlist, token, origin, codec, or relay branch changed. The existing `openRuntimeWebSocket` path remains authoritative. |
| `sync-state-invariants` | Generation and stale completion rules apply | Generation guards reject stale callbacks, store ownership gates reattach, and cross-runtime state clears before the generation bump. |
| `performance-engineering` | Terminal output is a streaming path | Reattach is generation-driven rather than output-driven. It adds no per-output scan or subscription and preserves mounted viewport identity. |
| `packages/ui/src/apps/DOCUMENTATION.md` and `packages/ui/src/sync/DOCUMENTATION.md` | These are the nearest runtime/synchronization references | Existing runtime ownership and live-state rules are preserved. This PR does not change their documented module ownership. |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/lib/terminalTransportSwitch.test.ts packages/ui/src/lib/terminalApi.test.ts packages/ui/src/components/views/terminal/__tests__/terminalReattach.test.tsx` | Passed: 20 tests, 94 assertions. The mounted suite emits an existing Base UI native-button warning from `TerminalTabDropdown`. |
| `bun run --cwd packages/ui type-check` | Passed. |
| `bun run --cwd packages/ui lint` | Passed. |
| `bun run test` | Passed on the final commit: web 813 tests, UI 2,358 tests, Electron architecture 47 tests, Electron updater 29 tests. An earlier run failed because an App test mock did not export a newly imported helper; the import was removed and the focused App test plus the full suite then passed. |
| `bun run dead-code` | Completed with its non-blocking exit behavior. Report: 1 unused file and 377 unused exports in the existing repository; no changed terminal export or file was reported. |
| `git diff --check` | Passed. |
| `git status --short --branch` | Clean after commit and push. |
| `node --check` | Not run because no server JavaScript changed. |
| Manual direct/relay runtime exercise | Not run. Unit, mounted React, type, and lint checks do not prove live relay or platform behavior. |

## Visual evidence

N/A. This changes transport lifecycle behavior and adds no rendered UI, labels, layout, colors, or animation. The mounted `TerminalView` suite verifies that both panes keep the same viewport instances and visibility state through tab changes and transport replacement.

## Risks and failure behavior

- Stale data: stream callbacks capture the terminal transport generation plus directory/tab ownership. Output, snapshots, reconnect notices, and errors from the disposed generation cannot mutate the current buffer or connection state.
- Cross-runtime clear: `clearAll()` runs before the generation bump. The synchronous ownership check therefore rejects old PTY IDs, including collisions on the new runtime.
- Input drop: the mounted view gates input before starting reattach, and transport writes that straddle replacement reject with `Terminal runtime changed`. Input from the gap is not replayed.
- Scrollback: snapshot and output sequences remain monotonic. Equal or older replay sequences do not append duplicate output.
- Partial failure: each transport replacement disposes old listeners and timers first. A fresh snapshot clears the pending gate for the active PTY; ordinary transport retry behavior remains unchanged.
- Rollback: reverting this commit restores the previous behavior, where a same-runtime transport switch disposes the terminal socket without reattaching mounted PTYs. No data migration or persisted rollback is needed.
